### PR TITLE
migrate some links to owasp area

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To get the code, go to where you want your code to be located and do
 
 `git init`
 
-`git clone https://github.com/mike-goodwin/owasp-threat-dragon.git`
+`git clone https://github.com/owasp/threat-dragon.git`
 
 This installs code in two sub-folders. One for the main application (`td`) and one for the unit tests (`td.tests`). Get all the node packages:
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             <ul class="nav navbar-nav navbar-right">
                 <li><a href="https://threatdragon.org/" target="_blank"><span class="fa fa-flask fa-lg"></span> See the web app</a></li>
                 <li><a href="https://github.com/mike-goodwin/owasp-threat-dragon-desktop/releases" target="_blank"><span class="fa fa-cloud-download fa-lg"></span> Download the desktop app</a></li>
-                <li><a href="https://github.com/mike-goodwin/owasp-threat-dragon" target="_blank"><span class="fa fa-github fa-lg"></span> Visit us on GitHub</a></li>
+                <li><a href="https://github.com/owasp/threat-dragon" target="_blank"><span class="fa fa-github fa-lg"></span> Visit us on GitHub</a></li>
             </ul>
         </li>
       </ul>


### PR DESCRIPTION
Links to the github code migrated to owasp area.
Still to do are the links to the releases area, which should be done for next release, and the code analysis