### PR TITLE
feat: make github scope configurable

### DIFF
--- a/setup-env.md
+++ b/setup-env.md
@@ -26,6 +26,7 @@ command line:
 * `export SESSION_STORE=local`
 * SESSION_SIGNING_KEY as the random 32 character hexadecimal key, for example `export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
 * SESSION_ENCRYPTION_KEYS has the same 32 character key, for example `export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
+* GITHUB_SCOPE - set this to `repo` if you want access also to private repos
 
 Similarly for Windows, from the terminal used to start Threat Dragon enter at the
 command line:

--- a/td/config/passport.config.js
+++ b/td/config/passport.config.js
@@ -9,12 +9,14 @@ function passportConfig(app) {
     app.use(passport.initialize());
     app.use(passport.session());
     
+    var scope = process.env.GITHUB_SCOPE === undefined ? 'public_repo' : process.env.GITHUB_SCOPE;
+
     //github sigin
     passport.use(new Strategy({
         clientID: process.env.GITHUB_CLIENT_ID,
         clientSecret: process.env.GITHUB_CLIENT_SECRET,
         failureRedirect: 'login/github',
-        scope: [ 'public_repo' ]
+        scope: [ scope ]
     },
     function(accessToken, refreshToken, profile, done) {
         return done(null, {profile: profile, accessToken: accessToken});


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Allow to configure github scope by setting `GITHUB_SCOPE` env var - to support private repos, not only public ones.

**Description for the changelog**
<!--
A short (one line) summary that describes the changes in this
pull request for inclusion in the change log
If this is a bug fix, your description sahould include "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number
-->
fix #8 - allow to configure GITHUB token scope

**Other info**
<!--
Thanks for submitting a pull request!
Please make sure you read our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
