### PR TITLE
Update README for Docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This installs code in two sub-folders. One for the main application (`td`) and o
 
 `npm install`
 
+### Docker
+To run Threat Dragon using docker, configure your environment using dotenv as described in [setup-env.md](setup-env.md) and run the following from the root of the project:
+- `docker build -t owasp-threat-dragon:dev .`
+- `docker run -it -p 3000:3000 $(pwd)/.env:/app/td.server/.env owasp-threat-dragon:dev`
+
 ## Environment variables
 
 Threat Dragon uses GitHub to store threat models, so you need to go to your GitHub account and

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This installs code in two sub-folders. One for the main application (`td`) and o
 ### Docker
 To run Threat Dragon using docker, configure your environment using dotenv as described in [setup-env.md](setup-env.md) and run the following from the root of the project:
 - `docker build -t owasp-threat-dragon:dev .`
-- `docker run -it -p 3000:3000 $(pwd)/.env:/app/td.server/.env owasp-threat-dragon:dev`
+- `docker run -it -p 3000:3000 -v $(pwd)/.env:/app/td.server/.env owasp-threat-dragon:dev`
 
 ## Environment variables
 


### PR DESCRIPTION
**Summary**
Adding a section about running using docker to the README

**Description for the changelog**
Closes: #71
Using the `.env` configuration does not work with the `--env-file` flag when running the docker container.  Mounting the `.env` file works as expected.  This PR adds a note to the README to address this. 

**Other info**
N/A
