### PR TITLE
Changing the ZAP scan action to use "pull_request_target" instead of …

### DIFF
--- a/.github/workflows/zap_scan.yaml
+++ b/.github/workflows/zap_scan.yaml
@@ -1,6 +1,6 @@
 name: OWASP ZAP scan
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
 jobs:


### PR DESCRIPTION
Closes #77 

**Summary**
ZAP scans are failing on merging of PRs from forked repos.

**Description for the changelog**
Updated the zap scan yaml to use `pull_request_target` to attempt to fix the failing ZAP scan on merging a PR from a forked repo.

**Other info**
It looks as though this is a known issue with secrets.  I don't know if any secrets are involved with the ZAP scanner action, however, it may be worth while to try using `pull_request_target` instead of `pull_request` for the action, as noted in [this blog post](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/):

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. 