### PR TITLE
Bring docs and dev notes into one place

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = https://github.com/threatdragon/threatdragon.github.io

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ which has the issues and pull requests from October 2015 up to June 2020.
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/OWASP/threat-dragon.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/OWASP/threat-dragon/context:javascript)
 
 # [OWASP](https://www.owasp.org) Threat Dragon #
-
 Threat Dragon is a free, open-source, cross-platform threat modelling application including system diagramming
-and a threat rule engine to auto-generate threats/mitigations. It is an [OWASP Incubator Project](https://www.owasp.org/index.php/OWASP_Threat_Dragon)
+and a threat rule engine to auto-generate threats/mitigations.
+It is an [OWASP Incubator Project](https://www.owasp.org/index.php/OWASP_Threat_Dragon)
 and follows the values and principles of the [threat modeling manifesto](https://www.threatmodelingmanifesto.org/).
-The roadmap for the project is a great UX, a powerful rule engine and integration with other development lifecycle tools.
+The roadmap for the project is a simple UX, a powerful rule engine
+and integration with other development lifecycle tools.
 
 The application comes in two variants:
 
@@ -23,74 +24,86 @@ The application comes in two variants:
 For the web application, models files are stored in GitHub (other storage will become available).
 We are currently maintaining [a working protoype](https://threatdragon.org) in synch with the master code branch.
 
-2. [**A desktop application**](https://github.com/owasp/threat-dragon-desktop): This is based on [Electron](https://electron.atom.io/).
+2. [**A desktop application**](https://github.com/owasp/threat-dragon-desktop):
+This is based on [Electron](https://electron.atom.io/).
 There are installers available for both Windows and Mac OSX, as well as rpm and debian packages for Linux.
 Note that for the desktop variant the models are stored on the local filesystem rather than a remote repository.
 
-[End user help](https://threatdragon.github.io) is available for both variants.
+[End user help](https://docs.threatdragon.org) is available for both variants.
 
 This repository contains the files for the web application variant.
 
-Core files that are shared between both the desktop and web variants are stored in an [seperate repo](https://github.com/owasp/threat-dragon-core)
-and are installable as a [seperate package](https://www.npmjs.com/package/owasp-threat-dragon-core).
+Core files that are shared between both the desktop and web variants are stored in
+a [separate repo](https://github.com/owasp/threat-dragon-core) and are
+installed as an [npm package](https://www.npmjs.com/package/owasp-threat-dragon-core).
 
 ## Installing
+Threat Dragon is a Single Page Application (SPA) using Angular on the client and node.js on the server.
+To build and run locally follow these steps:
 
-Threat Dragon is a Single Page Application (SPA) using Angular on the client and node.js on the server. To build and run locally follow these steps:
+Install git and node.js - which includes the node package manager npm.
+To get the code, navigate to where you want your code to be located and do
 
-Install git and node.js - which includes the node package manager npm. To get the code, navigate to where you want your code to be located and do
+- `git init`
+- `git clone --recursive https://github.com/owasp/threat-dragon.git`
 
-`git init`
+This installs code in two sub-folders.
+One for the back-end application (`td.server`) and one for the front-end (`td.site`).
 
-`git clone https://github.com/owasp/threat-dragon.git`
-
-This installs code in two sub-folders. One for the back-end application (`td.server`) and one for the front-end (`td.site`). To install, do:
-
-`npm install`
-and go into the `server` directory and run `npm install` there as well, eg: `cd td.server && npm install`
+To install, do: `npm install` and go into the `server` directory and run `npm install` there as well,
+eg: `cd td.server && npm install`
 
 Running `npm run start` from the root directory of the repository will start the front-end and the server.
 
 ### Docker
-To run Threat Dragon using docker, configure your environment using dotenv as described in [setup-env.md](setup-env.md) and run the following from the root of the project:
+To run Threat Dragon in a docker container, configure your environment using dotenv
+as described in [setup-env.md](setup-env.md) and run the following from the root of the project:
 - `docker build -t owasp-threat-dragon:dev .`
 - `docker run -it -p 3000:3000 -v $(pwd)/.env:/app/td.server/.env owasp-threat-dragon:dev`
 
 ## Environment variables
-
 Threat Dragon uses GitHub to store threat models, so you need to go to your GitHub account and
 [register it as a GitHub application](https://github.com/settings/applications/new).
-Once you have done that you need to set the Client ID and Client Secret as environment variables (`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`).
+Once you have done that you need to set the Client ID and Client Secret as environment variables
+(`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`).
 
 You also need to set a session signing key environment variable (`SESSION_SIGNING_KEY`).
-Setting up these environment variables has caused some confusion in the past, so there is a [step-by-step guide](setup-env.md) to this. 
+Setting up these environment variables has caused some confusion in the past,
+so there is a [step-by-step guide](setup-env.md) to this. 
 
-Once a user is signed in, their session information contains an OAuth access token with write access to their GitHub repos.
-For security, this is encrypted before storage in the session. The session encryption supports multiple keys so that they can be expired
-without any interruption to the running application. The primary key is always used for encryption. Retired keys can be kept available
-for decrypting existing sessions. Once all sessions are using the new primary key (typically this will be around 60 minutes maximum),
-the old one can be safely removed. The keys are stored as a JSON string in  the `SESSION_ENCRYPTION_KEYS` environment variable. For example:
+Once a user is signed in, their session information contains an OAuth access token
+with write access to their GitHub repos.
+For security, this is encrypted before storage in the session.
+The session encryption supports multiple keys so that they can be expired
+without any interruption to the running application. The primary key is always used for encryption.
+Retired keys can be kept available for decrypting existing sessions.
+Once all sessions are using the new primary key (typically this will be around 60 minutes maximum),
+the old one can be safely removed.
+The keys are stored as a JSON string in  the `SESSION_ENCRYPTION_KEYS` environment variable. For example:
 
 `[{\"isPrimary\": true, \"id\": 0, \"value\": \"abcdef\"}, {\"isPrimary\": false, \"id\": 1, \"value\": \"ghijkl\"}]`
 
-If you are developing locally, you can choose to store the session data in memory using the express-session in-memory store. To do this the
-`SESSION_STORE`environment variale to `local`. As [mentioned in the express-session docs](https://github.com/expressjs/session) this is for
-development only - it is not suitable for production. To remind you of this, Threat Dragon will write a log message at severity ERROR when
+If you are developing locally, you can choose to store the session data in memory
+using the express-session in-memory store. To do this set the `SESSION_STORE`environment variable to `local`.
+As [mentioned in the express-session docs](https://github.com/expressjs/session) this is for
+development only - it is not suitable for production.
+To remind you of this, Threat Dragon will write a log message at severity ERROR when
 it starts if the in memory session store is used.
 
 For production use, Threat Dragon currently supports Azure Table Storage for the session store via
-[connect-azuretables](https://www.npmjs.com/package/connect-azuretables). To make this store work you need to specify an Azure Storage Account
+[connect-azuretables](https://www.npmjs.com/package/connect-azuretables).
+To make this store work you need to specify an Azure Storage Account
 and key as environment variables `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCESS_KEY`.
 See the [connect-azuretables](https://www.npmjs.com/package/connect-azuretables) documentation for more options.
 
-If you want to use an [alternative session store](https://github.com/expressjs/session#compatible-session-stores) in production,
-install it and edit the [session.config.js](https://github.com/owasp/threat-dragon/blob/master/td/config/session.config.js) file.
+If you want to use an [alternative session store](https://github.com/expressjs/session#compatible-session-stores)
+in production, install it and edit the
+[session.config.js](https://github.com/owasp/threat-dragon/blob/master/td/config/session.config.js) file.
 
 Lastly, by default, Threat Dragon will set the `secure` flag on cookies. To override this for development purposes,
 set the `NODE_ENV` environment variable to `development`. 
 
 ## Running the application
-
 Once your environment variables are set up, start the node web server:
 
 `npm start`
@@ -98,7 +111,6 @@ Once your environment variables are set up, start the node web server:
 If you then browse to `http://localhost:3000` you should see the running application.
 
 ## Building
-
 The basic build script is:
 
 `npm run build`
@@ -106,12 +118,13 @@ The basic build script is:
 See `package.json` for other build tasks.
 
 ## Running the unit tests
-
-The unit tests are written using Jasmine and Karma. Coverage is by Istanbul. A few different npm tasks are available, and these are split between the front-end and back-end directories.
+The unit tests are written using Jasmine and Karma, coverage is provided by Istanbul.
+A few different npm tasks are available, and these are split between the front-end and back-end directories.
 
 For front-end (root of the project):
 * `pretest`: runs jshint without the unit tests
-* `test-client-phantomjs`, `test-client-firefox`, `test-client-chrome`, `test-client-ie`: runs client side tests using the specified browser
+* `test-client-phantomjs`, `test-client-firefox`, `test-client-chrome`, `test-client-ie`:
+runs client side tests using the specified browser
 * `test`: runs jshint, client side tests on Firefox and PhantomJS (this is what runs on Travis CI)
 * `test-local`: runs jshint, client side tests on all browsers (useful as a pre-push git hook)
 * `citest`: continously runs client side tests in PhantomJS with `--single-run false` (useful while coding)
@@ -120,22 +133,22 @@ For the back-end (from the `td.server` directory):
 * `pretest`: runs jshint without the unit tests
 * `test`: runs the server side tests
 
-**Note:** If you are on Windows and are having problems installing Karma, the simplest way to resolve this seems to be to install
+**Note:** If you are on Windows and are having problems installing Karma,
+the simplest way to resolve this seems to be to install
 Python v2.7.x (not v3+) and then install Visual Studio Express as per the SO answer suggested in
 [this link](http://codedmi.com/questions/298619/npm-install-g-karma-error-msb4019-the-imported-project-c-microsoft-cpp-defau).
-This sounds mad, but the alternative is a world of pain installing various patches and components one by one. At least it's free :o/
+This sounds mad, but the alternative is a world of pain installing various patches and components one by one.
+At least it's free :o/
 
 # Contributing #
-
 Pull requests, feature requests, bug reports and feedback of any kind are very welcome, please refer to the page for
 [contributors](https://github.com/OWASP/threat-dragon-core/blob/main/CONTRIBUTING.md). 
 
-We are trying to keep the test coverage relatively high, so please try to update tests in any PRs and make PRs on the development branch.
-There are some [developer notes](https://github.com/OWASP/threat-dragon-core/blob/main/dev-notes.md) in the core
-[threat dragon](https://github.com/OWASP/threat-dragon-core) repo to help get started with this project.
+We are trying to keep the test coverage relatively high,
+so please try to update tests in any PRs and make PRs on the development branch.
+There are some [developer notes](dev-notes.md) to help get started with this project.
 
 # Vulnerability disclosure #
-
 If you find a vulnerability in this project please let us know ASAP and we will fix it as a priority.
 For secure disclosure, please see the [security policy](SECURITY.md).
 

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -1,13 +1,390 @@
-# Developer notes for [OWASP](https://www.owasp.org) [Threat Dragon](https://owasp.org/www-project-threat-dragon/) version 2 #
+# Developer notes for [OWASP](https://www.owasp.org) [Threat Dragon](https://owasp.org/www-project-threat-dragon/) #
 
-## Overview ##
-
+## Overview
 This is a collection of notes used during development, most of which should be up to date - if not then raise an issue.
 The recipes are for both Windows and Linux/MacOS; in general the `npm` and `git` commands are the same on all platforms,
 but some of the commands (eg `cd ../..`) need to be modified if running on a Windows platform.
 
 Threat Dragon is a [node.js](https://nodejs.org)
-[single page application](https://en.wikipedia.org/wiki/Single-page_application) built on the
-[Angular](https://angular.io/) framework.
-It comes in two variants, this [web application](https://github.com/OWASP/threat-dragon)
-and also a [desktop application](https://github.com/OWASP/threat-dragon-desktop).
+[single page application](https://en.wikipedia.org/wiki/Single-page_application)
+built on [Angular](https://angular.io/) framework. It comes in two variants, a web application and a desktop application, both variants use a common core.
+
+The core repo common to both the web app and the desktop app is at
+[github.com/OWASP/threat-dragon-core](https://github.com/OWASP/threat-dragon-core)
+
+The desktop application repo, which relies on the core functions, is at
+[github.com/OWASP/threat-dragon-desktop](https://github.com/OWASP/threat-dragon-desktop)
+
+The web application repo, which also relies on the core functions, is at
+[github.com/OWASP/threat-dragon](https://github.com/OWASP/threat-dragon)
+
+Both application variants install `threat-dragon-core` as part of the install process `npm install`, under directory
+`node-modules/owasp-threat-dragon-core`. This package is downloaded during install from the [npmjs registry](https://www.npmjs.com/) as the [owasp-threat-dragon-core](https://www.npmjs.com/package/owasp-threat-dragon-core) package.
+
+## Demo and dev websites
+The public sites are updated from Mike Goodwin's original repo at
+[github.com/mike-goodwin/owasp-threat-dragon](https://github.com/mike-goodwin/owasp-threat-dragon),
+so long as all the pull request checks pass.
+
+* merges to `master` [branch](https://github.com/mike-goodwin/owasp-threat-dragon)
+will update the [online demo](https://threatdragon.org/)
+* merges to `development` [branch](https://github.com/mike-goodwin/owasp-threat-dragon/tree/development)
+will update the [snapshot demo](https://threatdragondev.azurewebsites.net/)
+
+## Documentation
+The [documentation repo](https://github.com/threatdragon/threatdragon.github.io) will update documentation
+at both [threatdragon.github.io](https://threatdragon.github.io)
+and [docs.threatdragon.org](https://docs.threatdragon.org/) websites.
+
+## Install and Run Codebase
+
+#### Install and run web application
+
+```
+~> git clone --recursive git@github.com:OWASP/threat-dragon.git
+~> cd threat-dragon
+~/threat-dragon> npm install
+~/threat-dragon> npm run pretest
+~/threat-dragon> npm run build
+~/threat-dragon> npm test
+~/threat-dragon> export GITHUB_CLIENT_ID=<the client id>
+~/threat-dragon> export GITHUB_CLIENT_SECRET=<the client secret>
+~/threat-dragon> export NODE_ENV=development
+~/threat-dragon> export SESSION_STORE=local
+~/threat-dragon> export SESSION_SIGNING_KEY=<32 char key>
+~/threat-dragon> export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "<32 char key>"}]'
+~/threat-dragon> npm start
+```
+
+Note that  some [environment variables](setup-env.md) need to be set up for the webapp to run.
+Once these are in place then use `npm start` to run the threat dragon server.
+
+Navigate in a browser to http://localhost:3000/ to test the app.
+If there is an error such as 'Cannot GET /' then make sure the 
+[environment variables](https://github.com/OWASP/threat-dragon/blob/main/setup-env.md) are set up correctly.
+
+#### Install and run desktop application
+
+```
+~> git clone git@github.com:OWASP/threat-dragon-desktop.git
+~> cd threat-dragon-desktop
+~/threat-dragon-desktop> npm install
+~/threat-dragon-desktop> npm run pretest
+~/threat-dragon-desktop> npm run build-content
+~/threat-dragon-desktop> npm test
+~/threat-dragon-desktop> npm start
+```
+
+The electron-based desktop application should then launch
+
+### Run webapp in docker container
+A Dockerfile is provided that can be used to create a docker image:
+* checkout the threat dragon source repo
+* from the root directory build the docker image using `docker build -t owasp-threat-dragon:dev .`
+* wait for the docker image to build
+* create a `.env` environment variable file using the example `example.env` as a template
+* spin up a docker container using
+`docker run -it -p 3000:3000 -v $(pwd)/.env:/app/td.server/.env owasp-threat-dragon:dev`
+* navigate in a browser to http://localhost:3000/
+* if there is an error in the browser such as 'Cannot GET /' then make sure `.env` file is correct
+
+## Development
+
+#### Develop web application
+Install as before:
+
+```
+git clone --recursive git@github.com:OWASP/threat-dragon.git -b your-dev-branch-name
+cd threat-dragon
+npm install
+npm run pretest
+npm run build
+npm test
+```
+
+Make changes to code, and depending on the changes (eg .html or .css), `npm run build`
+
+Run modified app with `npm run start`, and navigate in a browser to http://localhost:3000/ .
+As above, if there is an error such as 'Cannot GET /' then ensure the 
+[environment variables](https://github.com/OWASP/threat-dragon/blob/main/setup-env.md) are set up. 
+
+#### Develop desktop application
+Install:
+
+```
+git clone git@github.com:OWASP/threat-dragon-desktop.git -b your-dev-branch-name
+cd threat-dragon-desktop
+npm install
+npm run pretest
+npm run build-content
+npm test
+ln -sf node_modules/electron/cli.js electron
+```
+
+Make changes to code, and depending on the changes (eg .html or .css), `npm run build-content`
+
+Run modified app with either `./electron . run -vv` or `npm run start`
+
+#### Develop core functions using web app
+Install and build as before
+
+```
+~> git clone --recursive git@github.com:OWASP/threat-dragon.git
+~> cd threat-dragon
+~/threat-dragon> npm install
+~/threat-dragon> npm run pretest
+~/threat-dragon> npm run build
+~/threat-dragon> npm test
+```
+
+Replace the TD core using:
+
+```
+~/threat-dragon> cd node_modules
+~/threat-dragon/node_modules> rm -rf owasp-threat-dragon-core
+~/threat-dragon/node_modules> git clone git@github.com:OWASP/threat-dragon-core.git owasp-threat-dragon-core
+~/threat-dragon/node_modules> cd owasp-threat-dragon-core
+~/threat-dragon/node_modules/owasp-threat-dragon-core> npm install
+~/threat-dragon/node_modules/owasp-threat-dragon-core> npm run build
+~/threat-dragon/node_modules/owasp-threat-dragon-core> npm run pretest
+~/threat-dragon/node_modules/owasp-threat-dragon-core> npm test
+~/threat-dragon/node_modules/owasp-threat-dragon-core> cd ../..
+```
+
+Rebuild the webapp using the swapped in core package,
+[setting environment variables](https://github.com/OWASP/threat-dragon/blob/main/setup-env.md) :
+
+```
+~/threat-dragon> npm run build
+~/threat-dragon> export GITHUB_CLIENT_ID=<the client id>
+~/threat-dragon> export GITHUB_CLIENT_SECRET=<the client secret>
+~/threat-dragon> export NODE_ENV=development
+~/threat-dragon> export SESSION_STORE=local
+~/threat-dragon> export SESSION_SIGNING_KEY=<32 char key>
+~/threat-dragon> export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "<32 char key>"}]'
+~/threat-dragon> npm run start
+```
+
+The webapp can now be run as normal and tested by navigating in a browser to http://localhost:3000/ .
+If changes are made to the core files, then to see them in the webapp (depending on the changes) need to rebuild using
+command `npm run build` in core directory and then webapp directory:
+
+```
+~/threat-dragon> cd node_modules/owasp-threat-dragon-core
+~/threat-dragon/node_modules/owasp-threat-dragon-core> npm run build
+~/threat-dragon> cd -
+~/threat-dragon> npm run build
+~/threat-dragon> npm run start
+```
+
+#### Develop core functions using desktop app
+Install and build as before
+
+```
+~> git clone git@github.com:OWASP/threat-dragon-desktop.git
+~> cd threat-dragon-desktop
+~/threat-dragon-desktop> npm install
+~/threat-dragon-desktop> npm run pretest
+~/threat-dragon-desktop> npm run build-content
+~/threat-dragon-desktop> npm test
+```
+
+Replace the TD core using:
+
+```
+~/threat-dragon-desktop> cd node_modules
+~/threat-dragon-desktop/node_modules> rm -rf owasp-threat-dragon-core
+~/threat-dragon-desktop/node_modules> git clone git@github.com:OWASP/threat-dragon-core.git owasp-threat-dragon-core
+~/threat-dragon-desktop/node_modules> cd owasp-threat-dragon-core
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> npm install
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> npm run build
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> npm run pretest
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> npm test
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> cd ../..
+```
+
+Rebuild the desktop app using the swapped in core package:
+
+```
+~/threat-dragon-desktop> npm run build-content
+~/threat-dragon-desktop> ln -sf node_modules/electron/cli.js electron
+~/threat-dragon-desktop> ./electron . run --verbose
+```
+
+The desktop will run as before. If changes are made to the core files then to see them in the desktop
+(depending on the changes) need to rebuild using command ` npm run build` in core directory and then
+command ` npm run build-content` in desktop directory:
+
+```
+~/threat-dragon-desktop> cd node_modules/owasp-threat-dragon-core
+~/threat-dragon-desktop/node_modules/owasp-threat-dragon-core> npm run build
+~/threat-dragon-desktop> cd -
+~/threat-dragon-desktop> npm run build-content
+~/threat-dragon-desktop> ./electron . run --verbose
+```
+
+### Keep branches in sync
+Say your fork or branch is out of sync with the main OWASP repo, usually some commits behind.
+This example is for `threat-dragon-desktop` repo, but the same applies to `threat-dragon`
+and `threat-dragon-core` repos:
+
+```
+git clone https://github.com/<YOUR-USER-NAME>/threat-dragon-desktop.git
+cd threat-dragon-desktop
+git remote add original https://github.com/OWASP/threat-dragon-desktop
+git fetch original
+```
+
+Apply the changes with `git merge original/main` or `git rebase --no-ff original/main` .
+When happy with _everything_ then `git push --force` to update your repo
+
+## Create New Releases
+
+#### TD Core release
+
+1. create branch `release-ready` in [core repo](https://github.com/OWASP/threat-dragon-core)
+1. `git clone git@github.com:OWASP/threat-dragon-core.git -b release-ready`
+1. `cd threat-dragon-core`
+1. update `package.json` version declaration to, eg `"version": "1.3.1",`
+1. `npm install`
+1. `npm run pretest`
+1. `npm run build`
+1. `npm test`
+1. `git commit -a -m"<some release message>"`
+1. `git push`
+1. merge branch in [core repo](https://github.com/OWASP/threat-dragon-core) and then checkout master:
+1. `git clone git@github.com:OWASP/threat-dragon-core.git`
+1. `cd threat-dragon-core`
+1. `git tag v1.3.1`
+1. `git push origin v1.3.1`
+1. `npm install`
+1. `npm run pretest`
+1. `npm run build`
+1. `npm test`
+1. login to npm `npm login` using username, password and email address
+1. update package on [npmjs registry](https://www.npmjs.com/) with `npm publish`
+1. check that [owasp-threat-dragon-core](https://www.npmjs.com/package/owasp-threat-dragon-core) is at correct version
+
+It is good to keep Mike Goodwin's area up to date with releases from the OWASP area. For example with version 1.3.1:
+1. Create branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon-core.git
+1. `git clone git@github.com:mike-goodwin/owasp-threat-dragon-core.git -b version-1.3.1`
+1. `cd owasp-threat-dragon-core/`
+1. `git remote add upstream https://github.com/owasp/threat-dragon-core`
+1. `git fetch upstream`
+1. `git rebase upstream/main`
+1. `git status`
+1. `git push`
+1. create pull request from branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon-core.git
+
+#### Webapp release
+
+1. create branch `release-ready` in [webapp repo](https://github.com/OWASP/threat-dragon)
+1. `git clone git@github.com:OWASP/threat-dragon.git -b release-ready`
+1. `cd threat-dragon`
+1. ensure `package.json` specifies the latest version of core package, eg `"owasp-threat-dragon-core": "1.3.1",`
+1. update `package.json` version declaration to, eg `"version": "1.3.1",`
+1. `npm install`
+1. `npm run pretest`
+1. `npm run build`
+1. `npm test`
+1. `git commit -a -m"<some release message>"`
+1. `git push`
+1. merge branch in [webapp repo](https://github.com/OWASP/threat-dragon) and then checkout master:
+1. `git clone git@github.com:OWASP/threat-dragon.git`
+1. `cd threat-dragon`
+1. `git tag v1.3.1`
+1. `git push origin v1.3.1`
+
+Test the release as in 'Install and run web application' above, ideally on all of Windows, linux and MacOS.
+In general if it works on one platform then it will work on the others, so one platform may be sufficient
+
+Keep Mike Goodwin's area up to date with this release from the OWASP area. For example with version 1.3.1:
+1. Create branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon.git
+1. `git clone git@github.com:mike-goodwin/owasp-threat-dragon.git -b version-1.3.1`
+1. `cd owasp-threat-dragon/`
+1. `git remote add upstream https://github.com/owasp/threat-dragon`
+1. `git fetch upstream`
+1. `git rebase upstream/main`
+1. `git status`
+1. `git push`
+1. create pull request from branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon.git
+
+#### Tag the desktop release
+
+1. create branch `release-ready` in [desktop repo](https://github.com/OWASP/threat-dragon-desktop)
+1. `git clone git@github.com:OWASP/threat-dragon-desktop.git -b release-ready`
+1. `cd threat-dragon-desktop`
+1. ensure `package.json` specifies the latest version of core package, eg `"owasp-threat-dragon-core": "1.3.1",`
+1. update `package.json` version declaration to, eg `"version": "1.3.1",`
+1. `npm install`
+1. `npm run pretest`
+1. `npm run build-content`
+1. `npm test`
+1. `git commit -a -m"<some release message>"`
+1. `git push`
+1. merge branch in [desktop repo](https://github.com/OWASP/threat-dragon-desktop) and then checkout master:
+1. `git clone git@github.com:OWASP/threat-dragon-desktop.git`
+1. `cd threat-dragon-desktop`
+1. `git tag v1.3.1`
+1. `git push origin v1.3.1`
+
+#### Windows installer for TD desktop
+Create windows .exe and test it on a windows box
+1. `git clone https://github.com/OWASP/threat-dragon-desktop.git`
+1. `cd threat-dragon-desktop`
+1. `npm install`
+1. make sure `node-modules/owasp-threat-dragon-core/package.json` is at correct version
+1. `npm run pretest`
+1. `npm test`
+1. `npm run build-win`
+1. make sure the installer works, navigate to `.exe` and run
+1. obtain SHA256 of .exe file using `shasum -a256`
+
+#### MacOS installer for TD desktop
+Create MacOS .deb installer and test it on a mac
+1. `git clone git@github.com:OWASP/threat-dragon-desktop.git`
+1. `cd threat-dragon-desktop`
+1. `npm install`
+1. make sure `node-modules/owasp-threat-dragon-core/package.json` is at correct version
+1. `npm run pretest`
+1. `npm test`
+1. `npm run build-osx`
+1. make sure the installer works, navigate to .dmg and run
+1. obtain SHA256 of .dmg file using `shasum -a256`
+
+#### Linux installers for TD desktop
+Create linux .rpm, .deb .snap, AppImage and test them on a linux box
+1. `git clone git@github.com:OWASP/threat-dragon-desktop.git`
+1. `cd threat-dragon-desktop`
+1. `npm install`
+1. make sure `node-modules/owasp-threat-dragon-core/package.json` is at correct version
+1. `npm run pretest`
+1. `npm test`
+1. `npm run build-lin`
+1. make sure the installers work, navigate to .deb or .rpm package and test
+1. test the Snap .snap and AppImage files
+1. obtain SHA256 of .deb, .rpm, .snap and .AppImage files using `shasum -a256`
+
+#### TD desktop release
+
+1. tag the desktop release, see above
+1. create the windows installer as above
+1. create the linux installers as above
+1. create the MacOS installer as above
+1. create the release in [OWASP desktop repo](https://github.com/OWASP/threat-dragon-desktop) using tag v1.3.1
+1. add the release notes to this release
+1. attach installer files to this release
+1. list SHA256 for each installer file: .exe, .dmg, .deb, .rpm, .snap and .AppImage
+
+Keep Mike Goodwin's area up to date with this release from the OWASP area. For example with version 1.3.1:
+1. Create branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon-desktop.git
+1. `git clone git@github.com:mike-goodwin/owasp-threat-dragon-desktop.git -b version-1.3.1`
+1. `cd owasp-threat-dragon-desktop/`
+1. `git remote add upstream https://github.com/owasp/threat-dragon-desktop`
+1. `git fetch upstream`
+1. `git rebase upstream/main`
+1. `git status`
+1. `git push`
+1. create pull request from branch `version-1.3.1` on https://github.com/mike-goodwin/owasp-threat-dragon-desktop.git
+
+_Threat Dragon: making threat models more dragony_

--- a/setup-env.md
+++ b/setup-env.md
@@ -1,53 +1,80 @@
-## [OWASP](https://www.owasp.org) Threat Dragon ##
+## [OWASP](https://www.owasp.org) Threat Dragon
 
-### Steps to set up the environment variables ###
+### Steps to set up the environment variables
 
-* In your github account, go to `Settings -> 'Developer settings' -> 'OAuth Apps' -> 'New OAuth App'`
+1. In your github account, go to `Settings -> 'Developer settings' -> 'OAuth Apps' -> 'New OAuth App'`
 
-* fill out the form with the following:
-**Application name**: not critical, suggest something like 'Threat Dragon'
-**Homepage URL**: `http://localhost:3000`
-**Application description**: not critical, suggest something like 'Threat Dragon for local development'
-**Authorization callback URL**: `http://localhost:3000/oauth/github`
+1. fill out the form with the following:
+  * **Application name**: not critical, suggest something like 'Threat Dragon'
+  * **Homepage URL**: `http://localhost:3000`
+  * **Application description**: not critical, suggest something like 'Threat Dragon for local development'
+  * **Authorization callback URL**: `http://localhost:3000/oauth/github`
 
-* Register the application, an example screenshot is at the bottom of this document
+1. Register the application, an example screenshot is at the bottom of this document
 
-* In this new OAuth App, note the values for Client ID (something like `01234567890123456789`) and Client Secret (something like `0123456789abcdef0123456789abcdef01234567`)
+1. In this new OAuth App, note the values for Client ID (something like `01234567890123456789`)
+and Client Secret (something like `0123456789abcdef0123456789abcdef01234567`)
 
-* Generate a random 32 character hexadecimal key (something like `11223344556677889900aabbccddeeff`)
+1. Generate a random 32 character hexadecimal key (something like `11223344556677889900aabbccddeeff`)
 
 You now have all the info to set up the environment variables.
 
 # Configuring Environment Variables
-Environment variables can be configured by exporting variables to your terminal from which you'll be running Threat Dragon, or by using a `.env` file as described below.  
+
+Environment variables can be configured by exporting variables to your terminal
+from which you'll be running Threat Dragon, or by using a `.env` file as described below.
 
 ## Dotenv
-Place a file named `.env` at the root of the project with your environment variables.  The `example.env` is there for reference.  The application will load any variables in this file as environment variables.
+
+Place a file named `.env` at the root of the project with your environment variables.
+The `example.env` is there for reference.  The application will load any variables in this file as environment variables.
 
 ## MacOS / Linux
+
 For MacOS and Linux go into the terminal from which you start Threat Dragon and enter at the
 command line:
 * GITHUB_CLIENT_ID from Client ID above, for example `export GITHUB_CLIENT_ID=01234567890123456789`
-* GITHUB_CLIENT_SECRET from Client Secret above, for example `export GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
+* GITHUB_CLIENT_SECRET from Client Secret above,
+for example `export GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
 * `export NODE_ENV=development`
 * `export SESSION_STORE=local`
-* SESSION_SIGNING_KEY as the random 32 character hexadecimal key, for example `export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
-* SESSION_ENCRYPTION_KEYS has the same 32 character key, for example `export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
-* GITHUB_SCOPE - set this to `repo` if you want access also to private repos
+* SESSION_SIGNING_KEY as the random 32 character hexadecimal key,
+for example `export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
+* SESSION_ENCRYPTION_KEYS has the same 32 character key,
+for example `export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
+* GITHUB_SCOPE - set this to `repo` if you want access also to private github repos
+
+so that it looks something like (but with your values inserted):
+
+```
+export GITHUB_CLIENT_ID=01234567890123456789
+export GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567
+export NODE_ENV=development
+export SESSION_STORE=local
+export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff
+export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'
+export GITHUB_SCOPE=repo
+```
 
 ## Windows
-Similarly for Windows, from the terminal used to start Threat Dragon enter at the
-command line:
-* `set GITHUB_CLIENT_ID=01234567890123456789`
-* `set GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
-* `set NODE_ENV=development`
-* `set SESSION_STORE=local`
-* `set SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
-* `set SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
 
-You should now be able to start the threat dragon webapp using `npm run-script start` and then navigate in a browser to "http://localhost:3000/"
+Similarly for Windows, from the terminal used to start Threat Dragon enter at the command line:
+
+```
+set GITHUB_CLIENT_ID=01234567890123456789
+set GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567
+set NODE_ENV=development
+set SESSION_STORE=local
+set SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff
+set SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'
+set GITHUB_SCOPE=repo
+```
+
+You should now be able to start the threat dragon webapp using `npm run-script start`
+and then navigate in a browser to "http://localhost:3000/"
 
 Example screenshot of registering a new OAuth application:
 
-
 ![Register new OAuth application](/td/public/content/images/register-new-OAuth-application.png)
+
+_Threat Dragon: making threat models more dragony_


### PR DESCRIPTION
**Summary**
Bring docs and dev notes into one place, this Threat Dragon repo.
* The file `dev-notes.md` has been brought over from the threat-dragon-core repo and some changes made to bring it up to date, mainly dotenv notes
* `README.md` and `setup-env.md` updated
* docs directory is the github.com/threatdragon/threatdragon.github.io repo referenced as a github submodule

**Description for the changelog**
Bring docs and dev notes into threat dragon repo

**Other info**
This satisfies issue #80 .

Note that docs is a github submodule because we do not want it to be a dependency via npmjs. Using a submodule means that the docs are easily accessed from the source code ... in the hope that they will be more likely to be kept up to date
