### PR TITLE
Adding build action for docker container

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,7 +1,7 @@
 name: Build Docker Image
 on:
   push:
-    branches: [ feature/docker-build-github-action ]
+    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,37 @@
+name: Build Docker Image
+on:
+  push:
+    branches: [ feature/docker-build-github-action ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build (do not push)
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          tags: "owasp-threat-dragon:latest"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
**Summary**
Adds a build action to build a docker container

**Description for the changelog**
Adding GitHub action to build the docker image using a cache
Closes #104 

**Other info**
This work is based on https://docs.docker.com/ci-cd/github-actions/

When we are ready to start pushing official images, we can do this in an automated way.  We will need to add dockerhub credentials as secrets to the repository, then add the following step to the action:
```
      - name: Login to Docker Hub
        uses: docker/login-action@v1
        with:
          username: ${{ secrets.DOCKER_HUB_USERNAME }}
          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
```

To enable the push, update the build step to have `push: true`.  Also ensure that the tags are correct.