### PR TITLE
Test cleanup

### DIFF
--- a/td.server/.eslintrc.js
+++ b/td.server/.eslintrc.js
@@ -182,7 +182,7 @@ module.exports = {
         "no-useless-constructor": "error",
         "no-useless-rename": "error",
         "no-useless-return": "error",
-        "no-var": "off",
+        "no-var": "error",
         "no-void": "error",
         "no-warning-comments": "error",
         "no-whitespace-before-property": "error",

--- a/td.server/src/helpers/encryption.helper.js
+++ b/td.server/src/helpers/encryption.helper.js
@@ -102,7 +102,7 @@ const encryptPromise = (plainText) => {
  * @returns {String}
  */
 const decrypt = (encryptedData) => {
-    var iv = Buffer.from(encryptedData.iv, keyEncoding);
+    const iv = Buffer.from(encryptedData.iv, keyEncoding);
     const key = getKeyById(encryptedData.keyId);
     return decryptData(encryptedData.data, key, iv);  
 };

--- a/td.server/test/app_spec.js
+++ b/td.server/test/app_spec.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import appFactory from '../src/app.js';
 import envConfig from '../src/config/env.config.js';
 import expressHelper from '../src/helpers/express.helper.js';
+import { getMockApp } from './express.mocks.js';
 import loggersConfig from '../src/config/loggers.config.js';
 import parsersConfig from '../src/config/parsers.config.js';
 import passportConfig from '../src/config/passport.config.js';
@@ -14,19 +15,15 @@ import securityHeaders from '../src/config/securityheaders.config.js';
 import sessionConfig from '../src/config/session.config.js';
 
 describe('app tests', () => {
-    const mockExpress = {
-        set: () => {},
-        use: () => {}
-    };
+    let mockApp;
     const mockLogger = {
         info: () => {},
         error: () => {}
     };
 
     beforeEach(() => {
-        sinon.stub(expressHelper, 'getInstance').returns(mockExpress);
-        sinon.spy(mockExpress, 'set');
-        sinon.spy(mockExpress, 'use');
+        mockApp = getMockApp();
+        sinon.stub(expressHelper, 'getInstance').returns(mockApp);
         sinon.stub(express, 'static');
         sinon.stub(bunyan, 'createLogger').returns(mockLogger);
         sinon.spy(mockLogger, 'info');
@@ -52,15 +49,15 @@ describe('app tests', () => {
         });
 
         it('trusts proxies', () => {
-            expect(mockExpress.set).to.have.been.calledWith('trust proxy', true);
+            expect(mockApp.set).to.have.been.calledWith('trust proxy', true);
         });
 
         it('uses views', () => {
-            expect(mockExpress.set).to.have.been.calledWith('views', sinon.match('views'));
+            expect(mockApp.set).to.have.been.calledWith('views', sinon.match('views'));
         });
 
         it('uses the pug view engine', () => {
-            expect(mockExpress.set).to.have.been.calledWith('view engine', 'pug');
+            expect(mockApp.set).to.have.been.calledWith('view engine', 'pug');
         });
 
         it('uses dotenv config', () => {
@@ -68,7 +65,7 @@ describe('app tests', () => {
         });
         
         it('uses /public for static content', () => {
-            expect(mockExpress.use).to.have.been.calledWith('/public', sinon.match.any);
+            expect(mockApp.use).to.have.been.calledWith('/public', sinon.match.any);
             expect(express.static).to.have.been.calledWith(sinon.match('dist'));
         });
 

--- a/td.server/test/config/loggers.config_spec.js
+++ b/td.server/test/config/loggers.config_spec.js
@@ -1,36 +1,21 @@
 import { expect } from 'chai';
-import request from 'supertest';
-import sinon from 'sinon';
 
+import { getMockApp } from '../express.mocks.js';
 import loggers from '../../src/config/loggers.config.js';
 
 describe('loggers config tests', () => {
-    let app;
+    let mockApp;
     
     beforeEach(() => {
-        app = require('express')();
+        mockApp = getMockApp();
     });
-    
-    it('should set the logger on requests', (done) => {
-        loggers.configLoggers(app);
-        app.get('/test', (req, res) => {
-            expect(req.log).not.to.be.undefined;
-            res.status(200).send('result');
-        });
-        
-        request(app)
-            .get('/test')
-            .expect(200)
-            .end(done);
+
+    it('should set the logger using expressBunyan', () => {
+        loggers.configLoggers(mockApp);
+        expect(mockApp.use).to.have.been.calledOnce;
     });
-    
-    it('should log to stdout', function() {
-        const testMessage = 'test log';
-        const logger = loggers.logger;
-        sinon.spy(process.stdout, 'write');
-        logger.info(testMessage);
-        const message = JSON.parse(process.stdout.write.getCall(0).args[0]);
-        expect(message.name).to.eq('threatdragon');
-        expect(message.msg).to.eq(testMessage);
+
+    it('should create a logger', () => {
+        expect(loggers.logger.info).to.be.a('function');
     });
 });

--- a/td.server/test/config/passport.config_spec.js
+++ b/td.server/test/config/passport.config_spec.js
@@ -3,16 +3,16 @@ import passport from 'passport';
 import sinon from 'sinon';
 
 import env from '../../src/env/Env.js';
+import { getMockApp } from '../express.mocks.js';
 import passportConfig from '../../src/config/passport.config.js';
 
 describe('passport configuration tests', () => {
+    let mockApp;
     const clientId = 'clientid',
-        clientSecret = 'clientsecret',
-        mockApp = {
-            use: () => {}
-        };
+        clientSecret = 'clientsecret';
 
     beforeEach(() => {
+        mockApp = getMockApp();
         sinon.stub(passport, 'initialize');
         sinon.stub(passport, 'session');
         sinon.stub(passport, 'use');

--- a/td.server/test/config/routes.config_spec.js
+++ b/td.server/test/config/routes.config_spec.js
@@ -4,14 +4,12 @@ import sinon from 'sinon';
 
 import githubController from '../../src/controllers/githublogincontroller.js';
 import homeController from '../../src/controllers/homecontroller.js';
+import { getMockApp } from '../express.mocks.js';
 import routeConfig from '../../src/config/routes.config.js';
 import threatmodelController from '../../src/controllers/threatmodelcontroller.js';
 
 describe('route config tests', () => {
-    const mockApp = {
-        use: () => {}
-    };
-
+    let mockApp;
     const mockRouter = {
         get: () => {},
         post: () => {},
@@ -20,8 +18,8 @@ describe('route config tests', () => {
     };
 
     beforeEach(() => {
+        mockApp = getMockApp();
         sinon.stub(express, 'Router').returns(mockRouter);
-        sinon.spy(mockApp, 'use');
         sinon.spy(mockRouter, 'get');
         sinon.spy(mockRouter, 'post');
         sinon.spy(mockRouter, 'put');

--- a/td.server/test/config/securityheaders.config_spec.js
+++ b/td.server/test/config/securityheaders.config_spec.js
@@ -2,19 +2,14 @@ import { expect } from 'chai';
 import helmet from 'helmet';
 import sinon from 'sinon';
 
+import { getMockApp } from '../express.mocks.js';
 import securityHeaders from '../../src/config/securityheaders.config.js';
 
 describe('config/securityHeaders.config.js', () => {
-    const mockApp = {
-        set: () => {},
-        use: (fn) => {
-            if (fn) { fn(); }
-        }
-    };
+    let mockApp;
 
     beforeEach(() => {
-        sinon.spy(mockApp, 'set');
-        sinon.spy(mockApp, 'use');
+        mockApp = getMockApp();
         sinon.stub(helmet, 'hsts');
         sinon.stub(helmet, 'frameguard');
         sinon.stub(helmet, 'hidePoweredBy');

--- a/td.server/test/config/session.config_spec.js
+++ b/td.server/test/config/session.config_spec.js
@@ -1,20 +1,18 @@
 import { expect } from 'chai';
-import session from 'express-session';
 import sinon from 'sinon';
 
 import azureTableSession from '../../src/config/azuretablesession.config.js';
 import env from '../../src/env/Env.js';
 import loggers from '../../src/config/loggers.config.js';
+import { getMockApp } from '../express.mocks.js';
 import sessionConfig from '../../src/config/session.config.js';
 
 describe('session config tests', () => {
-    const mockApp = {
-        use: () => {}
-    };
     const sessionSigningKey = 'somekey';
+    let mockApp;
 
     beforeEach(() => {
-        sinon.spy(mockApp, 'use');
+        mockApp = getMockApp();
         sinon.spy(loggers.logger, 'error');
     });
 

--- a/td.server/test/controllers/error_spec.js
+++ b/td.server/test/controllers/error_spec.js
@@ -2,18 +2,15 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import error from '../../src/controllers/errors.js';
+import { getMockResponse } from '../express.mocks.js';
 import { logger } from '../../src/config/loggers.config.js';
 
 describe('controllers/error.js', () => {
     const errorMsg = 'Whoopsies';
-    const resStub = {
-        status: () => {},
-        json: () => {}
-    };
+    let mockResponse;
 
     beforeEach(() => {
-        sinon.stub(resStub, 'status').returns(resStub);
-        sinon.stub(resStub, 'json').returns(resStub);
+        mockResponse = getMockResponse();
         sinon.stub(logger, 'debug');
     });
 
@@ -25,7 +22,7 @@ describe('controllers/error.js', () => {
         let res;
 
         beforeEach(() => {
-            res = error.serverError(errorMsg, resStub);
+            res = error.serverError(errorMsg, mockResponse);
         });
 
         it('defines a serverError function', () => {
@@ -33,7 +30,7 @@ describe('controllers/error.js', () => {
         });
 
         it('responds with a status code of 500', () => {
-            expect(resStub.status).to.have.been.calledWith(500);
+            expect(mockResponse.status).to.have.been.calledWith(500);
         });
 
         it('sets the json body', () => {
@@ -42,11 +39,11 @@ describe('controllers/error.js', () => {
                 message: 'Internal Server Error',
                 details: errorMsg
             };
-            expect(resStub.json).to.have.been.calledWith(expected);
+            expect(mockResponse.json).to.have.been.calledWith(expected);
         });
 
         it('returns the res object', () => {
-            expect(res).to.deep.equal(resStub);
+            expect(res).to.deep.equal(mockResponse);
         });
 
         it('logs the error to the debug log', () => {
@@ -58,7 +55,7 @@ describe('controllers/error.js', () => {
         let res;
 
         beforeEach(() => {
-            res = error.notFound(errorMsg, resStub);
+            res = error.notFound(errorMsg, mockResponse);
         });
 
         it('defines a notFound function', () => {
@@ -66,7 +63,7 @@ describe('controllers/error.js', () => {
         });
 
         it('responds with a status code of 404', () => {
-            expect(resStub.status).to.have.been.calledWith(404);
+            expect(mockResponse.status).to.have.been.calledWith(404);
         });
 
         it('sets the json body', () => {
@@ -75,11 +72,11 @@ describe('controllers/error.js', () => {
                 message: 'Not Found',
                 details: errorMsg
             };
-            expect(resStub.json).to.have.been.calledWith(expected);
+            expect(mockResponse.json).to.have.been.calledWith(expected);
         });
 
         it('returns the res object', () => {
-            expect(res).to.deep.equal(resStub);
+            expect(res).to.deep.equal(mockResponse);
         });
 
         it('logs the error to the debug log', () => {
@@ -91,7 +88,7 @@ describe('controllers/error.js', () => {
         let res;
 
         beforeEach(() => {
-            res = error.badRequest(errorMsg, resStub);
+            res = error.badRequest(errorMsg, mockResponse);
         });
 
         it('defines a badRequest function', () => {
@@ -99,7 +96,7 @@ describe('controllers/error.js', () => {
         });
 
         it('responds with a status code of 400', () => {
-            expect(resStub.status).to.have.been.calledWith(400);
+            expect(mockResponse.status).to.have.been.calledWith(400);
         });
 
         it('sets the json body', () => {
@@ -108,11 +105,11 @@ describe('controllers/error.js', () => {
                 message: 'Bad Request',
                 details: errorMsg
             };
-            expect(resStub.json).to.have.been.calledWith(expected);
+            expect(mockResponse.json).to.have.been.calledWith(expected);
         });
 
         it('returns the res object', () => {
-            expect(res).to.deep.equal(resStub);
+            expect(res).to.deep.equal(mockResponse);
         });
 
         it('logs the error to the debug log', () => {
@@ -124,7 +121,7 @@ describe('controllers/error.js', () => {
         let res;
 
         beforeEach(() => {
-            res = error.forbidden(resStub);
+            res = error.forbidden(mockResponse);
         });
 
         it('defines a forbidden function', () => {
@@ -132,7 +129,7 @@ describe('controllers/error.js', () => {
         });
 
         it('responds with a status code of 403', () => {
-            expect(resStub.status).to.have.been.calledWith(403);
+            expect(mockResponse.status).to.have.been.calledWith(403);
         });
 
         it('sets the json body', () => {
@@ -141,11 +138,11 @@ describe('controllers/error.js', () => {
                 message: 'Forbidden',
                 details: 'Forbidden'
             };
-            expect(resStub.json).to.have.been.calledWith(expected);
+            expect(mockResponse.json).to.have.been.calledWith(expected);
         });
 
         it('returns the res object', () => {
-            expect(res).to.deep.equal(resStub);
+            expect(res).to.deep.equal(mockResponse);
         });
 
         it('logs the error to the debug log', () => {

--- a/td.server/test/controllers/githublogincontroller_spec.js
+++ b/td.server/test/controllers/githublogincontroller_spec.js
@@ -3,34 +3,16 @@ import passport from 'passport';
 import sinon from 'sinon';
 
 import cryptoPromise from '../../src/helpers/crypto.promise.js';
+import { getMockRequest, getMockResponse } from '../express.mocks.js';
 import githubLoginController from '../../src/controllers/githublogincontroller.js';
 
 describe('githublogincontroller tests', () => {
-    let mockRequest, next;
-    const mockResponse = {
-        status: () => {},
-        send: () => {},
-        redirect: () => {},
-        json: () => {}
-    };
+    let mockResponse, mockRequest, next;
 
     beforeEach(() => {
-        mockRequest = {
-            session: {},
-            query: {},
-            log: {
-                info: () => {},
-                error: () => {}
-            },
-            user: {
-                profile: {
-                    username: 'test user',
-                    provider: 'github'
-                }
-            }
-        };
+        mockRequest = getMockRequest();
+        mockResponse = getMockResponse();
         next = sinon.spy();
-        sinon.stub(mockResponse, 'status').returns(mockResponse);
     });
     
     afterEach(() => {
@@ -81,16 +63,7 @@ describe('githublogincontroller tests', () => {
 
 
     describe('completeLogin', () => {
-        beforeEach(() => {
-
-        });
-
         describe('with error', () => {
-            beforeEach(() => {
-                sinon.spy(mockRequest.log, 'error');
-                sinon.spy(mockResponse, 'send');
-            });
-
             it('logs an error for invalid oauth state', () => {
                 mockRequest.session.githubOauthState = 'aaaa';
                 mockRequest.query.state = 'bbbbb';
@@ -121,8 +94,6 @@ describe('githublogincontroller tests', () => {
             beforeEach(() => {
                 mockRequest.session.githubOauthState = 'aaaa';
                 mockRequest.query.state = 'aaaa';
-                sinon.spy(mockRequest.log, 'info');
-                sinon.spy(mockResponse, 'redirect');
             });
 
             it('logs a successful login', () => {

--- a/td.server/test/controllers/homecontroller_spec.js
+++ b/td.server/test/controllers/homecontroller_spec.js
@@ -3,34 +3,16 @@ import sinon from 'sinon';
 
 import env from '../../src/env/Env.js';
 import homeController from '../../src/controllers/homecontroller.js';
+import { getMockRequest, getMockResponse } from '../express.mocks.js';
 
 describe('homecontroller tests', () => {
-    const mockRequest = {
-        log: {
-            info: () => {},
-            error: () => {}
-        },
-        csrfToken: () => 'some_token',
-        logOut: () => {},
-        user: {
-            profile: {
-                username: 'test user',
-                provider: 'idp'
-            }
-        },
-        session: {
-            destroy: () => {}
-        }
-    };
+    let mockRequest, mockResponse;
 
-    const mockResponse = {
-        sendFile: () => {},
-        cookie: () => {},
-        clearCookie: () => {},
-        render: () => {},
-        redirect: () => {}
-    };
-    
+    beforeEach(() => {
+        mockRequest = getMockRequest();
+        mockResponse = getMockResponse();
+    });
+
     afterEach(() => {
         sinon.restore();
     });
@@ -43,9 +25,6 @@ describe('homecontroller tests', () => {
                 }
             };
             sinon.stub(env, 'get').returns(mockEnv);
-            sinon.spy(mockResponse, 'cookie');
-            sinon.spy(mockResponse, 'sendFile');
-            sinon.spy(mockRequest.log, 'error');
             homeController.index(mockRequest, mockResponse);
         });
 
@@ -71,7 +50,6 @@ describe('homecontroller tests', () => {
 
     describe('login', () => {
         beforeEach(() => {
-            sinon.spy(mockResponse, 'render');
             homeController.login(mockRequest, mockResponse);
         });
 
@@ -85,7 +63,6 @@ describe('homecontroller tests', () => {
     
     describe('logoutform', () => {
         beforeEach(() => {
-            sinon.spy(mockResponse, 'render');
             homeController.logoutform(mockRequest, mockResponse);
         });
 
@@ -102,12 +79,6 @@ describe('homecontroller tests', () => {
     
     describe('logout', () => {
         beforeEach(() => {
-            const mockDestroy = (cb) => cb();
-            sinon.spy(mockRequest, 'logOut');
-            sinon.spy(mockResponse, 'clearCookie');
-            sinon.stub(mockRequest.session, 'destroy').callsFake(mockDestroy);
-            sinon.spy(mockRequest.log, 'info');
-            sinon.spy(mockResponse, 'redirect');
             homeController.logout(mockRequest, mockResponse);
         });
 
@@ -147,7 +118,6 @@ describe('homecontroller tests', () => {
                 }
             };
             sinon.stub(env, 'get').returns(mockEnv);
-            sinon.spy(mockResponse, 'cookie');
             homeController.index(mockRequest, mockResponse);
         });
         

--- a/td.server/test/controllers/threatmodelcontroller_spec.js
+++ b/td.server/test/controllers/threatmodelcontroller_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { getMockRequest, getMockResponse } from '../express.mocks.js';
 import threatModelController from '../../src/controllers/threatmodelcontroller.js';
 import threatModelRepository from '../../src/repositories/threatmodelrepository.js';
 
@@ -8,22 +9,11 @@ describe('threat model controller tests', () => {
     const headers = {
         link: 'url1; rel="link", url2; rel="link"'
     };
-    const mockResponse = {
-        send: () => {},
-        status: () => {},
-        json: () => {}
-    };
     const err = new Error('whoops');
-    let mockRequest;
+    let mockRequest, mockResponse;
 
     beforeEach(() => {
-        mockRequest = {
-            user: {
-                accessToken: 'token',
-                profile: {
-                    username: 'foobar'
-                }
-            },
+        mockRequest = Object.assign(getMockRequest(), {
             params: {
                 organisation: 'test org',
                 repo: 'test repo',
@@ -33,15 +23,9 @@ describe('threat model controller tests', () => {
             query: {
                 page: 'test page'
             },
-            body: 'test body',
-            log: {
-                error: () => {}
-            }
-        };
-        sinon.stub(mockResponse, 'status').returns(mockResponse);
-        sinon.spy(mockResponse, 'json');
-        sinon.spy(mockResponse, 'send');
-        sinon.spy(mockRequest.log, 'error');
+            body: 'test body'
+        });
+        mockResponse = getMockResponse();
     });
 
     afterEach(() => {

--- a/td.server/test/express.mocks.js
+++ b/td.server/test/express.mocks.js
@@ -1,0 +1,77 @@
+import sinon from 'sinon';
+
+/**
+ * @name express.mocks
+ * @description A collection of reusable mocks useful for testing an express application
+ */
+
+export const getMockApp = () => {
+    const mockApp = {
+        set: () => {},
+        use: () => {}
+    };
+
+    sinon.spy(mockApp, 'set');
+    sinon.spy(mockApp, 'use');
+
+    return mockApp;
+};
+
+export const getMockRequest = () => {
+    const mockRequest = {
+        user: {
+            accessToken: 'token',
+            profile: {
+                username: 'foobar',
+                provider: 'fake idp'
+            }
+        },
+        params: {},
+        query: {},
+        session: {
+            destroy: (cb) => { if(cb) { cb(); }}
+        },
+        csrfToken: () => 'some_token',
+        logOut: () => {},
+        log: {
+            error: () => {},
+            debug: () => {},
+            fatal: () => {},
+            info: () => {},
+            warn: () => {}
+        }
+    };
+
+    sinon.spy(mockRequest.log, 'error');
+    sinon.spy(mockRequest.log, 'debug');
+    sinon.spy(mockRequest.log, 'fatal');
+    sinon.spy(mockRequest.log, 'info');
+    sinon.spy(mockRequest.log, 'warn');
+    sinon.spy(mockRequest.session, 'destroy');
+
+    return mockRequest;
+};
+
+export const getMockResponse = () => {
+    const mockResponse = {
+        send: () => {},
+        status: () => {},
+        json: () => {},
+        redirect: () => {},
+        sendFile: () => {},
+        cookie: () => {},
+        clearCookie: () => {},
+        render: () => {}
+    };
+
+    sinon.stub(mockResponse, 'status').returns(mockResponse);
+    sinon.stub(mockResponse, 'json').returns(mockResponse);
+    sinon.spy(mockResponse, 'send');
+    sinon.spy(mockResponse, 'redirect');
+    sinon.spy(mockResponse, 'sendFile');
+    sinon.spy(mockResponse, 'cookie');
+    sinon.spy(mockResponse, 'clearCookie');
+    sinon.spy(mockResponse, 'render');
+
+    return mockResponse;
+};

--- a/td.server/test/test-setup.spec.js
+++ b/td.server/test/test-setup.spec.js
@@ -1,8 +1,21 @@
+import bunyan from 'bunyan';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 
+import { logger } from '../src/config/loggers.config.js';
+
+/**
+ * Prevent logging during testing
+ */
+const suppressLogging = () => {
+    logger.level(bunyan.FATAL + 1);
+};
+
 before(() => {
     chai.use(sinonChai);
     chai.use(chaiAsPromised);
+
+    suppressLogging();
 });
+


### PR DESCRIPTION
**Summary**
Uses reusable express mocks for `td.server` tests

**Description for the changelog**
Chore: Cleanup tests by using reusable mocks for unit testing of td.server (Closes #111 )

**Other info**
Just some testing cleanup, no *functional* changes to application code (I did update eslint rules to enforce no-var, and found one instance that was missed by previous refactors)
