### PR TITLE
V2/docker vuln scanner

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,19 @@
+name: build
+on:
+  push:
+    branches:
+      - 'v2/*'
+jobs:
+  build:
+    name: Scan with Trivy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'imoshtokill/threat-dragon-dev:ci-latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,8 +1,10 @@
-name: build
+name: Trivy Daily Container Scan
 on:
   push:
     branches:
       - 'v2/*'
+  schedule:
+    - cron: '0 20 * * *'
 jobs:
   build:
     name: Scan with Trivy

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,8 +1,5 @@
 name: Trivy Daily Container Scan
 on:
-  push:
-    branches:
-      - 'v2/*'
   schedule:
     - cron: '0 20 * * *'
 jobs:

--- a/docs/development/actions/trivy.md
+++ b/docs/development/actions/trivy.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Trivy
+nav_order: 3
+path: /actions/trivy
+group: Actions
+---
+# Trivy Container Scan
+
+[Trivy](https://github.com/aquasecurity/trivy) is an open-source container and artifact vulnerability scanning tool.
+
+The trivy action is configured to run once a day to identify unpatched vulnerabilities in the docker image.  At the time of writing, the image is based on a [distroless](https://github.com/GoogleContainerTools/distroless) image which only contains the application and the runtime dependencies.  For this reason, the scanner is unlikely to find anything.  There are situations where this could become useful, such as the base image becoming unmaintained or changing.


### PR DESCRIPTION
**Summary**
We are now building and working on publishing an official docker image.  That image should be scanned for vulnerabilities on a regular interval.

**Description for the changelog**
Added [trivy](https://github.com/aquasecurity/trivy-action) github action to scan the published image daily for vulnerabilities

**Other info**
While it's unlikely to find anything because we are using the distroless base image, things change and this is a great fail-safe.  We could wind up changing the base image for some reason, it could stop getting updates from Google, etc.
