### PR TITLE
Adding SBOM to the docs.  This will be built as part of the docker bu…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,49 @@
+# Both front-end and back-end images need the same
+# global npm module to generate an SBOM. 
+FROM        node:14 as build-node
+WORKDIR     /app
+RUN         mkdir boms
+RUN         npm install -g @cyclonedx/bom
+
+# Builds td.server.  This step requires dev dependencies 
+# that do not need to be included in the final image
+FROM        build-node as build-backend
+COPY        ./td.server/package* ./
+RUN         npm ci
+RUN         cyclonedx-bom -o boms/server_json_bom.json .
+COPY        ./td.server/.babelrc ./
+COPY        ./td.server/src ./src
+RUN         npm run build
+
+# Builds td.vue.  This step requires dev dependencies 
+# that do not need to be included in the final image
+FROM        build-node as build-frontend
+COPY        ./td.vue/package* ./
+RUN         npm ci
+RUN         cyclonedx-bom -o boms/site_json_bom.json .
+COPY        ./td.vue/src ./src
+COPY        ./td.vue/public ./public
+COPY        ./td.vue/*.config.js ./
+RUN         npm run build
+
+# Build the canonical bom
+FROM        cyclonedx/cyclonedx-cli:0.15.0 as build-canonical-bom
+RUN         mkdir boms
+COPY        --from=build-backend /app/boms/* ./boms/
+COPY        --from=build-frontend /app/boms/* ./boms/
+RUN         ./cyclonedx convert \
+                --input-file boms/site_json_bom.json \
+                --output-file boms/site_xml_bom.xml
+RUN         ./cyclonedx convert \
+                --input-file boms/server_json_bom.json \
+                --output-file boms/server_xml_bom.xml
+RUN         ./cyclonedx merge \
+                --input-files boms/site_json_bom.json boms/server_json_bom.json \
+                --output-file boms/canonical_json_bom.json
+RUN         ./cyclonedx convert \
+                --input-file boms/canonical_json_bom.json \
+                --output-file boms/canonical_xml_bom.xml
+
 # Builds the docs
 FROM        ruby:2.6 as build-docs
 RUN         gem install jekyll bundler
@@ -5,28 +51,11 @@ WORKDIR     /td.docs
 COPY        ./docs/Gemfile* ./
 RUN         bundle install
 COPY        ./docs .
+RUN         mkdir _data
+RUN         mkdir downloads
+COPY        --from=build-canonical-bom boms/canonical_json_bom.json _data/canonical_json_bom.json
+COPY        --from=build-canonical-bom boms/* downloads/
 RUN         bundle exec jekyll build -b docs/
-
-# Builds td.server.  This step requires dev dependencies 
-# that do not need to be included in the final image
-FROM        node:14 as build-backend
-WORKDIR     /app
-COPY        ./td.server/package* ./
-RUN         npm ci
-COPY        ./td.server/.babelrc ./
-COPY        ./td.server/src ./src
-RUN         npm run build
-
-# Builds td.vue.  This step requires dev dependencies 
-# that do not need to be included in the final image
-FROM        node:14 as build-frontend
-WORKDIR     /app/td.vue
-COPY        ./td.vue/package* ./
-RUN         npm ci
-COPY        ./td.vue/src ./src
-COPY        ./td.vue/public ./public
-COPY        ./td.vue/*.config.js ./
-RUN         npm run build
 
 # Get the runtime dependencies for td.server that we will 
 # need for the final image
@@ -43,6 +72,6 @@ WORKDIR     /app
 COPY        --from=build-docs /td.docs/_site /app/docs
 COPY        --from=deps-backend /app ./td.server
 COPY        --from=build-backend /app/dist ./td.server/dist
-COPY        --from=build-frontend /app/td.vue/dist /app/dist
+COPY        --from=build-frontend /app/dist /app/dist
 COPY        ./td.server/index.js ./td.server/index.js
-CMD ["td.server/index.js"]
+CMD         ["td.server/index.js"]

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.2.0"
 
 # Theme
-gem "owasp-td-jekyll", "~> 0.1.3"
+gem "owasp-td-jekyll", "~> 0.2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    owasp-td-jekyll (0.1.3)
+    owasp-td-jekyll (0.2.0)
       jekyll (~> 4.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -67,7 +67,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-feed (~> 0.12)
-  owasp-td-jekyll (~> 0.1.3)
+  owasp-td-jekyll (~> 0.2.0)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -65,6 +65,8 @@ nav:
       groups:
         - name: About
           fa_class: fas fa-info-circle
+        - name: Trust
+          fa_class: fas fa-lock
     - name: Usage
       groups:
         - name: Installation

--- a/docs/home/trust/sbom.md
+++ b/docs/home/trust/sbom.md
@@ -1,0 +1,40 @@
+---
+layout: page
+title: SBOM
+nav_order: 0
+path: /trust/sbom
+group: Trust
+---
+
+# SBOMs
+
+[CyclyoneDX](https://cyclonedx.org/) Software Bill of Materials are generated for the front-end, back-end and combined Threat Dragon projects.  These SBOMs are generated during the build of the docker image, and should always be an up-to-date version for the current snapshot / tag that is running.
+
+Downloads:
+
+{:.table .table-striped}
+|Project|Format|Link|
+|---|---|---|
+|td.vue|json|[site_json_bom.json]({{ '/downloads/site_json_bom.json' | relative_url }})|
+|td.vue|xml|[site_xml_bom.xml]({{ '/downloads/site_xml_bom.xml' | relative_url }})|
+|td.server|json|[server_json_bom.json]({{ '/downloads/server_json_bom.json' | relative_url }})|
+|td.server|xml|[server_xml_bom.xml]({{ '/downloads/server_xml_bom.xml' | relative_url }})|
+|Canonical|json|[canonical_json_bom.json]({{ '/downloads/canonical_json_bom.json' | relative_url }})|
+|Canonical|xml|[canonical_xml_bom.xml]({{ '/downloads/canonical_xml_bom.xml' | relative_url }})|
+
+
+# Searchable SBOM:
+
+{: .table .table-striped .td-data-table}
+|Name|Version|Licenses|
+|---|---|---|
+{% for component in site.data.canonical_json_bom.components -%}
+{%- assign website = component.externalReferences | where: "type", "website" | first -%}
+{%- capture name -%}
+{% if component.group -%}{{ component.group }}/{% endif %}{{ component.name }}
+{%- endcapture -%}
+{%- capture nameLink -%}
+{% if website -%}<a href="{{ website.url }}" target="_blank" rel="noopener noreferrer">{{ name }}</a>{%- else -%}{{ name }}{%- endif -%}
+{%- endcapture -%}
+| {{ nameLink }} | {{ component.version }} | {%- if component.licenses -%}{{ component.licenses | map: 'license' | map: 'id' | join: ', ' }}{%- endif -%} |
+{% endfor %}

--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -10,3 +10,7 @@
 - Error handling for API requests that might fail (toast service?)
 - Add more e2e tests after the no backend work is done (hard to test since we would need loads of configuration)
 - Document architecture
+- Create deployment pipeline separate from the other actions
+    - Clean up the other actions a bit
+    - Make a separate E2E test suite for smoke tests
+    - Add a smoke test for SBOM


### PR DESCRIPTION
**Summary**
Adding a Software Bill of Materials for td.vue and td.server

**Description for the changelog**
#178 - Adding SBOM to docs for td.vue and td.server.  Will be part of v2

**Other info**
SBOM is built by [cyclonedx](https://cyclonedx.org/) as part of the docker build.  There is a new section in the docs called "Trust".  Currently the only page there is for the SBOM, but I will be adding to the trust section to document the security features baked into the Threat Dragon ecosystem.

Download links are provided for json/xml formats for td.server, td.vue and "canonical" (a combination of the two).
Additionally, a searchable bootstrap datatable is in the docs that includes the name, a link to the website (if available), the version and the license type.