### PR TITLE
State is cleared on fetch actions

### DIFF
--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -1,5 +1,4 @@
 - Do a POC to use no back-end whatsoever (demo and test only)
-- Fetch actions need to clear the associated state
 - Gracefully handle an expired refresh token (TODO in httpClient)
 - Logout
 - Add tests for ThreatmodelEdit view

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -19,7 +19,8 @@ const state = {
 
 const actions = {
     [BRANCH_CLEAR]: ({ commit }) => commit(BRANCH_CLEAR),
-    [BRANCH_FETCH]: async ({ commit, rootState }) => {
+    [BRANCH_FETCH]: async ({ commit, dispatch, rootState }) => {
+        dispatch(BRANCH_CLEAR);
         const resp = await threatmodelApi.branchesAsync(rootState.repo.selected);
         commit(BRANCH_FETCH, resp.data.branches);
     },
@@ -29,7 +30,6 @@ const actions = {
 const mutations = {
     [BRANCH_CLEAR]: (state) => clearState(state),
     [BRANCH_FETCH]: (state, branches) => {
-        state.all.length = 0;
         branches.forEach((branch, idx) => Vue.set(state.all, idx, branch));
     },
     [BRANCH_SELECTED]: (state, repo) => {

--- a/td.vue/src/store/modules/provider.js
+++ b/td.vue/src/store/modules/provider.js
@@ -19,7 +19,8 @@ const state = {
 
 const actions = {
     [PROVIDER_CLEAR]: ({ commit }) => commit(PROVIDER_CLEAR),
-    [PROVIDER_FETCH]: ({ commit }) => {
+    [PROVIDER_FETCH]: ({ commit, dispatch }) => {
+        dispatch(PROVIDER_CLEAR);
         // TODO: Get a list of configured providers from the backend
         commit(PROVIDER_FETCH, Object.keys(providers.providerNames));
     },

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -19,7 +19,8 @@ const state = {
 
 const actions = {
     [REPOSITORY_CLEAR]: ({ commit }) => commit(REPOSITORY_CLEAR),
-    [REPOSITORY_FETCH]: async ({ commit }) => {
+    [REPOSITORY_FETCH]: async ({ commit, dispatch }) => {
+        dispatch(REPOSITORY_CLEAR);
         const resp = await threatmodelApi.reposAsync();
         commit(REPOSITORY_FETCH, resp.data.repos);
     },

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -22,7 +22,8 @@ const state = {
 
 const actions = {
     [THREATMODEL_CLEAR]: ({ commit }) => commit(THREATMODEL_CLEAR),
-    [THREATMODEL_FETCH]: async ({ commit, state, rootState }) => {
+    [THREATMODEL_FETCH]: async ({ commit, dispatch, state, rootState }) => {
+        dispatch(THREATMODEL_CLEAR);
         if (rootState.provider.selected !== 'local') {
             const resp = await threatmodelApi.modelAsync(
                 rootState.repo.selected,

--- a/td.vue/tests/unit/store/modules/branch.spec.js
+++ b/td.vue/tests/unit/store/modules/branch.spec.js
@@ -5,6 +5,7 @@ import threatmodelApi from '@/service/threatmodelApi.js';
 describe('store/modules/branch.js', () => {
     const mocks = {
         commit: () => {},
+        dispatch: () => {},
         rootState: {
             auth: {
                 jwt: 'test'
@@ -17,6 +18,7 @@ describe('store/modules/branch.js', () => {
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
+        jest.spyOn(mocks, 'dispatch');
     });
 
     afterEach(() => {
@@ -38,15 +40,25 @@ describe('store/modules/branch.js', () => {
             branchModule.actions[BRANCH_CLEAR](mocks);
             expect(mocks.commit).toHaveBeenCalledWith(BRANCH_CLEAR);
         });
-        
-        it('commits the fetch action', async () => {
+
+        describe('fetch', () => {
             const branches = [ 'foo', 'bar' ];
-            jest.spyOn(threatmodelApi, 'branchesAsync').mockResolvedValue({ data: { branches }});
-            await branchModule.actions[BRANCH_FETCH](mocks);
-            expect(mocks.commit).toHaveBeenCalledWith(
-                BRANCH_FETCH,
-                branches
-            );
+
+            beforeEach(async () => {
+                jest.spyOn(threatmodelApi, 'branchesAsync').mockResolvedValue({ data: { branches }});
+                await branchModule.actions[BRANCH_FETCH](mocks);
+            });
+
+            it('dispatches the clear event', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(BRANCH_CLEAR);
+            });
+
+            it('commits the fetch action', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(
+                    BRANCH_FETCH,
+                    branches
+                );
+            });
         });
 
         it('commits the selected branch', () => {

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -4,11 +4,13 @@ import providerService from '@/service/providers.js';
 
 describe('store/modules/provider.js', () => {
     const mocks = {
-        commit: () => {}
+        commit: () => {},
+        dispatch: () => {}
     };
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
+        jest.spyOn(mocks, 'dispatch');
     });
 
     afterEach(() => {
@@ -31,12 +33,21 @@ describe('store/modules/provider.js', () => {
             expect(mocks.commit).toHaveBeenCalledWith(PROVIDER_CLEAR);
         });
         
-        it('commits the fetch action will providerNames', () => {
-            providerModule.actions[PROVIDER_FETCH](mocks);
-            expect(mocks.commit).toHaveBeenCalledWith(
-                PROVIDER_FETCH,
-                Object.keys(providerService.providerNames)
-            );
+        describe('fetch', () => {
+            beforeEach(() => {
+                providerModule.actions[PROVIDER_FETCH](mocks);
+            });
+
+            it('dispatches the clear action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(PROVIDER_CLEAR);
+            });
+
+            it('commits the fetch action will providerNames', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(
+                    PROVIDER_FETCH,
+                    Object.keys(providerService.providerNames)
+                );
+            });
         });
         
         describe('selected', () => {

--- a/td.vue/tests/unit/store/modules/repository.spec.js
+++ b/td.vue/tests/unit/store/modules/repository.spec.js
@@ -5,6 +5,7 @@ import threatmodelApi from '@/service/threatmodelApi.js';
 describe('store/modules/repository.js', () => {
     const mocks = {
         commit: () => {},
+        dispatch: () => {},
         rootState: {
             auth: {
                 jwt: 'test'
@@ -14,6 +15,7 @@ describe('store/modules/repository.js', () => {
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
+        jest.spyOn(mocks, 'dispatch');
     });
 
     afterEach(() => {
@@ -35,15 +37,25 @@ describe('store/modules/repository.js', () => {
             repoModule.actions[REPOSITORY_CLEAR](mocks);
             expect(mocks.commit).toHaveBeenCalledWith(REPOSITORY_CLEAR);
         });
-        
-        it('commits the fetch action', async () => {
+
+        describe('fetch', () => {
             const repos = [ 'foo', 'bar' ];
-            jest.spyOn(threatmodelApi, 'reposAsync').mockResolvedValue({ data: { repos }});
-            await repoModule.actions[REPOSITORY_FETCH](mocks);
-            expect(mocks.commit).toHaveBeenCalledWith(
-                REPOSITORY_FETCH,
-                repos
-            );
+
+            beforeEach(async () => {
+                jest.spyOn(threatmodelApi, 'reposAsync').mockResolvedValue({ data: { repos }});
+                await repoModule.actions[REPOSITORY_FETCH](mocks);
+            });
+
+            it('dispatches the clear event', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(REPOSITORY_CLEAR);
+            });
+
+            it('commits the fetch action', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(
+                    REPOSITORY_FETCH,
+                    repos
+                );
+            });
         });
 
         it('commits the selected repo', () => {

--- a/td.vue/tests/unit/store/modules/threatmodel.spec.js
+++ b/td.vue/tests/unit/store/modules/threatmodel.spec.js
@@ -55,22 +55,41 @@ describe('store/modules/threatmodel.js', () => {
             threatmodelModule.actions[THREATMODEL_CLEAR](mocks);
             expect(mocks.commit).toHaveBeenCalledWith(THREATMODEL_CLEAR);
         });
-        
-        it('commits the fetch action', async () => {
-            const data = 'foobar';
-            jest.spyOn(threatmodelApi, 'modelAsync').mockResolvedValue({ data });
-            await threatmodelModule.actions[THREATMODEL_FETCH](mocks);
-            expect(mocks.commit).toHaveBeenCalledWith(
-                THREATMODEL_FETCH,
-                data
-            );
-        });
 
-        it('does not do a fetch if using a local provider', async () => {
-            jest.spyOn(threatmodelApi, 'modelAsync');
-            mocks.rootState.provider.selected = 'local';
-            await threatmodelModule.actions[THREATMODEL_FETCH](mocks);
-            expect(threatmodelApi.modelAsync).not.toHaveBeenCalled();
+        describe('fetch', () => {
+            const data = 'foobar';
+
+            beforeEach(() => {
+                jest.spyOn(threatmodelApi, 'modelAsync').mockResolvedValue({ data });
+            });
+            
+            describe('local provider', () => {
+                beforeEach(async () => {                    
+                    mocks.rootState.provider.selected = 'local';
+                    await threatmodelModule.actions[THREATMODEL_FETCH](mocks);
+                });
+
+                it('does not do a fetch if using a local provider', () => {
+                    expect(threatmodelApi.modelAsync).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('back-end provider', () => {
+                beforeEach(async () => {
+                    await threatmodelModule.actions[THREATMODEL_FETCH](mocks);
+                });
+
+                it('dispatches the clear event', () => {
+                    expect(mocks.dispatch).toHaveBeenCalledWith(THREATMODEL_CLEAR);
+                });
+            
+                it('commits the fetch action', () => {
+                    expect(mocks.commit).toHaveBeenCalledWith(
+                        THREATMODEL_FETCH,
+                        data
+                    );
+                });
+            });
         });
         
         it('commits the fetch all action', async () => {


### PR DESCRIPTION
**Summary**
The state previously was not cleared on fetch actions causing an incorrect state should the fetch action fail, leading to 500 errors.  Mostly notable when switching between local and remote IDPs.

**Description for the changelog**
State is now cleared on fetch actions

**Other info**
V2 only, Vue specific
