### PR TITLE
V2/logout

### DIFF
--- a/td.server/src/config/routes.config.js
+++ b/td.server/src/config/routes.config.js
@@ -15,8 +15,6 @@ import threatmodelController from '../controllers/threatmodelcontroller.js';
 const unauthRoutes = (router) => {
     router.get('/', homeController.index);
     router.get('/healthz', healthcheck.healthz);
-    router.get('/logoutform', homeController.logoutform);
-    router.post('/logout', homeController.logout);
 
     router.get('/api/login/:provider', auth.login);
     router.get('/api/oauth/return', auth.oauthReturn);
@@ -31,6 +29,7 @@ const unauthRoutes = (router) => {
  * @returns {express.Router}
  */
 const routes = (router) => {
+    router.post('/api/logout', auth.logout);
     router.get('/api/threatmodel/repos', threatmodelController.repos);
     router.get('/api/threatmodel/:organisation/:repo/branches', threatmodelController.branches);
     router.get('/api/threatmodel/:organisation/:repo/:branch/models', threatmodelController.models);

--- a/td.server/src/controllers/auth.js
+++ b/td.server/src/controllers/auth.js
@@ -41,6 +41,25 @@ const completeLogin = (req, res) => {
     }
 };
 
+const logout = (req, res) => responseWrapper.sendResponse(() => {
+    try {
+        const refreshToken = req.body.refreshToken;
+        if (!refreshToken) {
+            req.log.warn({ security: true }, 'Attempting to log out without a refresh token');
+            // Return OK even though it's not really ok
+            // If this happens, it could be a client error, or it could be
+            // something more nefarious. 
+            return '';
+        }
+
+        tokenRepo.remove(refreshToken);
+        return '';
+    } catch (e) {
+        req.log.error({ security: true }, e);
+        return '';
+    }
+}, req, res);
+
 const refresh = (req, res) => {
     const tokenBody = tokenRepo.verify(req.body.refreshToken);
     if (!tokenBody) {
@@ -53,12 +72,6 @@ const refresh = (req, res) => {
         // Limit the time refresh tokens live, so do not provide a new one.
         return { accessToken, refreshToken: req.body.refreshToken };
     }, req, res);
-};
-
-const logout = (req, res) => {
-    // Delete refresh token
-    req.log.error('Not implemented');
-    res.status(400).json({ status: 400, message: 'Not implemented on the server' });
 };
 
 export default {

--- a/td.server/src/controllers/homecontroller.js
+++ b/td.server/src/controllers/homecontroller.js
@@ -18,37 +18,6 @@ const index = (req, res) => {
     res.sendFile(indexHtmlPath);
 };
 
-/**
- * Gets the angular view for the logout form
- * Dynamic for username
- * @param {Object} req
- * @param {Object} res
- * @returns {Object}
- */
-const logoutform = (req, res) => res.render('logoutform', {
-        username: req.user.profile.username
-});
-
-/**
- * Logs the user out
- * @param {Object} req
- * @param {Object} res
- * @returns {Object}
- */
-const logout = (req, res) => {
-    const userName = req.user.profile.username;
-    const idp = req.user.profile.provider;
-
-    req.logOut();
-
-    return req.session.destroy(() => {
-        req.log.info({ security: true, userName, idp }, 'logged out');
-        return res.redirect('/');
-    });
-};
-
 export default {
-    index,
-    logout,
-    logoutform
+    index
 };

--- a/td.server/test/config/routes.config_spec.js
+++ b/td.server/test/config/routes.config_spec.js
@@ -52,7 +52,7 @@ describe('route config tests', () => {
         });
     });
 
-    describe('login and logout', () => {
+    describe('login/logout', () => {
         it('routes GET /api/login/:provider', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/login/:provider',
@@ -60,17 +60,10 @@ describe('route config tests', () => {
             );
         });
 
-        it('routes GET /logoutform', () => {
-            expect(mockRouter.get).to.have.been.calledWith(
-                '/logoutform',
-                homeController.logoutform
-            );
-        });
-
-        it('routes POST /logout', () => {
+        it('routes POST /api/logout', () => {
             expect(mockRouter.post).to.have.been.calledWith(
-                '/logout',
-                homeController.logout
+                '/api/logout',
+                auth.logout
             );
         });
     });

--- a/td.server/test/controllers/auth_spec.js
+++ b/td.server/test/controllers/auth_spec.js
@@ -65,6 +65,44 @@ describe('controllers/auth.js', () => {
         });
     });
 
+    describe('logout', () => {
+        const refresh = 'asdf';
+
+        describe('with refresh token', () => {
+            beforeEach(() => {
+                sinon.stub(tokenRepo, 'remove');
+                mockRequest.body.refreshToken = refresh;
+                auth.logout(mockRequest, mockResponse);
+            });
+
+            it('removes the refresh token', () => {
+                expect(tokenRepo.remove).to.have.been.calledWith(refresh);
+            });
+        });
+
+        describe('without a refresh token', () => {
+            beforeEach(() => {
+                auth.logout(mockRequest, mockResponse);
+            });
+
+            it('logs a warning', () => {
+                expect(mockRequest.log.warn).to.have.been.calledOnce;
+            });
+        });
+
+        describe('with an error removing the token', () => {
+            beforeEach(() => {
+                sinon.stub(tokenRepo, 'remove').throws('whoops!');
+                mockRequest.body.refreshToken = refresh;
+                auth.logout(mockRequest, mockResponse);
+            });
+
+            it('logs an error', () => {
+                expect(mockRequest.log.error).to.have.been.calledOnce;
+            });
+        });
+    });
+
     describe('oauthReturn', () => {
         beforeEach(() => {
             mockRequest.query.code = '12345';

--- a/td.server/test/controllers/homecontroller_spec.js
+++ b/td.server/test/controllers/homecontroller_spec.js
@@ -32,44 +32,4 @@ describe('homecontroller tests', () => {
             expect(mockResponse.sendFile).to.have.been.calledWith(sinon.match(/index\.html$/));
         });
     });
-    
-    describe('logoutform', () => {
-        beforeEach(() => {
-            homeController.logoutform(mockRequest, mockResponse);
-        });
-
-        it('should pass the username to the logout form', () => {
-            expect(mockResponse.render).to.have.been.calledWith(
-                'logoutform',
-                {
-                    username: mockRequest.user.profile.username
-                }
-            );
-        });
-    });
-    
-    describe('logout', () => {
-        beforeEach(() => {
-            homeController.logout(mockRequest, mockResponse);
-        });
-
-        it('should destroy the session', () => {
-            expect(mockRequest.session.destroy).to.have.been.calledOnce;
-        });
-
-        it('should write the logout to the log', () => {
-            expect(mockRequest.log.info).to.have.been.calledWith(
-                {
-                    security: true,
-                    userName: mockRequest.user.profile.username,
-                    idp: mockRequest.user.profile.provider
-                },
-                sinon.match.string
-            );
-        });
-
-        it('should redirect the user', () => {
-            expect(mockResponse.redirect).to.have.been.calledWith('/');
-        });
-    });
 });

--- a/td.server/test/express.mocks.js
+++ b/td.server/test/express.mocks.js
@@ -38,7 +38,6 @@ export const getMockRequest = () => {
             destroy: (cb) => { if(cb) { cb(); }}
         },
         csrfToken: () => 'some_token',
-        logOut: () => {},
         log: {
             error: () => {},
             debug: () => {},

--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -1,9 +1,8 @@
 - Do a POC to use no back-end whatsoever (demo and test only)
 - Fetch actions need to clear the associated state
-- Gracefully handle an expired refresh token (TODO in httpClient)
-- Logout
-- Add tests for ThreatmodelEdit view
 - Deep linking (redo routing entirely, match old way?)
+- Gracefully handle an expired refresh token (TODO in httpClient)
+- Add tests for ThreatmodelEdit view
 - Update flow to create a new diagram
 - Add report feature
 - Add the download from github feature

--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -8,7 +8,7 @@
     <b-collapse id="nav-collapse" is-nav>
       <b-navbar-nav class="ml-auto">
         <b-nav-text v-show="username" class="logged-in-as">Logged in as {{ username }}</b-nav-text>
-        <b-nav-item v-show="username" href="#" id="nav-sign-out">
+        <b-nav-item v-show="username" @click="onLogOut" id="nav-sign-out">
           <font-awesome-icon
             icon="sign-out-alt"
             class="td-fa-nav"
@@ -73,12 +73,22 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import { LOGOUT } from '@/store/actions/auth.js';
+import router from '@/router/index.js';
+
 export default {
     name: 'TdNavbar',
     computed: {
         ...mapGetters([
             'username'
         ])
+    },
+    methods: {
+        onLogOut(evt) {
+            evt.preventDefault();
+            this.$store.dispatch(LOGOUT);
+            router.push('/');
+        }
     }
 };
 </script>

--- a/td.vue/src/service/loginApi.js
+++ b/td.vue/src/service/loginApi.js
@@ -4,7 +4,10 @@ const loginAsync = (provider) => api.getAsync(`/api/login/${provider}`);
 
 const completeLoginAsync = (provider, code) => api.getAsync(`/api/oauth/${provider}?code=${code}`);
 
+const logoutAsync = (refreshToken) => api.postAsync('/api/logout', { refreshToken });
+
 export default {
     completeLoginAsync,
-    loginAsync
+    loginAsync,
+    logoutAsync
 };

--- a/td.vue/src/store/actions/auth.js
+++ b/td.vue/src/store/actions/auth.js
@@ -1,6 +1,7 @@
 export const AUTH_CLEAR = 'AUTH_CLEAR';
 export const AUTH_SET_JWT = 'AUTH_SET_JWT';
 export const AUTH_SET_LOCAL = 'AUTH_SET_LOCAL';
+export const LOGOUT = 'LOGOUT';
 
 export default {
     setJwt: AUTH_SET_JWT

--- a/td.vue/src/store/modules/auth.js
+++ b/td.vue/src/store/modules/auth.js
@@ -1,6 +1,8 @@
 import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL, LOGOUT } from '../actions/auth.js';
 import { BRANCH_CLEAR } from '../actions/branch.js';
+import loginApi from '../../service/loginApi.js';
 import { PROVIDER_CLEAR } from '../actions/provider.js';
+import providers from '../../service/providers.js';
 import { REPOSITORY_CLEAR } from '../actions/repository.js';
 import { THREATMODEL_CLEAR } from '../actions/threatmodel.js';
 
@@ -22,7 +24,14 @@ const actions = {
     [AUTH_CLEAR]: ({ commit }) => commit(AUTH_CLEAR),
     [AUTH_SET_JWT]: ({ commit }, tokens) => commit(AUTH_SET_JWT, tokens),
     [AUTH_SET_LOCAL]: ({ commit }) => commit(AUTH_SET_LOCAL),
-    [LOGOUT]: ({ dispatch }) => {
+    [LOGOUT]: async ({ dispatch, state, rootState }) => {
+        try {
+            if (rootState.provider.selected !== providers.allProviders.local.key) {
+                await loginApi.logoutAsync(state.refreshToken);
+            }
+        } catch (e) {
+            console.error('Error calling logout api', e);
+        }
         dispatch(AUTH_CLEAR);
         dispatch(BRANCH_CLEAR);
         dispatch(PROVIDER_CLEAR);

--- a/td.vue/src/store/modules/auth.js
+++ b/td.vue/src/store/modules/auth.js
@@ -1,4 +1,8 @@
-import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL } from '../actions/auth.js';
+import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL, LOGOUT } from '../actions/auth.js';
+import { BRANCH_CLEAR } from '../actions/branch.js';
+import { PROVIDER_CLEAR } from '../actions/provider.js';
+import { REPOSITORY_CLEAR } from '../actions/repository.js';
+import { THREATMODEL_CLEAR } from '../actions/threatmodel.js';
 
 export const clearState = (state) => {
     state.jwt = '';
@@ -17,7 +21,14 @@ const state = {
 const actions = {
     [AUTH_CLEAR]: ({ commit }) => commit(AUTH_CLEAR),
     [AUTH_SET_JWT]: ({ commit }, tokens) => commit(AUTH_SET_JWT, tokens),
-    [AUTH_SET_LOCAL]: ({ commit }) => commit(AUTH_SET_LOCAL)
+    [AUTH_SET_LOCAL]: ({ commit }) => commit(AUTH_SET_LOCAL),
+    [LOGOUT]: ({ dispatch }) => {
+        dispatch(AUTH_CLEAR);
+        dispatch(BRANCH_CLEAR);
+        dispatch(PROVIDER_CLEAR);
+        dispatch(REPOSITORY_CLEAR);
+        dispatch(THREATMODEL_CLEAR);
+    }
 };
 
 const mutations = {

--- a/td.vue/tests/e2e/specs/logout.js
+++ b/td.vue/tests/e2e/specs/logout.js
@@ -1,0 +1,16 @@
+describe('logout', () => {
+    beforeEach(() => {
+        cy.visit('/');
+        cy.get('#local-login-btn').click();
+        cy.contains('Logged in as Guest');
+        cy.get('#nav-sign-out').click();
+    });
+
+    it('does not show the logged in text', () => {
+        cy.get('.logged-in-as').should('not.be', 'visible');
+    });
+
+    it('should redirect to the home page', () => {
+        cy.url().should('not.contain', '/dashboard');
+    });
+});

--- a/td.vue/tests/unit/components/navbar.spec.js
+++ b/td.vue/tests/unit/components/navbar.spec.js
@@ -11,7 +11,9 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 
+import { LOGOUT } from '@/store/actions/auth.js';
 import Navbar from '@/components/Navbar.vue';
+import router from '@/router/index.js';
 
 describe('components/Navbar.vue', () => {
     let wrapper, localVue, mockStore;
@@ -24,7 +26,8 @@ describe('components/Navbar.vue', () => {
         mockStore = new Vuex.Store({
             getters: {
                 username: () => 'foobar'
-            }
+            },
+            dispatch: () => {}
         });
         wrapper = shallowMount(Navbar, {
             localVue,
@@ -96,6 +99,8 @@ describe('components/Navbar.vue', () => {
                 signOut = navItems
                     .filter(x => x.attributes('id') === 'nav-sign-out')
                     .at(0);
+                router.push = jest.fn();
+                mockStore.dispatch = jest.fn();
             });
 
             it('has the sign out button', () => {
@@ -105,6 +110,16 @@ describe('components/Navbar.vue', () => {
             it('uses fa sign-out-alt', () => {
                 expect(signOut.findComponent(FontAwesomeIcon).attributes('icon'))
                     .toEqual('sign-out-alt');
+            });
+
+            it('dispatches the logout event', async () => {
+                await signOut.trigger('click');
+                expect(mockStore.dispatch).toHaveBeenCalledWith(LOGOUT);
+            });
+
+            it('navigates to the home page', async () => {
+                await signOut.trigger('click');
+                expect(router.push).toHaveBeenCalledWith('/');
             });
         });
 

--- a/td.vue/tests/unit/service/loginApi.spec.js
+++ b/td.vue/tests/unit/service/loginApi.spec.js
@@ -7,6 +7,7 @@ describe('service/loginApi.js', () => {
 
     beforeEach(() => {
         jest.spyOn(api, 'getAsync').mockResolvedValue({ data: '' });
+        jest.spyOn(api, 'postAsync').mockResolvedValue({ data: '' });
     });
 
     describe('loginAsync', () => {
@@ -29,4 +30,18 @@ describe('service/loginApi.js', () => {
         });
     });
 
+    describe('logoutAsync', () => {
+        const refreshToken = 'foobar';
+        beforeEach(async () => {
+            await loginApi.logoutAsync(refreshToken);
+        });
+
+        it('calls the logout endpoint', () => {
+            expect(api.postAsync).toHaveBeenCalledWith('/api/logout', expect.anything());
+        });
+
+        it('passes the refresh token', () => {
+            expect(api.postAsync).toHaveBeenCalledWith(expect.anything(), { refreshToken });
+        });
+    });
 });

--- a/td.vue/tests/unit/store/actions/auth.spec.js
+++ b/td.vue/tests/unit/store/actions/auth.spec.js
@@ -1,4 +1,4 @@
-import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL } from '@/store/actions/auth.js';
+import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL, LOGOUT } from '@/store/actions/auth.js';
 
 describe('store/actions/auth.js', () => {
     it('defines a clear action', () => {
@@ -11,5 +11,9 @@ describe('store/actions/auth.js', () => {
 
     it('defines a set local action', () => {
         expect(AUTH_SET_LOCAL).not.toBeUndefined();
+    });
+
+    it('defines a logout action', () => {
+        expect(LOGOUT).not.toBeUndefined();
     });
 });

--- a/td.vue/tests/unit/store/modules/auth.spec.js
+++ b/td.vue/tests/unit/store/modules/auth.spec.js
@@ -1,9 +1,14 @@
-import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL } from '@/store/actions/auth.js';
+import { AUTH_CLEAR, AUTH_SET_JWT, AUTH_SET_LOCAL, LOGOUT } from '@/store/actions/auth.js';
 import authModule, { clearState } from '@/store/modules/auth.js';
+import { BRANCH_CLEAR } from '@/store/actions/branch.js';
+import { PROVIDER_CLEAR } from '@/store/actions/provider.js';
+import { REPOSITORY_CLEAR } from '@/store/actions/repository.js';
+import { THREATMODEL_CLEAR } from '@/store/actions/threatmodel.js';
 
 describe('store/modules/auth.js', () => {
     const mocks = {
-        commit: () => {}
+        commit: () => {},
+        dispatch: () => {}
     };
     const jwtBody = { foo: 'bar', user: { username: 'whatever' }};
     const apiResp = {
@@ -13,6 +18,7 @@ describe('store/modules/auth.js', () => {
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
+        jest.spyOn(mocks, 'dispatch');
     });
 
     afterEach(() => {
@@ -56,7 +62,32 @@ describe('store/modules/auth.js', () => {
             authModule.actions[AUTH_SET_LOCAL](mocks);
             expect(mocks.commit).toHaveBeenCalledWith(AUTH_SET_LOCAL);
         });
+        
+        describe('logout', () => {
+            beforeEach(() => {
+                authModule.actions[LOGOUT](mocks);
+            });
 
+            it('dispatches the AUTH_CLEAR action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(AUTH_CLEAR);
+            });
+
+            it('dispatches the BRANCH_CLEAR action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(BRANCH_CLEAR);
+            });
+
+            it('dispatches the PROVIDER_CLEAR action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(PROVIDER_CLEAR);
+            });
+
+            it('dispatches the REPOSITORY_CLEAR action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(REPOSITORY_CLEAR);
+            });
+
+            it('dispatches the THREATMODEL_CLEAR action', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(THREATMODEL_CLEAR);
+            });
+        });
     });
 
     describe('mutations', () => {


### PR DESCRIPTION
**Summary**
Implementing Logout

**Description for the changelog**
Implements logout functionality

**Other info**
Because V2 is using JWT as opposed to sessions and cookie auth, the server implementation is a bit different.  In this case, our only knowledge of long-term user authentication is via refresh tokens (managed by JWTs, with a separate signing key from the main jwt signing key).  Refresh tokens can be used to re-generate a JWT after the JWT expires. Logout on the server only invalidates the refresh token, forcing the user to complete authentication again should they request a protected resource.

On the front-end, all states are cleared, and if not a local instance, the logout method is called on the server.  By clearing the states, we are clearing all meaningful data from the sessionStorage as well.  There is still a schema left behind in the session storage, but I see no security implications there as this is an open source product, and anyone can view the schema.