### PR TITLE
V2/smokes on prs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,6 +162,55 @@ jobs:
           path: td.vue/tests/e2e/videos
         if: ${{ always() }}
 
+
+  e2e_smokes:
+    runs-on: ubuntu-latest
+    needs: [build_docker_image]
+    defaults:
+      run:
+        working-directory: td.vue
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run Threat Dragon
+        run: |
+          docker run -d \
+            -p 3000:3000 \
+            -e GITHUB_CLIENT_ID='${{ secrets.CI_GITHUB_CLIENT_ID }}' \
+            -e GITHUB_CLIENT_SECRET='${{ secrets.CI_GITHUB_CLIENT_SECRET }}' \
+            -e ENCRYPTION_JWT_REFRESH_SIGNING_KEY='${{ secrets.CI_JWT_REFRESH_SIGNING_KEY }}' \
+            -e ENCRYPTION_JWT_SIGNING_KEY='${{ secrets.CI_JWT_SIGNING_KEY }}' \
+            -e ENCRYPTION_KEYS='${{ secrets.CI_SESSION_ENCRYPTION_KEYS }}' \
+            -e NODE_ENV='development' \
+            ${{ env.image_name }}
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Cache NPM dir
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-npm-cache-site-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-site-
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Run e2e tests
+        run: npm run test:e2e-ci-smokes
+
+      - name: Upload e2e videos
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e_vids.zip
+          path: td.vue/tests/e2e/videos
+        if: ${{ always() }}
+
   zap_scan_web:
     runs-on: ubuntu-latest
     needs: [build_docker_image]

--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -1,4 +1,3 @@
-- Run smoke tests on PRs
 - Empty state on list views
 -- List views should probably be a separate component to handle empty state
 -- Handle pagination

--- a/td.vue/cypress.smokes.ci.json
+++ b/td.vue/cypress.smokes.ci.json
@@ -1,0 +1,3 @@
+{
+  "pluginsFile": "tests/e2e/plugins/smokes.ci.js"
+}

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -8,6 +8,7 @@
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "test:e2e-ci": "vue-cli-service test:e2e --headless --url http://localhost:3000/",
+    "test:e2e-ci-smokes": "vue-cli-service test:e2e -C cypress.smokes.ci.json --headless --url http://localhost:3000/",
     "test:e2e-smokes": "browserstack-cypress run --cf browserstack.smokes.json --sync",
     "test:e2e-nightly": "browserstack-cypress run --cf browserstack.nightly.json --sync",
     "lint": "vue-cli-service lint",

--- a/td.vue/tests/e2e/plugins/smokes.ci.js
+++ b/td.vue/tests/e2e/plugins/smokes.ci.js
@@ -1,0 +1,10 @@
+module.exports = (on, config) => {
+    return Object.assign({}, config, {
+        fixturesFolder: 'tests/e2e/fixtures',
+        integrationFolder: 'tests/e2e/smokes',
+        screenshotsFolder: 'tests/e2e/screenshots',
+        videosFolder: 'tests/e2e/videos',
+        supportFile: 'tests/e2e/support/index.js',
+        baseUrl: 'http://localhost:3000/'
+    });
+};


### PR DESCRIPTION
**Summary**
Smoke tests should be run as part of the regular CI so that we know before deployment time if any tests are broken.

**Description for the changelog**
Smoke tests are now part of the CI process

**Other info**
 Rather than running smokes only on PRs, they should be run as part of the CI build. Earlier feedback is usually better. This can be run in parallel with the regular e2e tests and should be faster than them. This should not add any time to the build

