### PR TITLE
make return for diagram editor more obvious (issue #60)

### DIFF
--- a/td.site/src/app/core/diagrams/diagrameditor.html
+++ b/td.site/src/app/core/diagrams/diagrameditor.html
@@ -53,17 +53,14 @@
                     <form name="diagramEditToolBar">
                         <div class="col-md-12">
                             <div class="btn-group pull-left" role="group">
-                                <button type="button" class="btn btn-default" ng-model="vm.showGrid" uib-btn-checkbox ng-click="vm.setGrid()" data-toggle="tooltip" data-placement="top" title="Toggle Gridlines">
-                                        <span class="glyphicon glyphicon-th" aria-hidden="true"></span>
-                                </button>
-                                <a class="btn btn-default" ng-href="#/threatmodel/{{vm.getThreatModelPath()}}" role="button" data-toggle="tooltip" data-placement="top" title="Close Diagram">
-                                    <span class="glyphicon glyphicon-remove"></span>
-                                </a>
                                 <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.clear()" data-placement="top" title="Delete All Elements From This Diagram">
                                     <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                 </button>
                                 <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.reload()" data-placement="top" title="Discard Changes And Reopen Diagram">
                                     <span class="fa fa-undo" aria-hidden="true"></span>
+                                </button>
+                                <button type="button" class="btn btn-default" ng-model="vm.showGrid" uib-btn-checkbox ng-click="vm.setGrid()" data-toggle="tooltip" data-placement="top" title="Toggle Gridlines">
+                                        <span class="glyphicon glyphicon-th" aria-hidden="true"></span>
                                 </button>
                                 <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope || vm.selected.attributes.type == 'tm.Boundary'" type="button" data-toggle="tooltip" ng-click="vm.generateThreats(vm.diagram.diagramType)" data-placement="top" title="Suggest threats for the selected element">
                                     <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
@@ -71,9 +68,12 @@
                                 <button class="btn btn-default" ng-disabled="vm.selected == null" type="button" data-toggle="tooltip" ng-click="vm.duplicateElement()" data-placement="top" title="Duplicate the selected element">
                                     <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
                                 </button>
-                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save This Diagram">
+                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save Diagram">
                                     <span class="glyphicon glyphicon-save" aria-hidden="true"></span>
                                 </button>
+                                <a class="btn btn-default" ng-href="#/threatmodel/{{vm.getThreatModelPath()}}" role="button" data-toggle="tooltip" data-placement="top" title="Close and Return">
+                                    <span class="glyphicon glyphicon-arrow-left"></span>
+                                </a>
                             </div>
                         </div>
                     </form>

--- a/td.site/src/app/core/templates.js
+++ b/td.site/src/app/core/templates.js
@@ -152,17 +152,14 @@ angular.module('templates', [])
     '                    <form name="diagramEditToolBar">\n' +
     '                        <div class="col-md-12">\n' +
     '                            <div class="btn-group pull-left" role="group">\n' +
-    '                                <button type="button" class="btn btn-default" ng-model="vm.showGrid" uib-btn-checkbox ng-click="vm.setGrid()" data-toggle="tooltip" data-placement="top" title="Toggle Gridlines">\n' +
-    '                                        <span class="glyphicon glyphicon-th" aria-hidden="true"></span>\n' +
-    '                                </button>\n' +
-    '                                <a class="btn btn-default" ng-href="#/threatmodel/{{vm.getThreatModelPath()}}" role="button" data-toggle="tooltip" data-placement="top" title="Close Diagram">\n' +
-    '                                    <span class="glyphicon glyphicon-remove"></span>\n' +
-    '                                </a>\n' +
     '                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.clear()" data-placement="top" title="Delete All Elements From This Diagram">\n' +
     '                                    <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
     '                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.reload()" data-placement="top" title="Discard Changes And Reopen Diagram">\n' +
     '                                    <span class="fa fa-undo" aria-hidden="true"></span>\n' +
+    '                                </button>\n' +
+    '                                <button type="button" class="btn btn-default" ng-model="vm.showGrid" uib-btn-checkbox ng-click="vm.setGrid()" data-toggle="tooltip" data-placement="top" title="Toggle Gridlines">\n' +
+    '                                        <span class="glyphicon glyphicon-th" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
     '                                <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope || vm.selected.attributes.type == \'tm.Boundary\'" type="button" data-toggle="tooltip" ng-click="vm.generateThreats(vm.diagram.diagramType)" data-placement="top" title="Suggest threats for the selected element">\n' +
     '                                    <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>\n' +
@@ -170,9 +167,12 @@ angular.module('templates', [])
     '                                <button class="btn btn-default" ng-disabled="vm.selected == null" type="button" data-toggle="tooltip" ng-click="vm.duplicateElement()" data-placement="top" title="Duplicate the selected element">\n' +
     '                                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
-    '                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save This Diagram">\n' +
+    '                                <button class="btn btn-default" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save Diagram">\n' +
     '                                    <span class="glyphicon glyphicon-save" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
+    '                                <a class="btn btn-default" ng-href="#/threatmodel/{{vm.getThreatModelPath()}}" role="button" data-toggle="tooltip" data-placement="top" title="Close and Return">\n' +
+    '                                    <span class="glyphicon glyphicon-arrow-left"></span>\n' +
+    '                                </a>\n' +
     '                            </div>\n' +
     '                        </div>\n' +
     '                    </form>\n' +


### PR DESCRIPTION
**Summary**
Issue #60 asks that the button to return from the diagram editor is made more obvious
The image has been changed to arrow-left, and moved to be on the far right. The delete and reload buttons have been moved to far left so that they are disassociated from the save and return

**Description for the changelog**
make return for diagram editor more obvious

**Other info**
<img width="612" alt="move-return-button" src="https://user-images.githubusercontent.com/29352392/124350447-bdeb2080-dbec-11eb-9ea5-22fd93ed3437.png">

