### PR TITLE
make boundaries black, removing colour

### DIFF
--- a/td.site/src/app/core/services/joint.shapes.tm.js
+++ b/td.site/src/app/core/services/joint.shapes.tm.js
@@ -175,7 +175,7 @@ joint.shapes.tm.Boundary = joint.dia.Link.extend({
         type: 'tm.Boundary',
         size: { width: 10, height: 10 },
         attrs: {
-            '.connection': { stroke: 'green', 'stroke-width': 3, 'stroke-dasharray': '10,5' }
+            '.connection': { stroke: 'black', 'stroke-width': 3, 'stroke-dasharray': '10,5' }
         },
         smooth: true
     }, joint.dia.Link.prototype.defaults)


### PR DESCRIPTION
**Summary**
boundaries are now black, so that the only colour is for components with unmitigated threats

**Description for the changelog**
remove colour to make boundaries black

**Other info**
looks a lot better, and is better for red/green colour sightedness
<img width="684" alt="black-boundaries" src="https://user-images.githubusercontent.com/29352392/124517872-01a47c80-dddd-11eb-966e-ba7e015d2c89.png">

