### PR TITLE
Removing the green color from trust boundaries per #150

### DIFF
--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -19,7 +19,6 @@ const styles = {
         strokeDasharray: '2 2'
     },
     trustBoundary: {
-        color: 'green',
         strokeDasharray: '5 5',
         strokeWidth: 3
     },

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -18,7 +18,6 @@ export const TrustBoundaryBox = Shape.HeaderedRect.define({
             rx: 10,
             ry: 10,
             strokeDasharray: '5 5',
-            stroke: 'green',
             strokeWidth: 3,
             fill: '#777',
             fillOpacity: 0

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -25,7 +25,6 @@ export const TrustBoundaryCurve = Shape.Empty.define({
     ],
     attrs: {
         boundary: {
-            stroke: 'green',
             strokeWidth: 3,
             fill: '#ffffff',
             strokeDasharray: '5 5',
@@ -52,7 +51,6 @@ const getEdgeConfig = (position) => ({
     connector: 'smooth',
     attrs: {
         line: {
-            stroke: 'green',
             strokeWidth: 3,
             strokeDasharray: '5 5',
             sourceMarker: null,

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -106,11 +106,6 @@ describe('service/x6/graph/data-changed.js', () => {
             dataChanged.updateStyleAttrs(cell);
         });
 
-        it('sets the stroke', () => {
-            expect(cell.setAttrByPath)
-                .toHaveBeenCalledWith('line/stroke', 'green');
-        });
-
         it('sets the strokeDasharray', () => {
             expect(cell.setAttrByPath)
                 .toHaveBeenCalledWith('line/strokeDasharray', '5 5');

--- a/td.vue/tests/unit/service/x6/shapes/trust-boundary-curve.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/trust-boundary-curve.spec.js
@@ -31,10 +31,6 @@ describe('service/x6/shapes/trust-boundary-curve.js', () => {
             expect(config.connector).toEqual('smooth');
         });
 
-        it('sets the stroke color to green', () => {
-            expect(config.attrs.line.stroke).toEqual('green');
-        });
-
         it('sets the stroke dash array', () => {
             expect(config.attrs.line.strokeDasharray).toEqual('5 5');
         });


### PR DESCRIPTION
**Summary**
Removes the green color from trust boundaries, defaults to black.

**Description for the changelog**
Trust boundaries are black as seen in #150
