### PR TITLE
V2/machine trust boundaries title

### DIFF
--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -20,7 +20,6 @@ export const TrustBoundaryBox = Shape.HeaderedRect.define({
             strokeDasharray: '5 5',
             stroke: 'green',
             strokeWidth: 3,
-            fill: '#777',
             fillOpacity: 0
         },
         headerText: {
@@ -31,9 +30,8 @@ export const TrustBoundaryBox = Shape.HeaderedRect.define({
         header: {
             rx: 10,
             ry: 10,
-            fill: '#777',
-            fillOpacity: 0.2,
-            strokeWidth: 0
+            strokeWidth: 0,
+            fillOpacity: 0
         }
     }
 });

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -26,9 +26,9 @@ export const TrustBoundaryCurve = Shape.Empty.define({
     attrs: {
         boundary: {
             strokeWidth: 3,
+            stroke: '#333333',
             fill: '#ffffff',
             strokeDasharray: '5 5',
-            fillOpacity: 0,
             refD: 'M 30 20 C 70 20 70 100 110 100'
         },
         label: {


### PR DESCRIPTION
**Summary**
Removes the background color from the title of the machine / box trust boundary element

**Description for the changelog**
The machine / box style trust boundary has a title, and that title should have a transparent background per #54 
