### PR TITLE
return icon now left arrow not cross

### DIFF
--- a/td.site/package-lock.json
+++ b/td.site/package-lock.json
@@ -17,14 +17,14 @@
         "bootstrap": "3.4.1",
         "copyfiles": "^2.4.1",
         "font-awesome": "4.7.0",
-        "hotkeys-js": "^3.7.6",
+        "hotkeys-js": "^3.8.7",
         "jointjs": "^2.2.1",
         "jquery": "^3.4.1",
         "json-rules-engine": "3.1.0",
         "lodash": "^4.17.19",
         "pug": "^3.0.1",
-        "pug-bootstrap": "0.0.16",
-        "toastr": "2.1.4"
+        "pug-bootstrap": "^0.0.16",
+        "toastr": "^2.1.4"
       },
       "devDependencies": {
         "angular-mocks": "1.8.0",

--- a/td.site/package.json
+++ b/td.site/package.json
@@ -39,14 +39,14 @@
     "bootstrap": "3.4.1",
     "copyfiles": "^2.4.1",
     "font-awesome": "4.7.0",
-    "hotkeys-js": "^3.7.6",
+    "hotkeys-js": "^3.8.7",
     "jointjs": "^2.2.1",
     "jquery": "^3.4.1",
     "json-rules-engine": "3.1.0",
     "lodash": "^4.17.19",
     "pug": "^3.0.1",
-    "pug-bootstrap": "0.0.16",
-    "toastr": "2.1.4"
+    "pug-bootstrap": "^0.0.16",
+    "toastr": "^2.1.4"
   },
   "devDependencies": {
     "angular-mocks": "1.8.0",

--- a/td.site/src/app/core/templates.js
+++ b/td.site/src/app/core/templates.js
@@ -850,7 +850,7 @@ angular.module('templates', [])
     '                <span class="glyphicon glyphicon-print"></span> Print\n' +
     '            </button>\n' +
     '            <button class="btn btn-primary" id="cancelButton" role="button" ng-click="cancel()" data-toggle="tooltip" data-placement="top" title="Return To Detail View">\n' +
-    '                <span class="glyphicon glyphicon-remove"></span> Return\n' +
+    '                <span class="glyphicon glyphicon-arrow-left"></span> Return\n' +
     '            </button>\n' +
     '        </div>\n' +
     '    </div>\n' +
@@ -974,7 +974,7 @@ angular.module('templates', [])
     '                    <span class="glyphicon glyphicon-print"></span> Print\n' +
     '                </button>\n' +
     '                <button class="btn btn-primary" id="cancelButton" role="button" ng-click="cancel()" data-toggle="tooltip" data-placement="top" title="Return To Detail View">\n' +
-    '                    <span class="glyphicon glyphicon-remove"></span> Return\n' +
+    '                    <span class="glyphicon glyphicon-arrow-left"></span> Return\n' +
     '                </button>\n' +
     '            </div>\n' +
     '        </div>\n' +

--- a/td.site/src/app/core/threatmodels/threatmodelreport.html
+++ b/td.site/src/app/core/threatmodels/threatmodelreport.html
@@ -19,7 +19,7 @@
                 <span class="glyphicon glyphicon-print"></span> Print
             </button>
             <button class="btn btn-primary" id="cancelButton" role="button" ng-click="cancel()" data-toggle="tooltip" data-placement="top" title="Return To Detail View">
-                <span class="glyphicon glyphicon-remove"></span> Return
+                <span class="glyphicon glyphicon-arrow-left"></span> Return
             </button>
         </div>
     </div>
@@ -143,7 +143,7 @@
                     <span class="glyphicon glyphicon-print"></span> Print
                 </button>
                 <button class="btn btn-primary" id="cancelButton" role="button" ng-click="cancel()" data-toggle="tooltip" data-placement="top" title="Return To Detail View">
-                    <span class="glyphicon glyphicon-remove"></span> Return
+                    <span class="glyphicon glyphicon-arrow-left"></span> Return
                 </button>
             </div>
         </div>


### PR DESCRIPTION
**Summary**
It seemed odd to have the  'cross' icon for when we return from an action. This was changed for the diagram view to a left arrow, and this pull request changes the 'Return' button on the report view to have a left-arrow as well

**Description for the changelog**
return icon now left arrow not cross

**Other info**
<!--
Thanks for submitting a pull request!
Please make sure you read our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
