### PR TITLE
replaced the old repo link with the new repo link

### DIFF
--- a/td.desktop/app/layout/shell.js
+++ b/td.desktop/app/layout/shell.js
@@ -221,19 +221,19 @@ function shell($rootScope, $scope, $location, $route, common, datacontext, elect
                     {
                         label: 'Visit us on GitHub',
                         click: function() {
-                            electron.shell.openExternal('https://github.com/owasp/threat-dragon-desktop/');
+                            electron.shell.openExternal('https://github.com/owasp/threat-dragon/');
                         }
                     },
                     {
                         label: 'Submit an Issue',
                         click: function() {
-                            electron.shell.openExternal('https://github.com/owasp/threat-dragon-desktop/issues/new/choose/');
+                            electron.shell.openExternal('https://github.com/owasp/threat-dragon/issues/new/choose/');
                         }
                     },
                     {
                         label: 'Check for updates ...',
                         click: function() {
-                            electron.shell.openExternal('https://github.com/OWASP/threat-dragon-desktop/releases/');
+                            electron.shell.openExternal('https://github.com/OWASP/threat-dragon/releases/');
                         }
                     },
                     {

--- a/td.desktop/installer-win.js
+++ b/td.desktop/installer-win.js
@@ -13,7 +13,7 @@ var options = {
   iconUrl: 'https://raw.githubusercontent.com/owasp/threat-dragon/main/td.desktop/public/content/icons/win/td.ico',
   setupIcon: path.join(rootPath, 'content', 'icons', 'win', 'td.ico'),
   description: 'An open source threat modelling tool from OWASP',
-  remoteReleases: "https://github.com/owasp/threat-dragon-desktop"
+  remoteReleases: "https://github.com/OWASP/threat-dragon"
 };
 
 var rl = readline.createInterface({

--- a/td.desktop/test/spec/layout/shell_spec.js
+++ b/td.desktop/test/spec/layout/shell_spec.js
@@ -508,7 +508,7 @@ describe('shell controller', function () {
         expect(subMenu.submenu[4].label).toEqual('Visit us on GitHub');
         spyOn(mockElectron.shell, 'openExternal');
         subMenu.submenu[4].click();
-        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon-desktop/']); 
+        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon/']); 
     });
 
     it('Help menu item should browse to the GitHub issues page', function() {
@@ -517,7 +517,7 @@ describe('shell controller', function () {
         expect(subMenu.submenu[5].label).toEqual('Submit an Issue');
         spyOn(mockElectron.shell, 'openExternal');
         subMenu.submenu[5].click();
-        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon-desktop/issues/new/choose/']); 
+        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon/issues/new/choose/']); 
     });
 
     it('Help menu item should browse to check for updates', function() {
@@ -526,7 +526,7 @@ describe('shell controller', function () {
         expect(subMenu.submenu[6].label).toEqual('Check for updates ...');
         spyOn(mockElectron.shell, 'openExternal');
         subMenu.submenu[6].click();
-        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/OWASP/threat-dragon-desktop/releases/']); 
+        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/OWASP/threat-dragon/releases/']); 
     });
 
     it('Help menu seventh item should be a separator', function() {


### PR DESCRIPTION
**Summary**

Replaced the old repo link with the new repo link

**Description for the changelog**

It replaces the old GitHub repo link with the new GitHub repo link.
It does not replace GitHub links when they get broken by replacing.

**Other info**

Describe the bug
https://github.com/OWASP/threat-dragon-desktop is still used.

Expected behaviour
Users should visit https://github.com/OWASP/threat-dragon

To Reproduce
Go to "Help" in Main menu and click "Check for update", and it takes users to the old repo.


