### PR TITLE
Updating e2e tests

### DIFF
--- a/td.vue/tests/e2e/smokes/home.js
+++ b/td.vue/tests/e2e/smokes/home.js
@@ -12,7 +12,7 @@ describe('home', () => {
     });
 
     it('shows the threat dragon logo', () => {
-        cy.get('#home-td-logo').should('be', 'visible');
+        cy.get('#home-td-logo').should('be.visible');
     });
 
     it('displays the login options', () => {

--- a/td.vue/tests/e2e/specs/home.js
+++ b/td.vue/tests/e2e/specs/home.js
@@ -12,7 +12,7 @@ describe('home', () => {
     });
 
     it('shows the threat dragon logo', () => {
-        cy.get('#home-td-logo').should('be', 'visible');
+        cy.get('#home-td-logo').should('be.visible');
     });
 
     it('displays the login options', () => {

--- a/td.vue/tests/e2e/specs/logout.js
+++ b/td.vue/tests/e2e/specs/logout.js
@@ -7,7 +7,7 @@ describe('logout', () => {
     });
 
     it('does not show the logged in text', () => {
-        cy.get('.logged-in-as').should('not.be', 'visible');
+        cy.get('.logged-in-as').should('not.be.visible');
     });
 
     it('should redirect to the home page', () => {


### PR DESCRIPTION
**Summary**
It seems as though browserstack/cypress is failing on some syntax.  This is just a test to see if it will pass the e2e smoke test automation.