### PR TITLE
V2/diagram UI

### DIFF
--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -1,18 +1,6 @@
 <template>
   <div>
     <b-row>
-      <b-col>
-        <p>
-          Keyboard shortcuts: <b-badge>ctrl+c</b-badge> copy |
-          <b-badge>ctrl+v</b-badge> paste | <b-badge>ctrl+z</b-badge> undo |
-          <b-badge>ctrl+y</b-badge> redo | <b-badge>del</b-badge> delete |
-          <b-badge>shift+left-click</b-badge> pan(drag) |
-          <b-badge>click/drag</b-badge> on empty space for multi-select
-          | <b-badge>ctrl+mousewheel</b-badge> zoom
-        </p>
-      </b-col>
-    </b-row>
-    <b-row>
       <b-col md="2">
         <div ref="stencil_container"></div>
       </b-col>
@@ -27,6 +15,7 @@
                 text="Save"
               />
               <td-form-button :onBtnClick="noOp" icon="times" text="Close" />
+              <td-form-button :onBtnClick="noOp" v-b-modal.shortcuts  icon="keyboard" text="" />
               <td-form-button :onBtnClick="undo" icon="undo" text="" />
               <td-form-button :onBtnClick="redo" icon="redo" text="" />
               <td-form-button :onBtnClick="zoomIn" icon="search-plus" text="" />
@@ -55,11 +44,17 @@
         </b-row>
       </b-col>
       <b-col md="2">
-        <b-card header="Actions">
-            <b-button variant="primary" @click="testClick">Test Data Changed</b-button>
+        <b-card header="Properties">
+            TODO
         </b-card>
       </b-col>
     </b-row>
+
+    <div>
+        <b-modal id="shortcuts" size="lg" ok-variant="primary" ok-only title="Shortcuts">
+            <b-table :items="shortcuts"></b-table>
+        </b-modal>
+    </div>
   </div>
 </template>
 
@@ -81,7 +76,6 @@ import TdFormButton from '@/components/FormButton.vue';
         - Create component for entity actions
         - Edit labels inline, or keep in separate pane, or both?
         - Edit multiple threats at once
-    - Add help section for keyboard shortcuts and/or actions you can do
     - Add vertical scroll bar by default (if needed?)
     - "Link from here" - auto-linking of elements (needed or not?)
     - UI component for encryption (WIP, needs feedback https://github.com/OWASP/threat-dragon/issues/150)
@@ -111,7 +105,17 @@ export default {
     data() {
         return {
             graph: null,
-            gridShowing: true
+            gridShowing: true,
+            shortcuts: [
+                { shortcut: 'ctrl + c', action: 'Copy' },
+                { shortcut: 'ctrl + v', action: 'Paste' },
+                { shortcut: 'ctrl + z', action: 'Undo' },
+                { shortcut: 'ctrl + y', action: 'Redo' },
+                { shortcut: 'del', action: 'Delete' },
+                { shortcut: 'shift + left-click (hold/drag)', action: 'Pan' },
+                { shortcut: 'left-click on empty space and drag', action: 'Multi-select' },
+                { shortcut: 'ctrl + mousewheel', action: 'Zoom' }
+            ]
         };
     },
     async mounted() {
@@ -167,25 +171,6 @@ export default {
             this.graph.stopBatch(batchName);
 
             this.graph.centerContent();
-        },
-        testClick() {
-            // This same event works for edges as well
-            // The constructor name is going to be "edge",
-            // so instead of using that, we will likely need to
-            // add to add a data prop for trust boundary during
-            // initialization
-            const cells = this.graph.getSelectedCells();
-            if (!cells || cells.length === 0) {
-                console.log('No cells selected');
-                return;
-            }
-            cells.forEach((cell) => {
-                // Consider options:silent to prevent canvas redraw,
-                // Manaually trigger that after we are done updating the data
-                // Alternatively, do it in a batch:
-                // https://x6.antv.vision/en/docs/api/graph/graph#batchupdate
-                cell.replaceData({ hasOpenThreats: false });
-            });
         }
     },
 };

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -107,14 +107,14 @@ export default {
             graph: null,
             gridShowing: true,
             shortcuts: [
-                { shortcut: 'ctrl + c', action: 'Copy' },
-                { shortcut: 'ctrl + v', action: 'Paste' },
-                { shortcut: 'ctrl + z', action: 'Undo' },
-                { shortcut: 'ctrl + y', action: 'Redo' },
+                { shortcut: '(ctrl/cmd) + c', action: 'Copy' },
+                { shortcut: '(ctrl/cmd) + v', action: 'Paste' },
+                { shortcut: '(ctrl/cmd) + z', action: 'Undo' },
+                { shortcut: '(ctrl/cmd) + y', action: 'Redo' },
                 { shortcut: 'del', action: 'Delete' },
                 { shortcut: 'shift + left-click (hold/drag)', action: 'Pan' },
                 { shortcut: 'left-click on empty space and drag', action: 'Multi-select' },
-                { shortcut: 'ctrl + mousewheel', action: 'Zoom' }
+                { shortcut: '(ctrl/cmd) + mousewheel', action: 'Zoom' }
             ]
         };
     },

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -82,9 +82,9 @@ import TdFormButton from '@/components/FormButton.vue';
         - Edit labels inline, or keep in separate pane, or both?
         - Edit multiple threats at once
     - Add help section for keyboard shortcuts and/or actions you can do
-    - Add vertical scroll bar by default (if needed?)W
+    - Add vertical scroll bar by default (if needed?)
     - "Link from here" - auto-linking of elements (needed or not?)
-    - UI component for encryption (WIP, needs feedback)
+    - UI component for encryption (WIP, needs feedback https://github.com/OWASP/threat-dragon/issues/150)
     - Tooltips for graph buttons
     - Enable / Disable buttons based on state
     - Add threat suggestion button
@@ -97,9 +97,7 @@ import TdFormButton from '@/components/FormButton.vue';
     - Export JSON
     - Export images
     - Fix CSP
-    - Load model from API if not local provider
     - Write unit tests for this component
-    - If v2, load from json
 */
 
 export default {
@@ -117,7 +115,6 @@ export default {
         };
     },
     async mounted() {
-        // TODO: Load model from API if not local provider
         this.init();
         this.drawDiagramV1();
     },

--- a/td.vue/src/plugins/fontawesome-vue.js
+++ b/td.vue/src/plugins/fontawesome-vue.js
@@ -18,7 +18,8 @@ import {
     faSearchPlus,
     faSearchMinus,
     faTrash,
-    faTh
+    faTh,
+    faKeyboard
 } from '@fortawesome/free-solid-svg-icons';
 
 import { faGithub, faVuejs } from '@fortawesome/free-brands-svg-icons';
@@ -41,7 +42,8 @@ library.add(
     faSearchPlus,
     faSearchMinus,
     faTrash,
-    faTh
+    faTh,
+    faKeyboard
 );
 
 Vue.component('font-awesome-icon', FontAwesomeIcon);

--- a/td.vue/src/styles/bootstrap.scss
+++ b/td.vue/src/styles/bootstrap.scss
@@ -12,5 +12,8 @@ $font-family-base: "Ubuntu", Tahoma, "Helvetica Neue", Helvetica, Arial, sans-se
     color: $white !important;
 }
 
+.modal-backdrop {
+    opacity: .5;
+}
 
 @import '~bootstrap/scss/bootstrap';

--- a/td.vue/src/views/Diagram.vue
+++ b/td.vue/src/views/Diagram.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mt-5">
         <b-row>
-            <b-col class="text-center"><h2>Graph Test</h2></b-col>
+            <b-col class="text-center"><h2>{{ diagram.title }}</h2></b-col>
         </b-row>
         <b-row>
             <b-col>
@@ -12,13 +12,17 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import TdGraph from '@/components/Graph.vue';
 
 export default {
     name: 'Diagram',
     components: {
         TdGraph
-    }
+    },
+    computed: mapState({
+        diagram: (state) => state.threatmodel.selectedDiagram
+    })
 };
 
 </script>


### PR DESCRIPTION
**Summary**
Moving the temporary keyboard shortcuts listing on the graph page to a more production-ready location

**Description for the changelog**
Added a button on the graph ui to open a modal showing all shortcuts

**Other info**
Because the shortcuts include things you can do with the mouse, I intentionally named it "shortcuts" as opposed to keyboard shortcuts.  I think using the word "actions" may be confusing, because a user might think that an action has to do with the threat model.

The proposed implementation:
Button:
![Screenshot from 2021-08-03 22-22-57](https://user-images.githubusercontent.com/5851985/128112039-6e15db3e-9744-4e9d-a2f6-591388ff3cb1.png)

Modal:
![Screenshot from 2021-08-03 22-23-04](https://user-images.githubusercontent.com/5851985/128112055-387b453e-9a77-4d00-8c22-f716e823a238.png)
