### PR TITLE
Remove unnecessary `git init` step from Installing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The application comes in two variants:
 
 1. [**A web application (this repo)**](https://github.com/owasp/threat-dragon):
 For the web application, models files are stored in GitHub (other storage will become available).
-We are currently maintaining [a working protoype](https://threatdragon.org) in synch with the master code branch.
+We are currently maintaining [a working protoype](https://threatdragon.org) in sync with the main code branch.
 
 2. [**A desktop application**](https://github.com/OWASP/threat-dragon/tree/main/td.desktop):
 This is based on [Electron](https://electron.atom.io/).
@@ -39,11 +39,10 @@ To build and run locally follow these steps:
 Install git and node.js - which includes the node package manager npm.
 To get the code, navigate to where you want your code to be located and do
 
-- `git init`
 - `git clone --recursive https://github.com/owasp/threat-dragon.git`
 
-This installs code in two sub-folders.
-One for the back-end application (`td.server`) and one for the front-end (`td.site`).
+This downloads the code into a directory called `threat-dragon` and contains the application code in two sub-folders,
+one for the back-end application (`td.server`) and one for the front-end (`td.site`).
 
 To install, run: `npm install` from the root of the project.  A `postinstall` script is run that will install dependencies in both the `server` and `site` directories as well.
 


### PR DESCRIPTION
This commit removes the `git init` step, which is unnecessary and potentially
dangerous if done in, e.g., a user's Documents directory.

It also updates the documentation to tell the user where the clone will go.

(It also fixes a typo in the description of the web application.)

**Summary**
This updates the installation instructions so that users don't end up
running `git init` somewhere they don't want to.  If they did so, it
turns the current directory into a git repository.

**Description for the changelog**
Remove unnecessary `git init` step from Installing section