### PR TITLE
bugfix: sort out globstars for cross-platform, fixes #267

### DIFF
--- a/td.desktop/package.json
+++ b/td.desktop/package.json
@@ -12,7 +12,7 @@
     "build": "npm-run-all pretest build:fonts build:css build:models build:templates",
     "build:css": "./node_modules/.bin/rework-npm ./content/app.css -o ./content/threatdragon.css",
     "build:fonts": "./node_modules/.bin/copyfiles -f ./node_modules/font-awesome/fonts/*.* ./node_modules/bootstrap/dist/fonts/*.* ./fonts",
-    "build:models": "./node_modules/.bin/copyfiles --error --up 2 '../ThreatDragonModels/**/*' ./ThreatDragonModels/",
+    "build:models": "./node_modules/.bin/copyfiles --error --up 2 ../ThreatDragonModels/new-model/*.* ../ThreatDragonModels/demo-threat-model/*.* ./ThreatDragonModels/",
     "build:win": "electron-builder build --win",
     "build:osx": "electron-builder build --macos",
     "build:lin": "electron-builder build --linux",


### PR DESCRIPTION
**Summary**
The threat model files were not being copied across for td.desktop when invoking `npm run build:models` under Windows

**Description for the changelog**
sort out globstars for cross-platform

**Other info**
The fix has to be cross platform, and had to be written out explicitly (no **) so that it would work for both MacOS and Windows. Linux is well-behaved with either way of doing it, of course
