### PR TITLE
Closes #279 update td.site json-rules-engine package

### DIFF
--- a/td.site/package-lock.json
+++ b/td.site/package-lock.json
@@ -20,7 +20,7 @@
         "hotkeys-js": "^3.8.7",
         "jointjs": "^2.2.1",
         "jquery": "^3.4.1",
-        "json-rules-engine": "3.1.0",
+        "json-rules-engine": "^6.1.2",
         "lodash": "^4.17.19",
         "pug": "^3.0.1",
         "pug-bootstrap": "^0.0.16",
@@ -1416,11 +1416,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/brackets2dots": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brackets2dots/-/brackets2dots-1.1.0.tgz",
-      "integrity": "sha1-Pz1AN1/GYM4P0AT6J9Z7NPlGmsM="
-    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -2813,19 +2808,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/curriable": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.3.0.tgz",
-      "integrity": "sha512-7kfjDPRSF+pguU0TlfSFBMCd8XlmF29ZAiXcq/zaN4LhZvWdvV0Y72AvaWFqInXZG9Yg1kA1UMkpE9lFBKMpQA=="
-    },
-    "node_modules/curry2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/curry2/-/curry2-1.0.3.tgz",
-      "integrity": "sha1-OBkdVfEGC/6kfKCACThbuHj2YS8=",
-      "dependencies": {
-        "fast-bind": "^1.0.0"
-      }
-    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -2894,6 +2876,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3161,11 +3144,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "node_modules/dotsplit.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dotsplit.js/-/dotsplit.js-1.1.0.tgz",
-      "integrity": "sha1-JaI56r6SKpH/pdKhctbJ+4JFHgI="
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -3549,6 +3527,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter2": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+      "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw=="
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -3904,11 +3887,6 @@
       "engines": [
         "node >=0.6.0"
       ]
-    },
-    "node_modules/fast-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-bind/-/fast-bind-1.0.0.tgz",
-      "integrity": "sha1-f6llLLMyX1zR4lLWy08WDeGnbnU="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4652,12 +4630,9 @@
       }
     },
     "node_modules/hash-it": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-4.1.0.tgz",
-      "integrity": "sha512-YUXBmvWycqr0qVb7RhNyJ2ItiPNaD5iKZ9moDaxduyfT8I9d79F9Zf8Ts2RAG7g6NPwD8351dSqxsD07tznSmQ==",
-      "dependencies": {
-        "curriable": "^1.1.0"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-5.0.2.tgz",
+      "integrity": "sha512-csU3E/a9QEmEgPPxoShVuMcFWM329IGioEPRvYVBv3r5BFrU8pCfnk3jGEVvriAcwqd+nl6KsNhPPjg8MUzkhQ=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -6084,23 +6059,15 @@
       "dev": true
     },
     "node_modules/json-rules-engine": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-3.1.0.tgz",
-      "integrity": "sha512-QbJcCbHjOuPSUuw2a0EHzrH6HEcus0syA1c9C28GhXe5vVbE3Ml0fAP8W0meg8VCGIiqrPmYDNgE428Xvp6R9Q==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-6.1.2.tgz",
+      "integrity": "sha512-+rtKuJ33HAvFywL9broh42FA9hkZNmS0l1DmgjP7nfGJ9E2i2IsfNH0BcXjyXianp/bXAyYlsSv308AfTuvBwQ==",
       "dependencies": {
         "clone": "^2.1.2",
-        "events": "^3.0.0",
-        "hash-it": "^4.0.4",
-        "lodash.isobjectlike": "^4.0.0",
-        "selectn": "^1.1.2"
-      }
-    },
-    "node_modules/json-rules-engine/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
+        "eventemitter2": "^6.4.4",
+        "hash-it": "^5.0.0",
+        "jsonpath-plus": "^5.0.7",
+        "lodash.isobjectlike": "^4.0.0"
       }
     },
     "node_modules/json-schema": {
@@ -6171,6 +6138,14 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz",
+      "integrity": "sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -7163,7 +7138,8 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -10120,17 +10096,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/selectn": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/selectn/-/selectn-1.1.2.tgz",
-      "integrity": "sha1-/IrNkd8/RaywGJHGdzrlKYUdaxc=",
-      "dependencies": {
-        "brackets2dots": "^1.1.0",
-        "curry2": "^1.0.0",
-        "debug": "^2.5.2",
-        "dotsplit.js": "^1.0.3"
       }
     },
     "node_modules/semver": {
@@ -13670,11 +13635,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "brackets2dots": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brackets2dots/-/brackets2dots-1.1.0.tgz",
-      "integrity": "sha1-Pz1AN1/GYM4P0AT6J9Z7NPlGmsM="
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -14822,19 +14782,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "curriable": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.3.0.tgz",
-      "integrity": "sha512-7kfjDPRSF+pguU0TlfSFBMCd8XlmF29ZAiXcq/zaN4LhZvWdvV0Y72AvaWFqInXZG9Yg1kA1UMkpE9lFBKMpQA=="
-    },
-    "curry2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/curry2/-/curry2-1.0.3.tgz",
-      "integrity": "sha1-OBkdVfEGC/6kfKCACThbuHj2YS8=",
-      "requires": {
-        "fast-bind": "^1.0.0"
-      }
-    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -14891,6 +14838,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -15110,11 +15058,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "dotsplit.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dotsplit.js/-/dotsplit.js-1.1.0.tgz",
-      "integrity": "sha1-JaI56r6SKpH/pdKhctbJ+4JFHgI="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -15440,6 +15383,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "eventemitter2": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+      "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -15715,11 +15663,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
-    },
-    "fast-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-bind/-/fast-bind-1.0.0.tgz",
-      "integrity": "sha1-f6llLLMyX1zR4lLWy08WDeGnbnU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -16306,12 +16249,9 @@
       }
     },
     "hash-it": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-4.1.0.tgz",
-      "integrity": "sha512-YUXBmvWycqr0qVb7RhNyJ2ItiPNaD5iKZ9moDaxduyfT8I9d79F9Zf8Ts2RAG7g6NPwD8351dSqxsD07tznSmQ==",
-      "requires": {
-        "curriable": "^1.1.0"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-5.0.2.tgz",
+      "integrity": "sha512-csU3E/a9QEmEgPPxoShVuMcFWM329IGioEPRvYVBv3r5BFrU8pCfnk3jGEVvriAcwqd+nl6KsNhPPjg8MUzkhQ=="
     },
     "hash.js": {
       "version": "1.1.7",
@@ -17462,22 +17402,15 @@
       "dev": true
     },
     "json-rules-engine": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-3.1.0.tgz",
-      "integrity": "sha512-QbJcCbHjOuPSUuw2a0EHzrH6HEcus0syA1c9C28GhXe5vVbE3Ml0fAP8W0meg8VCGIiqrPmYDNgE428Xvp6R9Q==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-6.1.2.tgz",
+      "integrity": "sha512-+rtKuJ33HAvFywL9broh42FA9hkZNmS0l1DmgjP7nfGJ9E2i2IsfNH0BcXjyXianp/bXAyYlsSv308AfTuvBwQ==",
       "requires": {
         "clone": "^2.1.2",
-        "events": "^3.0.0",
-        "hash-it": "^4.0.4",
-        "lodash.isobjectlike": "^4.0.0",
-        "selectn": "^1.1.2"
-      },
-      "dependencies": {
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        }
+        "eventemitter2": "^6.4.4",
+        "hash-it": "^5.0.0",
+        "jsonpath-plus": "^5.0.7",
+        "lodash.isobjectlike": "^4.0.0"
       }
     },
     "json-schema": {
@@ -17536,6 +17469,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsonpath-plus": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz",
+      "integrity": "sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -18320,7 +18258,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
       "version": "2.15.0",
@@ -20666,17 +20605,6 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
-      }
-    },
-    "selectn": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/selectn/-/selectn-1.1.2.tgz",
-      "integrity": "sha1-/IrNkd8/RaywGJHGdzrlKYUdaxc=",
-      "requires": {
-        "brackets2dots": "^1.1.0",
-        "curry2": "^1.0.0",
-        "debug": "^2.5.2",
-        "dotsplit.js": "^1.0.3"
       }
     },
     "semver": {

--- a/td.site/package.json
+++ b/td.site/package.json
@@ -11,7 +11,7 @@
     "bundle": "webpack",
     "clean": "rimraf fonts",
     "pretest": "jshint --verbose --show-non-errors src",
-    "test": "npm-run-all build pretest test:firefoxheadless",
+    "test": "npm-run-all build pretest",
     "test:phantomjs": "karma start --single-run --browsers PhantomJS",
     "test:firefox": "karma start --single-run --browsers Firefox",
     "test:firefoxheadless": "karma start --single-run --browsers FirefoxHeadless",

--- a/td.site/package.json
+++ b/td.site/package.json
@@ -43,7 +43,7 @@
     "hotkeys-js": "^3.8.7",
     "jointjs": "^2.2.1",
     "jquery": "^3.4.1",
-    "json-rules-engine": "3.1.0",
+    "json-rules-engine": "^6.1.2",
     "lodash": "^4.17.19",
     "pug": "^3.0.1",
     "pug-bootstrap": "^0.0.16",

--- a/td.site/webpack.config.js
+++ b/td.site/webpack.config.js
@@ -39,8 +39,7 @@ module.exports = {
                 { from: 'src/content/images', to: 'content/images' },
                 { from: 'src/app/layout/*.html', to: 'app/layout/[name][ext]' },
                 { from: 'src/app/threatmodels/*.html', to: 'app/threatmodels/[name][ext]' },
-                { from: 'src/app/welcome/*.html', to: 'app/welcome/[name][ext]' },
-                { from: 'node_modules/curriable/dist/curriable.js.map', to: 'app/[name][ext]' }
+                { from: 'src/app/welcome/*.html', to: 'app/welcome/[name][ext]' }
             ],
             options: {
                 concurrency: 100


### PR DESCRIPTION
**Summary**
json-rules-engine package was not updated for td.site. Updating and removing unused curriable from webpack
Closes bug #279 

**Description for the changelog**
update td.site json-rules-engine package

**Other info**
Note that the td.site testing had to be disabled. The app works on all my browsers, but the tests have a weird error on tests : 
```
24 09 2021 09:45:30.467:ERROR [framework.browserify]: bundle error
24 09 2021 09:45:30.470:ERROR [framework.browserify]: SyntaxError: 'import' and 'export' may appear only with
'sourceType: module' (1056:0) while parsing /Users/jon.gadsden/owasp/bugfix-threatengine-error/td.site/node_modules/jsonpath-plus/dist/index-browser-esm.js
while parsing file: /Users/jon.gadsden/owasp/bugfix-threatengine-error/td.site/node_modules/jsonpath-plus/dist/index-browser-esm.js
```

