### PR TITLE
Enable td.site Tests 

### DIFF
--- a/td.site/karma.conf.js
+++ b/td.site/karma.conf.js
@@ -14,11 +14,11 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      { pattern: 'node_modules/babel-polyfill/browser.js', instrument: false},
-      'src/app/app.js',
-      'node_modules/angular-mocks/angular-mocks.js',
-      'test/**/*.js',
-      'src/app/**/*.html'
+        'node_modules/angular/angular.min.js',
+        'node_modules/angular-mocks/angular-mocks.js',
+        '../dist/app/threatdragon.min.js',
+        'test/**/*.js',
+        'src/app/**/*.html'
     ],
 
     // list of files to exclude

--- a/td.site/package.json
+++ b/td.site/package.json
@@ -11,7 +11,7 @@
     "bundle": "webpack",
     "clean": "rimraf fonts",
     "pretest": "jshint --verbose --show-non-errors src",
-    "test": "npm-run-all build pretest",
+    "test": "npm-run-all build pretest test:firefoxheadless",
     "test:phantomjs": "karma start --single-run --browsers PhantomJS",
     "test:firefox": "karma start --single-run --browsers Firefox",
     "test:firefoxheadless": "karma start --single-run --browsers FirefoxHeadless",


### PR DESCRIPTION
**Summary**
Enables td.site tests

**Description for the changelog**
Re-enabling td.site tests.  For td.site, please only use `npm run test` moving forward, or you may not be testing the most up-to-date code

**Other info**
Discussion on implementation in #281 
