### PR TITLE
v2/Demo Threat Models

### DIFF
--- a/.github/workflows/.zap-rules-web.tsv
+++ b/.github/workflows/.zap-rules-web.tsv
@@ -2,7 +2,7 @@
 10110	OUTOFSCOPE	.*graph-test.*\.js
 10099	OUTOFSCOPE	.*vendor.*\.js
 10099	OUTOFSCOPE	.*diagram-edit.*\.js
-10099   OUTOFSCOPE  .*app.*\.js
+10099	OUTOFSCOPE	.*app.*\.js
 10110	OUTOFSCOPE	.*diagram-edit.*\.js
 10055	IGNORE	(CSP: style-src unsafe-inline)
 10063	IGNORE	(Feature Policy Header Not Set)

--- a/.github/workflows/.zap-rules-web.tsv
+++ b/.github/workflows/.zap-rules-web.tsv
@@ -2,6 +2,7 @@
 10110	OUTOFSCOPE	.*graph-test.*\.js
 10099	OUTOFSCOPE	.*vendor.*\.js
 10099	OUTOFSCOPE	.*diagram-edit.*\.js
+10099   OUTOFSCOPE  .*app.*\.js
 10110	OUTOFSCOPE	.*diagram-edit.*\.js
 10055	IGNORE	(CSP: style-src unsafe-inline)
 10063	IGNORE	(Feature Policy Header Not Set)

--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -18,4 +18,4 @@
 - Legend for diagram
 
 BUGS:
-    - Ocassional bug decoding json on login using github
+    - Ocassional bug decoding json on login using github: DOMException: String contains an invalid character

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -78,10 +78,8 @@ import stencil from '@/service/x6/stencil.js';
 import TdFormButton from '@/components/FormButton.vue';
 /*
   UI TODOs:
-    - Add ability to change labels and other metadata
-        - Edit multiple threats at once
+    - Edit multiple threats at once (nice to have)
     - Add vertical scroll bar by default (if needed?)
-    - "Link from here" - auto-linking of elements (needed or not?)
     - UI component for encryption (WIP, needs feedback https://github.com/OWASP/threat-dragon/issues/150)
     - Tooltips for graph buttons
     - Enable / Disable buttons based on state

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -25,8 +25,11 @@ const en = {
         actions: {
             openExisting: 'Open an existing threat model',
             createNew: 'Create a completely new, empty threat model',
-            download: 'Download and explore a sample threat model'
+            demo: 'Explore a sample threat model'
         }
+    },
+    demo: {
+        select: 'Select a demo threat model from the list below'
     },
     repository: {
         select: 'Select a',

--- a/td.vue/src/router/index.js
+++ b/td.vue/src/router/index.js
@@ -23,6 +23,11 @@ const routes = [
         name: 'OAuthReturn',
         component: () => import(/* webpackChunkName: "oauth-return" */ '../views/OauthReturn.vue')
     },
+    {
+        path: '/demo/select',
+        name: 'DemoSelect',
+        component: () => import(/* webpackChunkName: "demo-select" */ '../views/demo/SelectDemoModel.vue')
+    },
     ...gitRoutes,
     ...localRoutes
 ];

--- a/td.vue/src/service/demo/demo-threat-model.js
+++ b/td.vue/src/service/demo/demo-threat-model.js
@@ -1,0 +1,934 @@
+export default {
+    'summary': {
+        'title': 'Demo Threat Model',
+        'owner': 'Mike Goodwin',
+        'description': 'A sample model of a web application, with a queue-decoupled background process.',
+        'id': 0
+    },
+    'detail': {
+        'contributors': [
+            {
+                'name': 'Tom Brown'
+            },
+            {
+                'name': 'Albert Moneypenny'
+            }
+        ],
+        'diagrams': [
+            {
+                'title': 'Main Request Data Flow',
+                'thumbnail': './public/content/images/thumbnail.jpg',
+                'id': 0,
+                'diagramJson': {
+                    'cells': [
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 565,
+                                'y': 414
+                            },
+                            'angle': 0,
+                            'id': 'a25bbb4e-093f-4238-a620-31efdee452dc',
+                            'z': 1,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'Encrypt the DB credentials in the configuration file.\n\nExpire and replace the DB credentials regularly.',
+                                    'description': 'The Background Worker configuration stores the credentials used by the worker to access the DB. An attacker could compromise the Background Worker and get access to the DB credentials.',
+                                    'title': 'Accessing DB credentials',
+                                    'type': 'Information disclosure'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Worker Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 290,
+                                'y': 420
+                            },
+                            'angle': 0,
+                            'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1',
+                            'z': 2,
+                            'isALog': true,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'description': 'An attacker could make an query call on the DB,',
+                                    'title': 'Unauthorised access',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Require all queries to be authenticated.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'title': 'Credential theft',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Database'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 40,
+                                'y': 420
+                            },
+                            'angle': 0,
+                            'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b',
+                            'z': 3,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'title': 'Credentials should be encrypted',
+                                    'type': 'Information disclosure',
+                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'mitigation': 'The Message Queue credentials should be encrypted.'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'outOfScope': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web Application Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 502,
+                                'y': 13
+                            },
+                            'angle': 0,
+                            'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067',
+                            'z': 4,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Message secrecy',
+                                    'type': 'Information disclosure',
+                                    'description': 'The data flow between the Web Application and the Background Worker is not point-to-point and therefore end-to-end secrecy cannot be provided at the transport layer. Messages could be read by an attacker at rest in the Message Queue.',
+                                    'mitigation': 'Use message level encryption for high sensitivity data (e.g. security tokens) in messages.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Message tampering',
+                                    'type': 'Tampering',
+                                    'description': 'Messages on the queue could be tampered with, causing incorrect processing by the Background Worker.',
+                                    'mitigation': 'Sign all queue messages at the Web Server. Validate the message signature at the Background Worker and reject any message with a missing or invalid signature. Log any failed messages.'
+                                },
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Fake messages could be placed on the queue',
+                                    'type': 'Spoofing',
+                                    'description': 'An attacker could put a fake message on queue, causing the Background Worker to do incorrect processing.',
+                                    'mitigation': 'Restrict access to the queue to the IP addresses of the Web Server and Background Worker.\n\nImplement authentication on the queue endpoint.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Message Queue'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 560,
+                                'y': 180
+                            },
+                            'angle': 0,
+                            'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3',
+                            'z': 5,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Poison messages 1',
+                                    'type': 'Denial of service',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.',
+                                    'mitigation': 'Implement a poison message queue where messages are placed after a fixed number of retries.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'mitigation': 'Validate the content of all messages, before processing. Reject any message that have invalid content and log the rejection. Do not log the malicious content - instead log a description of the error.',
+                                    'type': 'Denial of service',
+                                    'title': 'Poison messages 2',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.'
+                                }
+                            ],
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Background\nWorker Process'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 210,
+                                'y': 180
+                            },
+                            'angle': 0,
+                            'id': '0d9909ea-1398-4898-be81-cf1c808324dc',
+                            'z': 6,
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web\nApplication'
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Actor',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 40,
+                                'y': 29
+                            },
+                            'angle': 0,
+                            'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce',
+                            'z': 7,
+                            'threats': [],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Browser'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 80,
+                                'y': 220
+                            },
+                            'target': {
+                                'x': 295,
+                                'y': 51
+                            },
+                            'vertices': [
+                                {
+                                    'x': 276,
+                                    'y': 149
+                                }
+                            ],
+                            'id': '64d52ab0-9733-4ae9-af1b-a347cbc13186',
+                            'z': 8,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 350,
+                                'y': 10
+                            },
+                            'target': {
+                                'x': 663,
+                                'y': 156
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 117
+                                },
+                                {
+                                    'x': 432,
+                                    'y': 180
+                                }
+                            ],
+                            'id': '70a1b898-4131-462f-a26e-1adf9f2b2eda',
+                            'z': 9,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 245,
+                                    'y': 112
+                                }
+                            ],
+                            'id': '56b56e8c-751d-4d8a-a9c7-6554c9f142ee',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Request',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 10,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'isPublicNetwork': true,
+                            'isEncrypted': true,
+                            'protocol': 'HTTP/S',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 351,
+                                    'y': 120
+                                }
+                            ],
+                            'id': '86347588-6629-45e3-a441-09ca11bce894',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Put Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 13,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 544,
+                                    'y': 127
+                                }
+                            ],
+                            'id': '4bbf279c-49c7-436d-9afa-e94435e6ec72',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 14,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    'type': 'Information disclosure',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 466,
+                                    'y': 347
+                                }
+                            ],
+                            'id': '75949d2c-0449-4a10-add3-07ac91a0c608',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Query Results',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 17,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Man in the middle attack',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Enforce an encrypted connection at the DB server',
+                                    'description': 'An attacker could intercept the DB queries in transit and obtain sensitive information, such as DB credentials, query parameters or query results (is unlikely since the data flow is over a private network).'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 241,
+                                'y': 444
+                            },
+                            'target': {
+                                'x': 526,
+                                'y': 465
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 288
+                                },
+                                {
+                                    'x': 488,
+                                    'y': 267
+                                },
+                                {
+                                    'x': 552,
+                                    'y': 339
+                                }
+                            ],
+                            'id': 'a61cbe16-7e3f-400c-a0ea-c0695253c6ad',
+                            'z': 18,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 111,
+                                    'y': 175
+                                }
+                            ],
+                            'id': '1b1cf1eb-d9ac-463b-a9ae-d816c42e7107',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Response',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 19,
+                            'isEncrypted': true,
+                            'isPublicNetwork': true,
+                            'protocol': 'HTTP/S',
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These responses are over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 157,
+                                    'y': 292
+                                }
+                            ],
+                            'id': 'c8c746d8-2a26-464e-8524-3350be8dcae5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read web app config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 20,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'a25bbb4e-093f-4238-a620-31efdee452dc'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 664,
+                                    'y': 320
+                                }
+                            ],
+                            'id': '6cba52e8-0d26-481f-bcc1-dbf0b66d8b42',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read worker config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 21,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 311,
+                                    'y': 324
+                                }
+                            ],
+                            'id': '2fd00bd2-c603-4d72-a12f-c20a3a1ba77b',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 22,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'isPublicNetwork': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 377,
+                                    'y': 280
+                                }
+                            ],
+                            'id': 'd117ddba-2508-45ce-b9ea-fb9df56a79e5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web App Query\nResults',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 23,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 552,
+                                    'y': 382
+                                }
+                            ],
+                            'id': '015880b7-fb7a-4fe3-b729-fbd40bd7afcb',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 24,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        }
+                    ]
+                },
+                'size': {
+                    'height': 594,
+                    'width': 860
+                }
+            }
+        ],
+        'reviewer': 'Jane Smith'
+    }
+};

--- a/td.vue/src/service/demo/index.js
+++ b/td.vue/src/service/demo/index.js
@@ -1,0 +1,15 @@
+import demoThreatModel from './demo-threat-model.js';
+import legacyDesktopModel from './legacy-desktop-model.js';
+import legacyModel2 from './legacy-model-2.js';
+import legacyModel from './legacy-model.js';
+
+const models = [
+    { name: 'Demo Threat Model', model: demoThreatModel },
+    { name: 'Legacy Desktop Model', model: legacyDesktopModel },
+    { name: 'Legacy Model', model: legacyModel },
+    { name: 'Legacy Model 2', model: legacyModel2 }
+];
+
+export default {
+    models
+};

--- a/td.vue/src/service/demo/legacy-desktop-model.js
+++ b/td.vue/src/service/demo/legacy-desktop-model.js
@@ -1,0 +1,896 @@
+export default {
+    'summary': {
+        'title': 'Demo Threat Model',
+        'owner': 'Mike Goodwin',
+        'description': 'A sample model of a web application, with a queue-decoupled background process.',
+        'id': 0
+    },
+    'detail': {
+        'contributors': [
+            {
+                'name': 'Tom Brown'
+            },
+            {
+                'name': 'Albert Moneypenny'
+            }
+        ],
+        'diagrams': [
+            {
+                'title': 'Main Request Data Flow',
+                'thumbnail': './public/content/images/thumbnail.jpg',
+                'id': 0,
+                'diagramJson': {
+                    'cells': [
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 637,
+                                'y': 388
+                            },
+                            'angle': 0,
+                            'id': 'a25bbb4e-093f-4238-a620-31efdee452dc',
+                            'z': 1,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'Encrypt the DB credentials in the configuration file.\n\nExpire and replace the DB credentials regularly.',
+                                    'description': 'The Background Worker configuration stores the credentials used by the worker to access the DB. An attacker could compromise the Background Worker and get access to the DB credentials.',
+                                    'title': 'Accessing DB credentials',
+                                    'type': 'Information disclosure'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Worker Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 324,
+                                'y': 398
+                            },
+                            'angle': 0,
+                            'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1',
+                            'z': 2,
+                            'isALog': true,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'description': 'An attacker could make an query call on the DB,',
+                                    'title': 'Unauthorised access',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Require all queries to be authenticated.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'title': 'Credential theft',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Database'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 52,
+                                'y': 408
+                            },
+                            'angle': 0,
+                            'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b',
+                            'z': 3,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'title': 'Credentials should be encrypted',
+                                    'type': 'Information disclosure',
+                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'mitigation': 'The Message Queue credentials should be encrypted.'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'outOfScope': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web Application Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 408,
+                                'y': 28
+                            },
+                            'angle': 0,
+                            'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067',
+                            'z': 4,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Message secrecy',
+                                    'type': 'Information disclosure',
+                                    'description': 'The data flow between the Web Application and the Background Worker is not point-to-point and therefore end-to-end secrecy cannot be provided at the transport layer. Messages could be read by an attacker at rest in the Message Queue.',
+                                    'mitigation': 'Use message level encryption for high sensitivity data (e.g. security tokens) in messages.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Message tampering',
+                                    'type': 'Tampering',
+                                    'description': 'Messages on the queue could be tampered with, causing incorrect processing by the Background Worker.',
+                                    'mitigation': 'Sign all queue messages at the Web Server. Validate the message signature at the Background Worker and reject any message with a missing or invalid signature. Log any failed messages.'
+                                },
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Fake messages could be placed on the queue',
+                                    'type': 'Spoofing',
+                                    'description': 'An attacker could put a fake message on queue, causing the Background Worker to do incorrect processing.',
+                                    'mitigation': 'Restrict access to the queue to the IP addresses of the Web Server and Background Worker.\n\nImplement authentication on the queue endpoint.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Message Queue'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 598,
+                                'y': 179
+                            },
+                            'angle': 0,
+                            'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3',
+                            'z': 5,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Poison messages 1',
+                                    'type': 'Denial of service',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.',
+                                    'mitigation': 'Implement a poison message queue where messages are placed after a fixed number of retries.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'mitigation': 'Validate the content of all messages, before processing. Reject any message that have invalid content and log the rejection. Do not log the malicious content - instead log a description of the error.',
+                                    'type': 'Denial of service',
+                                    'title': 'Poison messages 2',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.'
+                                }
+                            ],
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Background\nWorker Process'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 215,
+                                'y': 181
+                            },
+                            'angle': 0,
+                            'id': '0d9909ea-1398-4898-be81-cf1c808324dc',
+                            'z': 6,
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web\nApplication'
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Actor',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 26,
+                                'y': 38
+                            },
+                            'angle': 0,
+                            'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce',
+                            'z': 7,
+                            'threats': [],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Browser'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 130,
+                                'y': 232
+                            },
+                            'target': {
+                                'x': 291,
+                                'y': 150
+                            },
+                            'vertices': [
+                                {
+                                    'x': 177,
+                                    'y': 149
+                                }
+                            ],
+                            'id': '64d52ab0-9733-4ae9-af1b-a347cbc13186',
+                            'z': 8,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 339,
+                                'y': 8
+                            },
+                            'target': {
+                                'x': 420,
+                                'y': 174
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 117
+                                }
+                            ],
+                            'id': '70a1b898-4131-462f-a26e-1adf9f2b2eda',
+                            'z': 9,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 245,
+                                    'y': 112
+                                }
+                            ],
+                            'id': '56b56e8c-751d-4d8a-a9c7-6554c9f142ee',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Request',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 10,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'isPublicNetwork': true,
+                            'isEncrypted': true,
+                            'protocol': 'HTTP/S',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 351,
+                                    'y': 120
+                                }
+                            ],
+                            'id': '86347588-6629-45e3-a441-09ca11bce894',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Put Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 13,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 645,
+                                    'y': 110
+                                }
+                            ],
+                            'id': '4bbf279c-49c7-436d-9afa-e94435e6ec72',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 14,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    'type': 'Information disclosure',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 551,
+                                'y': 178
+                            },
+                            'target': {
+                                'x': 753,
+                                'y': 125
+                            },
+                            'vertices': [
+                                {
+                                    'x': 635,
+                                    'y': 124
+                                }
+                            ],
+                            'id': 'cc656830-4c72-4ede-8f3b-0daeaa399d16',
+                            'z': 15,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 489,
+                                    'y': 342
+                                }
+                            ],
+                            'id': '75949d2c-0449-4a10-add3-07ac91a0c608',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Query Results',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 17,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Man in the middle attack',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Enforce an encrypted connection at the DB server',
+                                    'description': 'An attacker could intercept the DB queries in transit and obtain sensitive information, such as DB credentials, query parameters or query results (is unlikely since the data flow is over a private network).'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 253,
+                                'y': 380
+                            },
+                            'target': {
+                                'x': 560,
+                                'y': 442
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 288
+                                },
+                                {
+                                    'x': 475,
+                                    'y': 276
+                                }
+                            ],
+                            'id': 'a61cbe16-7e3f-400c-a0ea-c0695253c6ad',
+                            'z': 18,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 111,
+                                    'y': 175
+                                }
+                            ],
+                            'id': '1b1cf1eb-d9ac-463b-a9ae-d816c42e7107',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Response',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 19,
+                            'isEncrypted': true,
+                            'isPublicNetwork': true,
+                            'protocol': 'HTTP/S',
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These responses are over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 157,
+                                    'y': 292
+                                }
+                            ],
+                            'id': 'c8c746d8-2a26-464e-8524-3350be8dcae5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read web app config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 20,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'a25bbb4e-093f-4238-a620-31efdee452dc'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 664,
+                                    'y': 320
+                                }
+                            ],
+                            'id': '6cba52e8-0d26-481f-bcc1-dbf0b66d8b42',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read worker config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 21,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 311,
+                                    'y': 324
+                                }
+                            ],
+                            'id': '2fd00bd2-c603-4d72-a12f-c20a3a1ba77b',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 22,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'isPublicNetwork': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 377,
+                                    'y': 280
+                                }
+                            ],
+                            'id': 'd117ddba-2508-45ce-b9ea-fb9df56a79e5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web App Query\nResults',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 23,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 552,
+                                    'y': 382
+                                }
+                            ],
+                            'id': '015880b7-fb7a-4fe3-b729-fbd40bd7afcb',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 24,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        }
+                    ]
+                },
+                'size': {
+                    'height': 594,
+                    'width': 869
+                }
+            }
+        ],
+        'reviewer': 'Jane Smith'
+    }
+};
+

--- a/td.vue/src/service/demo/legacy-model-2.js
+++ b/td.vue/src/service/demo/legacy-model-2.js
@@ -1,0 +1,784 @@
+export default {
+    'summary': {
+        'title': 'Demo Threat Model',
+        'owner': 'Mike Goodwin',
+        'description': 'A sample model of a web application, with a queue-decoupled background process.',
+        'id': 0
+    },
+    'detail': {
+        'contributors': [
+            {
+                'name': 'Tom Brown',
+                '$$hashKey': 'object:154'
+            }
+        ],
+        'diagrams': [
+            {
+                'title': 'Main Request Flow',
+                'thumbnail': './public/content/images/thumbnail.jpg',
+                'id': 0,
+                '$$hashKey': 'object:160',
+                'diagramJson': {
+                    'cells': [
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 659,
+                                'y': 361
+                            },
+                            'angle': 0,
+                            'id': 'a25bbb4e-093f-4238-a620-31efdee452dc',
+                            'z': 1,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'Encrypt the DB credentials in the configuration file.\n\nExpire and replace the DB credentials regularly.',
+                                    'description': 'The Background Worker configuration stores the credentials used by the worker to access the DB. An attacker could compromise the Background Worker and get access to the DB credentials.',
+                                    'title': 'Accessing DB credentials',
+                                    'type': 'Information disclosure',
+                                    '$$hashKey': 'object:276'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Worker Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 328,
+                                'y': 372
+                            },
+                            'angle': 0,
+                            'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1',
+                            'z': 2,
+                            'isALog': true,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'description': 'An attacker could make an query call on the DB,',
+                                    'title': 'Unauthorised access',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Require all queries to be authenticated.',
+                                    '$$hashKey': 'object:215'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'title': 'Credential theft',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.',
+                                    '$$hashKey': 'object:233'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Database'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 67,
+                                'y': 368
+                            },
+                            'angle': 0,
+                            'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b',
+                            'z': 3,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'title': 'Credentials should be encrypted',
+                                    'type': 'Information disclosure',
+                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'mitigation': 'The Message Queue credentials should be encrypted.',
+                                    '$$hashKey': 'object:203'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'outOfScope': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web Application Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 419,
+                                'y': 25
+                            },
+                            'angle': 0,
+                            'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067',
+                            'z': 4,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Message secrecy',
+                                    'type': 'Information disclosure',
+                                    '$$hashKey': 'object:55',
+                                    'description': 'The data flow between the Web Application and the Background Worker is not point-to-point and therefore end-to-end secrecy cannot be provided at the transport layer. Messages could be read by an attacker at rest in the Message Queue.',
+                                    'mitigation': 'Use message level encryption for high sensitivity data (e.g. security tokens) in messages.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Message tampering',
+                                    'type': 'Tampering',
+                                    '$$hashKey': 'object:68',
+                                    'description': 'Messages on the queue could be tampered with, causing incorrect processing by the Background Worker.',
+                                    'mitigation': 'Sign all queue messages at the Web Server. Validate the message signature at the Background Worker and reject any message with a missing or invalid signature. Log any failed messages.'
+                                },
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Fake messages could be placed on the queue',
+                                    'type': 'Spoofing',
+                                    'description': 'An attacker could put a fake message on queue, causing the Background Worker to do incorrect processing.',
+                                    'mitigation': 'Restrict access to the queue to the IP addresses of the Web Server and Background Worker.\n\nImplement authentication on the queue endpoint.',
+                                    '$$hashKey': 'object:150'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Message Queue'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 664,
+                                'y': 151
+                            },
+                            'angle': 0,
+                            'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3',
+                            'z': 5,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Poison messages 1',
+                                    'type': 'Denial of service',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.',
+                                    'mitigation': 'Implement a poison message queue where messages are placed after a fixed number of retries.',
+                                    '$$hashKey': 'object:245'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'mitigation': 'Validate the content of all messages, before processing. Reject any message that have invalid content and log the rejection. Do not log the malicious content - instead log a description of the error.',
+                                    'type': 'Denial of service',
+                                    'title': 'Poison messages 2',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.',
+                                    '$$hashKey': 'object:260'
+                                }
+                            ],
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Background\nWorker Process'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 225,
+                                'y': 179
+                            },
+                            'angle': 0,
+                            'id': '0d9909ea-1398-4898-be81-cf1c808324dc',
+                            'z': 6,
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web\nApplication'
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Actor',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 27,
+                                'y': 30
+                            },
+                            'angle': 0,
+                            'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce',
+                            'z': 7,
+                            'threats': [],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Browser'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 115,
+                                'y': 231
+                            },
+                            'target': {
+                                'x': 291,
+                                'y': 150
+                            },
+                            'vertices': [
+                                {
+                                    'x': 177,
+                                    'y': 149
+                                }
+                            ],
+                            'id': '64d52ab0-9733-4ae9-af1b-a347cbc13186',
+                            'z': 8,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 339,
+                                'y': 8
+                            },
+                            'target': {
+                                'x': 410,
+                                'y': 148
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 117
+                                }
+                            ],
+                            'id': '70a1b898-4131-462f-a26e-1adf9f2b2eda',
+                            'z': 9,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 245,
+                                    'y': 112
+                                }
+                            ],
+                            'id': '56b56e8c-751d-4d8a-a9c7-6554c9f142ee',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Request',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 10,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    '$$hashKey': 'object:372'
+                                }
+                            ],
+                            'isPublicNetwork': true,
+                            'isEncrypted': true,
+                            'protocol': 'HTTP/S',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 351,
+                                    'y': 120
+                                }
+                            ],
+                            'id': '86347588-6629-45e3-a441-09ca11bce894',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Put Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 13,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    '$$hashKey': 'object:182'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 645,
+                                    'y': 110
+                                }
+                            ],
+                            'id': '4bbf279c-49c7-436d-9afa-e94435e6ec72',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 14,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    'type': 'Information disclosure',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    '$$hashKey': 'object:198'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 551,
+                                'y': 178
+                            },
+                            'target': {
+                                'x': 753,
+                                'y': 125
+                            },
+                            'vertices': [
+                                {
+                                    'x': 635,
+                                    'y': 124
+                                }
+                            ],
+                            'id': 'cc656830-4c72-4ede-8f3b-0daeaa399d16',
+                            'z': 15,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 533,
+                                    'y': 254
+                                }
+                            ],
+                            'id': '75949d2c-0449-4a10-add3-07ac91a0c608',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Query Results',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 17,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Man in the middle attack',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Enforce an encrypted connection at the DB server',
+                                    'description': 'An attacker could intercept the DB queries in transit and obtain sensitive information, such as DB credentials, query parameters or query results (is unlikely since the data flow is over a private network).',
+                                    '$$hashKey': 'object:291'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'smooth': true,
+                            'source': {
+                                'x': 398,
+                                'y': 258
+                            },
+                            'target': {
+                                'x': 592,
+                                'y': 362
+                            },
+                            'vertices': [
+                                {
+                                    'x': 507,
+                                    'y': 286
+                                }
+                            ],
+                            'id': 'a61cbe16-7e3f-400c-a0ea-c0695253c6ad',
+                            'z': 18,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 111,
+                                    'y': 175
+                                }
+                            ],
+                            'id': '1b1cf1eb-d9ac-463b-a9ae-d816c42e7107',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Response',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 19,
+                            'isEncrypted': true,
+                            'isPublicNetwork': true,
+                            'protocol': 'HTTP/S',
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These responses are over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    '$$hashKey': 'object:104'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 157,
+                                    'y': 292
+                                }
+                            ],
+                            'id': 'c8c746d8-2a26-464e-8524-3350be8dcae5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read web app config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 20,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'smooth': true,
+                            'source': {
+                                'id': 'a25bbb4e-093f-4238-a620-31efdee452dc'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 774,
+                                    'y': 295
+                                }
+                            ],
+                            'id': '6cba52e8-0d26-481f-bcc1-dbf0b66d8b42',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read worker config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 21,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        }
+                    ]
+                },
+                'size': {
+                    'height': 590,
+                    'width': 851.3660278320312
+                }
+            }
+        ],
+        'reviewer': 'Jane Smith'
+    }
+};

--- a/td.vue/src/service/demo/legacy-model.js
+++ b/td.vue/src/service/demo/legacy-model.js
@@ -1,0 +1,951 @@
+export default {
+    'summary': {
+        'title': 'Demo Threat Model',
+        'owner': 'Mike Goodwin',
+        'description': 'A sample model of a web application, with a queue-decoupled background process.',
+        'id': 0
+    },
+    'detail': {
+        'contributors': [
+            {
+                'name': 'Tom Brown'
+            },
+            {
+                'name': 'Albert Moneypenny'
+            }
+        ],
+        'diagrams': [
+            {
+                'title': 'Main Request Data Flow',
+                'thumbnail': './public/content/images/thumbnail.jpg',
+                'id': 0,
+                'diagramJson': {
+                    'cells': [
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 637,
+                                'y': 388
+                            },
+                            'angle': 0,
+                            'id': 'a25bbb4e-093f-4238-a620-31efdee452dc',
+                            'z': 1,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'Encrypt the DB credentials in the configuration file.\n\nExpire and replace the DB credentials regularly.',
+                                    'description': 'The Background Worker configuration stores the credentials used by the worker to access the DB. An attacker could compromise the Background Worker and get access to the DB credentials.',
+                                    'title': 'Accessing DB credentials',
+                                    'type': 'Information disclosure'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Worker Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 324,
+                                'y': 398
+                            },
+                            'angle': 0,
+                            'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1',
+                            'z': 2,
+                            'isALog': true,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'description': 'An attacker could make an query call on the DB,',
+                                    'title': 'Unauthorised access',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Require all queries to be authenticated.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'title': 'Credential theft',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Database'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 52,
+                                'y': 408
+                            },
+                            'angle': 0,
+                            'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b',
+                            'z': 3,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'title': 'Credentials should be encrypted',
+                                    'type': 'Information disclosure',
+                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'mitigation': 'The Message Queue credentials should be encrypted.'
+                                }
+                            ],
+                            'storesCredentials': true,
+                            'hasOpenThreats': true,
+                            'outOfScope': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web Application Config'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Store',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 408,
+                                'y': 28
+                            },
+                            'angle': 0,
+                            'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067',
+                            'z': 4,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Message secrecy',
+                                    'type': 'Information disclosure',
+                                    'description': 'The data flow between the Web Application and the Background Worker is not point-to-point and therefore end-to-end secrecy cannot be provided at the transport layer. Messages could be read by an attacker at rest in the Message Queue.',
+                                    'mitigation': 'Use message level encryption for high sensitivity data (e.g. security tokens) in messages.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Message tampering',
+                                    'type': 'Tampering',
+                                    'description': 'Messages on the queue could be tampered with, causing incorrect processing by the Background Worker.',
+                                    'mitigation': 'Sign all queue messages at the Web Server. Validate the message signature at the Background Worker and reject any message with a missing or invalid signature. Log any failed messages.'
+                                },
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Fake messages could be placed on the queue',
+                                    'type': 'Spoofing',
+                                    'description': 'An attacker could put a fake message on queue, causing the Background Worker to do incorrect processing.',
+                                    'mitigation': 'Restrict access to the queue to the IP addresses of the Web Server and Background Worker.\n\nImplement authentication on the queue endpoint.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Message Queue'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 598,
+                                'y': 179
+                            },
+                            'angle': 0,
+                            'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3',
+                            'z': 5,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'title': 'Poison messages 1',
+                                    'type': 'Denial of service',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.',
+                                    'mitigation': 'Implement a poison message queue where messages are placed after a fixed number of retries.'
+                                },
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Medium',
+                                    'mitigation': 'Validate the content of all messages, before processing. Reject any message that have invalid content and log the rejection. Do not log the malicious content - instead log a description of the error.',
+                                    'type': 'Denial of service',
+                                    'title': 'Poison messages 2',
+                                    'description': 'An attacker could generate a malicious message that the Background Worker cannot process.'
+                                }
+                            ],
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Background\nWorker Process'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Process',
+                            'size': {
+                                'width': 100,
+                                'height': 100
+                            },
+                            'position': {
+                                'x': 208,
+                                'y': 189
+                            },
+                            'angle': 0,
+                            'id': '0d9909ea-1398-4898-be81-cf1c808324dc',
+                            'z': 6,
+                            'privilegeLevel': 'executionContext =Limited',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Web\nApplication'
+                                },
+                                '#element-process': {
+                                    'class': 'outOfScopeElement'
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Actor',
+                            'size': {
+                                'width': 160,
+                                'height': 80
+                            },
+                            'position': {
+                                'x': 26,
+                                'y': 38
+                            },
+                            'angle': 0,
+                            'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce',
+                            'z': 7,
+                            'threats': [],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.element-shape': {
+                                    'class': 'element-shape hasNoOpenThreats isInScope'
+                                },
+                                'text': {
+                                    'text': 'Browser'
+                                },
+                                '#element-shape': {
+                                    'class': ''
+                                },
+                                '.undefined': {
+                                    'class': 'undefinedhasNoOpenThreats isInScope'
+                                },
+                                '.element-text': {
+                                    'class': 'element-text hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 130,
+                                'y': 232
+                            },
+                            'target': {
+                                'x': 291,
+                                'y': 150
+                            },
+                            'vertices': [
+                                {
+                                    'x': 177,
+                                    'y': 149
+                                }
+                            ],
+                            'id': '64d52ab0-9733-4ae9-af1b-a347cbc13186',
+                            'z': 8,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 339,
+                                'y': 8
+                            },
+                            'target': {
+                                'x': 420,
+                                'y': 174
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 117
+                                }
+                            ],
+                            'id': '70a1b898-4131-462f-a26e-1adf9f2b2eda',
+                            'z': 9,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 245,
+                                    'y': 112
+                                }
+                            ],
+                            'id': '56b56e8c-751d-4d8a-a9c7-6554c9f142ee',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Request',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 10,
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'isPublicNetwork': true,
+                            'isEncrypted': true,
+                            'protocol': 'HTTP/S',
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 351,
+                                    'y': 120
+                                }
+                            ],
+                            'id': '86347588-6629-45e3-a441-09ca11bce894',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Put Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 13,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'ec574fb4-87e7-494b-88dc-2a3c99172067'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 645,
+                                    'y': 110
+                                }
+                            ],
+                            'id': '4bbf279c-49c7-436d-9afa-e94435e6ec72',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Message',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 14,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'High',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.',
+                                    'type': 'Information disclosure',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'description': 'These requests are made over the public internet and could be intercepted by an attacker.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 551,
+                                'y': 178
+                            },
+                            'target': {
+                                'x': 753,
+                                'y': 125
+                            },
+                            'vertices': [
+                                {
+                                    'x': 635,
+                                    'y': 124
+                                }
+                            ],
+                            'id': 'cc656830-4c72-4ede-8f3b-0daeaa399d16',
+                            'z': 15,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 489,
+                                    'y': 342
+                                }
+                            ],
+                            'id': '75949d2c-0449-4a10-add3-07ac91a0c608',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Query Results',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 17,
+                            'threats': [
+                                {
+                                    'status': 'Open',
+                                    'severity': 'Low',
+                                    'title': 'Man in the middle attack',
+                                    'type': 'Information disclosure',
+                                    'mitigation': 'Enforce an encrypted connection at the DB server',
+                                    'description': 'An attacker could intercept the DB queries in transit and obtain sensitive information, such as DB credentials, query parameters or query results (is unlikely since the data flow is over a private network).'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Boundary',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'x': 253,
+                                'y': 380
+                            },
+                            'target': {
+                                'x': 560,
+                                'y': 442
+                            },
+                            'vertices': [
+                                {
+                                    'x': 333,
+                                    'y': 288
+                                },
+                                {
+                                    'x': 475,
+                                    'y': 276
+                                }
+                            ],
+                            'id': 'a61cbe16-7e3f-400c-a0ea-c0695253c6ad',
+                            'z': 18,
+                            'attrs': {}
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': 'b394f9f7-07ca-42bc-b616-ad77c6fbfcce'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 111,
+                                    'y': 175
+                                }
+                            ],
+                            'id': '1b1cf1eb-d9ac-463b-a9ae-d816c42e7107',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web Response',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 19,
+                            'isEncrypted': true,
+                            'isPublicNetwork': true,
+                            'protocol': 'HTTP/S',
+                            'threats': [
+                                {
+                                    'status': 'Mitigated',
+                                    'severity': 'High',
+                                    'title': 'Data flow should use HTTP/S',
+                                    'type': 'Information disclosure',
+                                    'description': 'These responses are over the public internet and could be intercepted by an attacker.',
+                                    'mitigation': 'The requests should require HTTP/S. This will provide confidentiality and integrity. HTTP should not be supported.'
+                                }
+                            ],
+                            'outOfScope': false,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'bdd3e115-4b92-4020-90b7-c3351dba292b'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 157,
+                                    'y': 292
+                                }
+                            ],
+                            'id': 'c8c746d8-2a26-464e-8524-3350be8dcae5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read web app config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 20,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': 'a25bbb4e-093f-4238-a620-31efdee452dc'
+                            },
+                            'target': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 664,
+                                    'y': 320
+                                }
+                            ],
+                            'id': '6cba52e8-0d26-481f-bcc1-dbf0b66d8b42',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Read worker config',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 21,
+                            'outOfScope': true,
+                            'reasonOutOfScope': 'This data flow represents a read from the file system',
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isOutOfScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 311,
+                                    'y': 324
+                                }
+                            ],
+                            'id': '2fd00bd2-c603-4d72-a12f-c20a3a1ba77b',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 22,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'isPublicNetwork': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'target': {
+                                'id': '0d9909ea-1398-4898-be81-cf1c808324dc'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 377,
+                                    'y': 280
+                                }
+                            ],
+                            'id': 'd117ddba-2508-45ce-b9ea-fb9df56a79e5',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Web App Query\nResults',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 23,
+                            'hasOpenThreats': false,
+                            'isEncrypted': true,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        },
+                        {
+                            'type': 'tm.Flow',
+                            'size': {
+                                'width': 10,
+                                'height': 10
+                            },
+                            'smooth': true,
+                            'source': {
+                                'id': '3e75b596-9c70-41b6-a2cf-a15899c254d3'
+                            },
+                            'target': {
+                                'id': '936557f9-22e2-4bac-bb70-0089c5c2fbe1'
+                            },
+                            'vertices': [
+                                {
+                                    'x': 552,
+                                    'y': 382
+                                }
+                            ],
+                            'id': '015880b7-fb7a-4fe3-b729-fbd40bd7afcb',
+                            'labels': [
+                                {
+                                    'position': 0.5,
+                                    'attrs': {
+                                        'text': {
+                                            'text': 'Worker Queries',
+                                            'font-weight': '400',
+                                            'font-size': 'small'
+                                        }
+                                    }
+                                }
+                            ],
+                            'z': 24,
+                            'hasOpenThreats': false,
+                            'attrs': {
+                                '.marker-target': {
+                                    'class': 'marker-target hasNoOpenThreats isInScope'
+                                },
+                                '.connection': {
+                                    'class': 'connection hasNoOpenThreats isInScope'
+                                }
+                            }
+                        }
+                    ]
+                },
+                'size': {
+                    'height': 594,
+                    'width': 869
+                }
+            }
+        ],
+        'reviewer': 'Jane Smith'
+    }
+};

--- a/td.vue/src/service/provider/github.provider.js
+++ b/td.vue/src/service/provider/github.provider.js
@@ -15,8 +15,8 @@ const getDashboardActions = () => ([
         icon: 'plus'
     },
     {
-        to: '/',
-        key: 'download',
+        to: '/demo/select',
+        key: 'demo',
         icon: 'cloud-download-alt'
     }
 ]);

--- a/td.vue/src/service/provider/local.provider.js
+++ b/td.vue/src/service/provider/local.provider.js
@@ -16,8 +16,8 @@ const getDashboardActions = () => ([
         icon: 'plus'
     },
     {
-        to: '/',
-        key: 'download',
+        to: '/demo/select',
+        key: 'demo',
         icon: 'cloud-download-alt'
     }
 ]);

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 
+import demo from '@/service/demo/index.js';
 import { getProviderType } from '../../service/provider/providers.js';
 import { providerTypes } from '../../service/provider/providerTypes.js';
 import {
@@ -37,20 +38,28 @@ const actions = {
                 threatModel
             );
             commit(THREATMODEL_FETCH, resp.data);
+        } else {
+            commit(THREATMODEL_FETCH, threatModel);
         }
     },
     [THREATMODEL_FETCH_ALL]: async ({ commit, rootState }) => {
-        if (rootState.provider.selected !== 'local') {
+        if (getProviderType(rootState.provider.selected) !== providerTypes.local) {
             const resp = await threatmodelApi.modelsAsync(
                 rootState.repo.selected,
                 rootState.branch.selected
             );
             commit(THREATMODEL_FETCH_ALL, resp.data);
+        } else {
+            commit(THREATMODEL_FETCH_ALL, demo.models);
         }
     },
-    [THREATMODEL_SELECTED]: ({ commit, dispatch }, threatModel) => {
-        commit(THREATMODEL_SELECTED, threatModel);
-        dispatch(THREATMODEL_FETCH, threatModel);
+    [THREATMODEL_SELECTED]: ({ commit, dispatch, rootState }, threatModel) => {
+        if (getProviderType(rootState.provider.selected) !== providerTypes.local) {
+            commit(THREATMODEL_SELECTED, threatModel);
+            dispatch(THREATMODEL_FETCH, threatModel);
+        } else {
+            commit(THREATMODEL_FETCH, threatModel);
+        }
     }
 };
 

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="model">
+    <div v-if="!!model && model.summary">
         <!-- metadata -->
         <b-row class="mb-4" id="title_row">
             <b-col>
@@ -132,8 +132,7 @@ export default {
         contributors: (state) => state.threatmodel.data.detail.contributors.map(x => x.name).join(', '),
         model: (state) => state.threatmodel.data,
         provider: state => state.provider.selected,
-        providerType: state => getProviderType(state.provider.selected),
-        repoName: state => state.repo.selected
+        providerType: state => getProviderType(state.provider.selected)
     }),
     methods: {
         onEditClick(evt) {

--- a/td.vue/src/views/demo/SelectDemoModel.vue
+++ b/td.vue/src/views/demo/SelectDemoModel.vue
@@ -1,0 +1,51 @@
+<template>
+    <b-container fluid>
+        <b-row>
+            <b-col>
+                <b-jumbotron class="text-center">
+                    <h4>
+                        {{ $t('demo.select') }}
+                    </h4>
+                </b-jumbotron>
+            </b-col>
+        </b-row>
+        <b-row>
+            <b-col md=6 offset=3>
+                <b-list-group>
+                    <b-list-group-item
+                        v-for="(model, idx) in models"
+                        :key="idx"
+                        href="javascript:void(0)"
+                        @click="onModelClick(model)"
+                    >{{ model.name }}</b-list-group-item>
+                </b-list-group>
+            </b-col>
+        </b-row>
+    </b-container>
+</template>
+
+<script>
+import demo from '@/service/demo/index.js';
+import threatmodelActions from '@/store/actions/threatmodel.js';
+
+export default {
+    name: 'SelectDemoModel',
+    data() {
+        return {
+            models: demo.models
+        };
+    },
+    mounted() {
+        this.$store.dispatch(threatmodelActions.clear);
+        this.$store.dispatch(threatmodelActions.fetchAll);
+    },
+    methods: {
+        onModelClick(model) {
+            this.$store.dispatch(threatmodelActions.selected, model.model);
+            const params = Object.assign({}, this.$route.params, { threatmodel: model.name });
+            this.$router.push({ name: 'localThreatModel' , params });
+        }
+    }
+};
+
+</script>

--- a/td.vue/tests/e2e/specs/demo.js
+++ b/td.vue/tests/e2e/specs/demo.js
@@ -1,0 +1,41 @@
+describe('demo', () => {
+    before(() => {
+        cy.visit('/');
+        cy.get('#local-login-btn').click();
+        cy.get('a[href="#/demo/select"]').click();
+    });
+
+    it('has the header text', () => {
+        cy.contains('demo threat model from the list');
+    });
+
+    it('has the Demo Threat Model', () => {
+        cy.contains('Demo Threat Model');
+    });
+
+    it('has the legacy desktop model', () => {
+        cy.contains('Legacy Desktop Model');
+    });
+
+    it('has the Legacy Model', () => {
+        cy.contains('Legacy Model');
+    });
+
+    it('opens the demo threat model', () => {
+        cy.get('a').contains('Demo Threat Model').click();
+        cy.url().should('contain', '/local/Demo%20Threat%20Model');
+    });
+
+    it('can edit the model', () => {
+        cy.get('#tm-edit-btn').click();
+        cy.url().should('contain', '/local/Demo%20Threat%20Model/edit');
+        cy.get('#description').should('be', 'visible');
+        cy.get('button').contains('Cancel').click();
+    });
+
+    it('can edit the diagram', () => {
+        cy.get('.td-diagram-thumb').click();
+        cy.url().should('contain', '/edit/Main%20Request%20Data%20Flow');
+    });
+
+});

--- a/td.vue/tests/unit/router/index.spec.js
+++ b/td.vue/tests/unit/router/index.spec.js
@@ -73,4 +73,29 @@ describe('router', () => {
             });
         });
     });
+
+    describe('demo-select', () => {
+        let demoSelectRoute;
+
+        beforeEach(() => {
+            demoSelectRoute = router.getRoutes()
+                .find(x => x.name === 'DemoSelect');
+        });
+
+        it('uses the /dashboard path', () => {
+            expect(demoSelectRoute.path).toEqual('/demo/select');
+        });
+
+        describe('lazily loaded component', () => {
+            let demoSelectComponent;
+
+            beforeEach(async () => {
+                demoSelectComponent = await demoSelectRoute.components.default();
+            });
+
+            it('uses the dashboard view', () => {
+                expect(demoSelectComponent.default.name).toEqual('SelectDemoModel');
+            });
+        });
+    });
 });

--- a/td.vue/tests/unit/service/provider/github.provider.spec.js
+++ b/td.vue/tests/unit/service/provider/github.provider.spec.js
@@ -36,16 +36,15 @@ describe('service/github.provider.js', () => {
             });
         });
 
-        describe('download', () => {
+        describe('demo', () => {
             let action;
 
             beforeEach(() => {
-                action = github.getDashboardActions().find(x=> x.key === 'download');
+                action = github.getDashboardActions().find(x=> x.key === 'demo');
             });
 
-            // TODO
-            xit('links to the repo select page', () => {
-                expect(action.to).toEqual('/git/github/repository');
+            it('links to the demo select page', () => {
+                expect(action.to).toEqual('/demo/select');
             });
 
             it('uses the cloud download icon', () => {

--- a/td.vue/tests/unit/service/provider/local.provider.spec.js
+++ b/td.vue/tests/unit/service/provider/local.provider.spec.js
@@ -36,16 +36,15 @@ describe('service/local.provider.js', () => {
             });
         });
 
-        describe('download', () => {
+        describe('demo', () => {
             let action;
 
             beforeEach(() => {
-                action = local.getDashboardActions().find(x=> x.key === 'download');
+                action = local.getDashboardActions().find(x=> x.key === 'demo');
             });
 
-            // TODO
-            xit('links to the home edit page', () => {
-                expect(action.to).toEqual('/repository');
+            it('links to the demo select page', () => {
+                expect(action.to).toEqual('/demo/select');
             });
 
             it('uses the cloud download icon', () => {

--- a/td.vue/tests/unit/store/actions/locale.spec.js
+++ b/td.vue/tests/unit/store/actions/locale.spec.js
@@ -1,0 +1,7 @@
+import { LOCALE_SELECTED } from '@/store/actions/locale.js';
+
+describe('store/actions/locale.js', () => {
+    it('defines a selected action', () => {
+        expect(LOCALE_SELECTED).not.toBeUndefined();
+    });
+});

--- a/td.vue/tests/unit/store/modules/locale.spec.js
+++ b/td.vue/tests/unit/store/modules/locale.spec.js
@@ -1,0 +1,41 @@
+import { LOCALE_SELECTED } from '@/store/actions/locale.js';
+import localeModule from '@/store/modules/locale.js';
+
+describe('store/modules/locale.js', () => {
+    const mocks = {
+        commit: () => {}
+    };
+
+    beforeEach(() => {
+        jest.spyOn(mocks, 'commit');
+    });
+
+    describe('state', () => {
+        it('defines a state object', () => {
+            expect(localeModule.state).toBeInstanceOf(Object);
+        });
+    });
+
+    describe('actions', () => {
+        it('commits the selected action', () => {
+            localeModule.actions[LOCALE_SELECTED](mocks, 'blah');
+            expect(mocks.commit).toHaveBeenCalledWith(LOCALE_SELECTED, 'blah');
+        });
+    });
+
+    describe('mutations', () => {
+        describe('selected', () => {    
+            beforeEach(() => {
+                localeModule.mutations[LOCALE_SELECTED](localeModule.state, 'foobar');
+            });
+
+            it('sets the locale', () => {
+                expect(localeModule.state.locale).toEqual('foobar');
+            });
+        });
+    });
+
+    it('defines a getters object', () => {
+        expect(localeModule.getters).toBeInstanceOf(Object);
+    });
+});

--- a/td.vue/tests/unit/store/modules/threatmodel.spec.js
+++ b/td.vue/tests/unit/store/modules/threatmodel.spec.js
@@ -127,16 +127,34 @@ describe('store/modules/threatmodel.js', () => {
 
         describe('selected', () => {
             const tm = 'test';
+
             beforeEach(async () => {
                 await threatmodelModule.actions[THREATMODEL_SELECTED](mocks, tm);
             });
+            
+            describe('local provider', () => {
+                beforeEach(async () => {                    
+                    mocks.rootState.provider.selected = 'local';
+                    await threatmodelModule.actions[THREATMODEL_SELECTED](mocks, tm);
+                });
 
-            it('commits the selected threatmodel', () => {
-                expect(mocks.commit).toHaveBeenCalledWith(THREATMODEL_SELECTED, tm);
+                it('commits the selected threatmodel', () => {
+                    expect(mocks.commit).toHaveBeenCalledWith(THREATMODEL_SELECTED, tm);
+                });
             });
 
-            it('dispatches the fetch event', () => {
-                expect(mocks.dispatch).toHaveBeenCalledWith(THREATMODEL_FETCH, tm);
+            describe('back-end provider', () => {
+                beforeEach(async () => {
+                    await threatmodelModule.actions[THREATMODEL_SELECTED](mocks, tm);
+                });
+
+                it('commits the selected threatmodel', () => {
+                    expect(mocks.commit).toHaveBeenCalledWith(THREATMODEL_SELECTED, tm);
+                });
+
+                it('dispatches the fetch event', () => {
+                    expect(mocks.dispatch).toHaveBeenCalledWith(THREATMODEL_FETCH, tm);
+                });
             });
         });
     });

--- a/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
+++ b/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
@@ -1,0 +1,81 @@
+import { BootstrapVue, BJumbotron, BListGroupItem } from 'bootstrap-vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import demoThreatModel from '@/service/demo/demo-threat-model.js';
+import SelectDemoModel from '@/views/demo/SelectDemoModel.vue';
+
+describe('views/demo/SelectDemoModel.vue', () => {
+
+    let wrapper, localVue, mockRouter, mockStore;
+
+    beforeEach(() => {
+        localVue = createLocalVue();
+        localVue.use(BootstrapVue);
+        localVue.use(Vuex);
+
+        mockStore = new Vuex.Store({
+            actions: {
+                THREATMODEL_CLEAR: () => {},
+                THREATMODEL_FETCH_ALL: () => {},
+                THREATMODEL_SELECTED: () => {}
+            }
+        });
+        mockStore.dispatch = jest.fn();
+
+        mockRouter = { push: jest.fn() };
+        wrapper = shallowMount(SelectDemoModel, {
+            localVue,
+            store: mockStore,
+            mocks: {
+                $t: key => key,
+                $route: {
+                    params: {}
+                },
+                $router: mockRouter
+            }
+        });
+    });
+
+    it('displays the title', () => {
+        expect(wrapper.findComponent(BJumbotron).text()).toEqual('demo.select');
+    });
+
+    it('displays the demo threat model', () => {
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Demo Threat Model')
+                .at(0)
+                .exists()
+        ).toEqual(true);
+    });
+    
+    it('clears the threatmodels', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_CLEAR');
+    });
+
+    it('fetches the demo models', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_FETCH_ALL');
+    });
+
+    describe('selecting a demo model', () => {
+        let demoModelItem;
+
+        beforeEach(async () => {
+            demoModelItem = await wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Demo Threat Model')
+                .at(0);
+            await demoModelItem.trigger('click');
+        });
+
+        it('dispatches the selected event', () => {
+            expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_SELECTED', demoThreatModel);
+        });
+
+        it('navigates to the threat model page', () => {
+            expect(mockRouter.push).toHaveBeenCalledWith(
+                { name: 'localThreatModel', params: { threatmodel: 'Demo Threat Model' }}
+            );
+        });
+    });
+});


### PR DESCRIPTION
**Summary**
Adding the ability to interact with a handful of the demo threat models.

**Description for the changelog**
Demo Threat Models are now hooked up and can be edited using v2 (with local/guest or github auth)

**Other info**
These are not actually downloaded from anywhere: they are included in the front-end package to avoid unnecessary network chatter.
