### PR TITLE
closes #299 Threat ID not consistently added to threats

### DIFF
--- a/td.desktop/core/diagrams/elementpropdirectives.js
+++ b/td.desktop/core/diagrams/elementpropdirectives.js
@@ -98,6 +98,9 @@ function elementThreats($routeParams, $location, common, dialogs) {
             editIndex = index;
             originalThreat = angular.copy(scope.threats[index]);
             $location.search('threat', originalThreat.id);
+            if (!threat.threatId) {
+                threat.threatId = uuidv4();
+            }
             dialogs.confirm(getTemplate(threat.modelType), scope.editThreat, function () { return { heading: 'Edit Threat', threat: threat, editing: true }; }, scope.cancelEdit);
         };
 


### PR DESCRIPTION
**Summary**
closes #299 Threat ID not consistently added to threats
threat ID added to threats after editing, only if theat ID is empty

**Description for the changelog**
if theat ID is empty then threat ID added to threats after editing

**Other info**

