### PR TITLE
Updating bootstrap to 4.6.1

### DIFF
--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -1,7 +1,6 @@
 - Add tests for ThreatmodelEdit view
 - Add report feature
 - Legend for diagram
-- Update bootstrap dev dep to 4.6.1 or 4.7.0 when they're available (remove sass division warnings that cannot be suppressed)
 - Update or remove the CSP violation reporter
 
 

--- a/td.vue/package-lock.json
+++ b/td.vue/package-lock.json
@@ -12851,9 +12851,9 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
     "listenercount": {

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -43,7 +43,7 @@
     "@vue/eslint-config-standard": "^5.1.2",
     "@vue/test-utils": "^1.0.3",
     "babel-eslint": "^10.1.0",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^4.6.1",
     "browserstack-cypress-cli": "^1.8.1",
     "chromedriver": "^90.0.0",
     "codecov": "^3.8.2",


### PR DESCRIPTION
**Summary**
Updates Bootstrap dev dependency in td.vue to 4.6.1

**Description for the changelog**
The sass compiler was [warning about division](https://sass-lang.com/documentation/breaking-changes/slash-div) when building td.vue.  This was from the Bootstrap dependency and was fixed in version 4.6.1
