### PR TITLE
Graph UI updates when data changes

### DIFF
--- a/td.vue/TODO
+++ b/td.vue/TODO
@@ -6,4 +6,3 @@
 
 
 - Add threat engine/suggested threats
-- Update UI when outOfScope value changed (or any other value that should change styles)

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -95,6 +95,7 @@ const cellUnselected = ({ cell }) => {
     }
     
     store.get().dispatch(CELL_UNSELECTED);
+    dataChanged.updateStyleAttrs(cell);
 };
 
 const listen = (graph) => {

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -1,6 +1,7 @@
 import events from '@/service/x6/graph/events.js';
 import shapes from '@/service/x6/shapes/index.js';
 import store from '@/store/index.js';
+import dataChanged from '../../../../../src/service/x6/graph/data-changed';
 
 describe('service/x6/graph/events.js', () => {
     let cell, edge, graph, mockStore;
@@ -239,6 +240,7 @@ describe('service/x6/graph/events.js', () => {
             beforeEach(() => {
                 cell.hasTools.mockImplementation(() => true);
                 cell.setName = jest.fn();
+                dataChanged.updateStyleAttrs = jest.fn();
                 cell.getData.mockImplementation(() => ({ name: 'test' }));
                 events.listen(graph);
                 graph.evts['cell:unselected']({ cell });
@@ -246,6 +248,10 @@ describe('service/x6/graph/events.js', () => {
 
             it('sets the name', () => {
                 expect(cell.setName).toHaveBeenCalledWith('test');
+            });
+
+            it('updates the style attributes', () => {
+                expect(dataChanged.updateStyleAttrs).toHaveBeenCalledTimes(1);
             });
         });
 


### PR DESCRIPTION
**Summary**
The graph UI now reflects changes to the data (such as "out of scope".

**Description for the changelog**
This is technically done when a cell is unselected.  

**Other info**
@jgadsden - FYI, I know you're planning to dig in soon.  Here's my thoughts on the current behavior for data changing in the graph:

The state is only updated when a cell is un-selected. This could or even should change to be a proper data binding in the future.  For now, it's an intentional design decision that follows how other metadata is updated (such as the names of properties).  This is not to say it's a *good* decision, we may want to revisit this before anything is released.  It doesn't feel super intuitive to have to un-select a cell to see data changing.

From a UX perspective, I think it'd make sense to either have to manually select "save", or just have everything update the state as you go. I'm leaning towards the latter with a single "save" point (to save the graph and all associated data at once), and then having the local state always be up to date.  Open to discussion and opinions on this!  For now, this is being added just to have it work at some level.