### PR TITLE
Removing "print PDF" button from desktop version

### DIFF
--- a/td.vue/src/views/Report.vue
+++ b/td.vue/src/views/Report.vue
@@ -54,12 +54,6 @@
             <b-col class="text-right right">
                 <b-btn-group>
                     <td-form-button
-                        id="td-save-pdf-btn"
-                        :onBtnClick="noOp"
-                        v-if="isElectron"
-                        icon="file-pdf"
-                        :text="$t('forms.savePdf')" />
-                    <td-form-button
                         id="td-print-btn"
                         :onBtnClick="print"
                         icon="print"
@@ -155,7 +149,6 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 
-import env from '@/service/env.js';
 import { getProviderType } from '@/service/provider/providers.js';
 import TdCoversheet from '@/components/report/Coversheet.vue';
 import TdDiagramDetail from '@/components/report/DiagramDetail.vue';
@@ -182,8 +175,7 @@ export default {
                 mitigated: true,
                 diagrams: true,
                 branding: true
-            },
-            isElectron: env.isElectron()
+            }
         };
     },
     computed: {
@@ -202,10 +194,6 @@ export default {
         })
     },
     methods: {
-        noOp() {
-            console.log('TODO');
-            return;
-        },
         onCloseClick() {
             this.$router.push({ name: `${this.providerType}ThreatModel`, params: this.$route.params });
         },

--- a/td.vue/tests/unit/views/report.spec.js
+++ b/td.vue/tests/unit/views/report.spec.js
@@ -105,12 +105,6 @@ describe('views/PrinterReport.vue', () => {
             .toEqual(true);
     });
 
-    it('does nothing with a noop', () => {
-        console.log = jest.fn();
-        wrapper.vm.noOp();
-        expect(console.log).toHaveBeenCalledWith('TODO');
-    });
-
     it('closes the report', () => {
         wrapper.vm.onCloseClick();
         expect(routerMock.push).toHaveBeenCalledWith({


### PR DESCRIPTION
**Summary**
Removes the "Print PDF" button from the Desktop version

**Description for the changelog**
Printing to a PDF is a standard OS feature.  There is no current need for a separate button to print to PDF.
Closes #342 

**Other info**
Tested that Ubuntu, MacOS and Windows all have native "print to pdf" features from the system print dialogue.  This appears to work as expected from the electron wrapper.
