### PR TITLE
disable magnet to allow grab of entire element

### DIFF
--- a/td.vue/src/service/migration/cells.js
+++ b/td.vue/src/service/migration/cells.js
@@ -6,7 +6,7 @@ import shapes from '../x6/shapes/index.js';
 const getCellConverter = () => ({
     'tm.Actor': {
         isNode: true,
-        mapper: nodes.map(shapes.Actor)
+        mapper: nodes.map(shapes.ActorShape)
     },
     'tm.Boundary': {
         isNode: false,
@@ -22,7 +22,7 @@ const getCellConverter = () => ({
     },
     'tm.Store': {
         isNode: true,
-        mapper: nodes.map(shapes.Store)
+        mapper: nodes.map(shapes.StoreShape)
     }
 });
 

--- a/td.vue/src/service/x6/shapes/actor.js
+++ b/td.vue/src/service/x6/shapes/actor.js
@@ -10,7 +10,7 @@ const name = 'actor';
  * Attrs can use standard SVG attributes (in camelCase)
  * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
  */
-export const Actor = Shape.Rect.define({
+export const ActorShape = Shape.Rect.define({
     height: 80,
     width: 150,
     constructorName: name,
@@ -23,19 +23,19 @@ export const Actor = Shape.Rect.define({
     }
 });
 
-Actor.prototype.updateStyle = function(color, dash, strokeWidth) {
+ActorShape.prototype.updateStyle = function(color, dash, strokeWidth) {
     this.setAttrByPath('body/stroke', color);
     this.setAttrByPath('body/strokeWidth', strokeWidth);
     this.setAttrByPath('body/strokeDasharray', dash);
 };
 
-Actor.prototype.type = 'tm.Actor';
+ActorShape.prototype.type = 'tm.Actor';
 
-Actor.prototype.setName = function (name) {
+ActorShape.prototype.setName = function (name) {
     this.label = name;
 };
 
 export default {
-    Actor,
-    name
+    name,
+    ActorShape
 };

--- a/td.vue/src/service/x6/shapes/actor.js
+++ b/td.vue/src/service/x6/shapes/actor.js
@@ -18,7 +18,7 @@ export const ActorShape = Shape.Rect.define({
     label: tc('threatmodel.shapes.actor'),
     attrs: {
         body: {
-            magnet: true
+            magnet: false      //needs to be disabled to grab whole shape
         }
     }
 });

--- a/td.vue/src/service/x6/shapes/index.js
+++ b/td.vue/src/service/x6/shapes/index.js
@@ -1,29 +1,29 @@
 import { Graph } from '@antv/x6';
 
-import { Actor } from './actor.js';
+import { ActorShape } from './actor.js';
 import { Flow } from './flow.js';
 import { FlowStencil } from './flow-stencil.js';
 import { ProcessShape } from './process.js';
-import { Store } from './store.js';
+import { StoreShape } from './store.js';
 import { TextBlock } from './text.js';
 import { TrustBoundaryBox } from './trust-boundary-box.js';
 import { TrustBoundaryCurve } from './trust-boundary-curve.js';
 import { TrustBoundaryCurveStencil } from './trust-boundary-curve-stencil.js';
 
-Graph.registerNode('actor', Actor);
+Graph.registerNode('actor', ActorShape);
 Graph.registerNode('flow', Flow);
 Graph.registerNode('process', ProcessShape);
-Graph.registerNode('store', Store);
+Graph.registerNode('store', StoreShape);
 Graph.registerNode('td-text-block', TextBlock);
 Graph.registerNode('trust-boundary-box', TrustBoundaryBox);
 Graph.registerNode('trust-broundary-curve', TrustBoundaryCurve);
 
 export default {
-    Actor,
+    ActorShape,
     Flow,
     FlowStencil,
     ProcessShape,
-    Store,
+    StoreShape,
     TextBlock,
     TrustBoundaryBox,
     TrustBoundaryCurve,

--- a/td.vue/src/service/x6/shapes/process.js
+++ b/td.vue/src/service/x6/shapes/process.js
@@ -18,7 +18,7 @@ export const ProcessShape = Shape.Circle.define({
     label: tc('threatmodel.shapes.process'),
     attrs: {
         body: {
-            magnet: true
+            magnet: false      //needs to be disabled to grab whole shape
         }
     }
 });

--- a/td.vue/src/service/x6/shapes/store.js
+++ b/td.vue/src/service/x6/shapes/store.js
@@ -39,7 +39,7 @@ export const StoreShape = Shape.Rect.define({
         },
         body: {
             opacity: 0,
-            magnet: true
+            magnet: false      //needs to be disabled to grab whole shape
         }
     },
     label: tc('threatmodel.shapes.store')

--- a/td.vue/src/service/x6/shapes/store.js
+++ b/td.vue/src/service/x6/shapes/store.js
@@ -5,12 +5,12 @@ import { tc } from '@/i18n/index.js';
 const name = 'store';
 
 /**
- * A graphical representation of a store (cylinder, white background)
+ * A graphical representation of a store (parallel lines, white background)
  * https://x6.antv.vision/en/docs/tutorial/intermediate/custom-node
  * Attrs can use standard SVG attributes (in camelCase)
  * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
  */
-export const Store = Shape.Rect.define({
+export const StoreShape = Shape.Rect.define({
     width: 150,
     height: 75,
     constructorName: name,
@@ -45,7 +45,7 @@ export const Store = Shape.Rect.define({
     label: tc('threatmodel.shapes.store')
 });
 
-Store.prototype.updateStyle = function (color, dash, strokeWidth) {
+StoreShape.prototype.updateStyle = function (color, dash, strokeWidth) {
     this.setAttrByPath('topLine/stroke', color);
     this.setAttrByPath('topLine/strokeWidth', strokeWidth);
     this.setAttrByPath('topLine/strokeDasharray', dash);
@@ -54,13 +54,13 @@ Store.prototype.updateStyle = function (color, dash, strokeWidth) {
     this.setAttrByPath('bottomLine/strokeDasharray', dash);
 };
 
-Store.prototype.type = 'tm.Store';
+StoreShape.prototype.type = 'tm.Store';
 
-Store.prototype.setName = function (name) {
+StoreShape.prototype.setName = function (name) {
     this.label = name;
 };
 
 export default {
     name,
-    Store
+    StoreShape
 };

--- a/td.vue/src/service/x6/shapes/text.js
+++ b/td.vue/src/service/x6/shapes/text.js
@@ -12,7 +12,7 @@ export const TextBlock = Shape.Rect.define({
     label: tc('threatmodel.shapes.text'),
     attrs: {
         body: {
-            magnet: true,
+            magnet: false,      //disabled because data flows not allowed to text box
             fillOpacity: 0,
             strokeOpacity: 0
         }

--- a/td.vue/src/service/x6/stencil.js
+++ b/td.vue/src/service/x6/stencil.js
@@ -49,8 +49,8 @@ const get = (target, container) => {
 
     stencil.load([
         new shapes.ProcessShape(),
-        new shapes.Store(),
-        new shapes.Actor(),
+        new shapes.StoreShape(),
+        new shapes.ActorShape(),
         new shapes.FlowStencil()
     ], 'entities');
 

--- a/td.vue/tests/unit/service/migration/cells.spec.js
+++ b/td.vue/tests/unit/service/migration/cells.spec.js
@@ -34,7 +34,7 @@ describe('service/migration/cells.js', () => {
         });
 
         it('calls the nodes mapper', () => {
-            expect(nodes.map).toHaveBeenCalledWith(shapes.Actor);
+            expect(nodes.map).toHaveBeenCalledWith(shapes.ActorShape);
         });
 
         it('adds the data', () => {
@@ -81,7 +81,7 @@ describe('service/migration/cells.js', () => {
         });
 
         it('calls the nodes mapper', () => {
-            expect(nodes.map).toHaveBeenCalledWith(shapes.Actor);
+            expect(nodes.map).toHaveBeenCalledWith(shapes.ActorShape);
         });
 
         it('adds the data', () => {
@@ -96,7 +96,7 @@ describe('service/migration/cells.js', () => {
         });
 
         it('calls the nodes mapper', () => {
-            expect(nodes.map).toHaveBeenCalledWith(shapes.Actor);
+            expect(nodes.map).toHaveBeenCalledWith(shapes.ActorShape);
         });
 
         it('adds the data', () => {

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -153,7 +153,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.convertToEdge = true;
                 cell.isNode.mockImplementation(() => true);
                 cell.constructor = { name: 'Store' };
-                cell.type = shapes.Store.prototype.type;
+                cell.type = shapes.StoreShape.prototype.type;
                 if (cell.data) { delete cell.data; }
                 cell.setData.mockImplementation((data) => cell.data = data);
                 graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));

--- a/td.vue/tests/unit/service/x6/shapes/actor.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/actor.spec.js
@@ -1,10 +1,10 @@
-import { Actor } from '@/service/x6/shapes/actor.js';
+import { ActorShape } from '@/service/x6/shapes/actor.js';
 
 describe('service/x6/shapes/actor.js', () => {
     let victim;
 
     beforeEach(() => {
-        victim = new Actor();
+        victim = new ActorShape();
     });
 
     it('can create the object', () => {

--- a/td.vue/tests/unit/service/x6/shapes/store.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/store.spec.js
@@ -1,10 +1,10 @@
-import store from '@/service/x6/shapes/store.js';
+import { StoreShape }  from '@/service/x6/shapes/store.js';
 
 describe('service/x6/shapes/store.js', () => {
     let victim;
 
     beforeEach(() => {
-        victim = new store.Store();
+        victim = new StoreShape();
     });
 
     it('can create the object', () => {

--- a/td.vue/tests/unit/service/x6/stencil.spec.js
+++ b/td.vue/tests/unit/service/x6/stencil.spec.js
@@ -16,9 +16,9 @@ describe('service/x6/stencil.js', () => {
                 onSearch: search
             };
         });
-        shapes.Actor = jest.fn();
+        shapes.ActorShape = jest.fn();
         shapes.ProcessShape = jest.fn();
-        shapes.Store = jest.fn();
+        shapes.StoreShape = jest.fn();
         shapes.Flow = jest.fn();
         shapes.TrustBoundaryBox = jest.fn();
         shapes.TrustBoundaryCurve = jest.fn();
@@ -86,19 +86,19 @@ describe('service/x6/stencil.js', () => {
         expect(shapes.ProcessShape).toHaveBeenCalledTimes(1);
     });
 
-    it('creates an instance of Actor', () => {
-        expect(shapes.Actor).toHaveBeenCalledTimes(1);
+    it('creates an instance of ActorShape', () => {
+        expect(shapes.ActorShape).toHaveBeenCalledTimes(1);
     });
 
-    it('creates an instance of ProcessShape', () => {
-        expect(shapes.Store).toHaveBeenCalledTimes(1);
+    it('creates an instance of StoreShape', () => {
+        expect(shapes.StoreShape).toHaveBeenCalledTimes(1);
     });
 
     it('loads the entities', () => {
         expect(load).toHaveBeenCalledWith([
             expect.any(shapes.ProcessShape),
-            expect.any(shapes.Store),
-            expect.any(shapes.Actor),
+            expect.any(shapes.StoreShape),
+            expect.any(shapes.ActorShape),
             expect.any(shapes.FlowStencil)
         ], 'entities');
     });


### PR DESCRIPTION
**Summary**
We found that the Actor, Process and Store diagram elements could only be grabbed using the element text, which can be fiddly for short text. If the user missed the grab then a dataflow is created, resulting in some confusion

**Description for the changelog**
disable magnet to allow grab of entire element

**Other info**
We have switched the magnets off for now. This means that data flows can only be created by dragging across from the palette. We need to fix this, so will raise an issue for that
