### PR TITLE
add rubberbanding alongside panning

### DIFF
--- a/td.vue/src/components/KeyboardShortcuts.vue
+++ b/td.vue/src/components/KeyboardShortcuts.vue
@@ -39,6 +39,10 @@ export default {
                     action: this.$t('threatmodel.shortcuts.delete.action')
                 },
                 {
+                    shortcut: this.$t('threatmodel.shortcuts.pan.shortcut'),
+                    action: this.$t('threatmodel.shortcuts.pan.action')
+                },
+                {
                     shortcut: this.$t('threatmodel.shortcuts.multiSelect.shortcut'),
                     action: this.$t('threatmodel.shortcuts.multiSelect.action')
                 },

--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -45,8 +45,21 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
     },
     selecting: {
         enabled: true,
+        pointerEvents: 'auto',
+        rubberband: true,
+        rubberNode: true,
+        rubberEdge: true,
+        multiple: true,
+        movable: true,
+        strict: true, // need strict select otherwise data flows select other elements
+        useCellGeometry: false, // disabled, otherwise multi-select does weird stuff
         showNodeSelectionBox: false,
-        showEdgeSelectionBox: true
+        showEdgeSelectionBox: false,
+        selectNodeOnMoved: false,
+        selectEdgeOnMoved: false,
+        selectCellOnMoved: false,
+        content: null,
+        handles: null
     },
     resizing: {
         enabled: true,
@@ -66,7 +79,7 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
         modifiers: ['ctrl', 'meta']
     },
     panning: {
-        enabled: true,
+        enabled: true, // provides panning, disable scroller.pannable below
         modifiers: ['shift']
     },
     connecting: {
@@ -76,7 +89,7 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
     scroller: {
         enabled: true,
         autoResize: true,
-        pannable: true,
+        pannable: false, // disable because it interferes with rubberbanding, see panning above
         pageVisible: true,
         pageBreak: true
     }

--- a/td.vue/tests/unit/service/x6/graph/graph.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/graph.spec.js
@@ -121,8 +121,21 @@ describe('service/x6/graph/graph.js', () => {
         it('enables selecting', () => {
             expect(graphRes.selecting).toEqual({
                 enabled: true,
+                pointerEvents: 'auto',
+                rubberband: true,
+                rubberNode: true,
+                rubberEdge: true,
+                multiple: true,
+                movable: true,
+                strict: true,
+                useCellGeometry: false,
                 showNodeSelectionBox: false,
-                showEdgeSelectionBox: true
+                showEdgeSelectionBox: false,
+                selectNodeOnMoved: false,
+                selectEdgeOnMoved: false,
+                selectCellOnMoved: false,
+                content: null,
+                handles: null
             });
         });
 
@@ -167,7 +180,7 @@ describe('service/x6/graph/graph.js', () => {
             expect(graphRes.scroller).toEqual({
                 enabled: true,
                 autoResize: true,
-                pannable: true,
+                pannable: false,
                 pageVisible: true,
                 pageBreak: true
             });


### PR DESCRIPTION
**Summary**
it is difficult to select a process diagram element and it can not be deleted using the 'red cross'. Once selected the trashcan icon can be used or the delete key

**Description for the changelog**
rubberbanding is useful for selecting multiple components and also deleting them. This allows easier selection of diagram elements

**Other info**
panning was initially interfering with rubberbanding, but we now have both
