### PR TITLE
version added to nav bar

### DIFF
--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -2,6 +2,7 @@
   "name": "threat-dragon-frontend",
   "productName": "Threat Dragon",
   "version": "2.0.0",
+  "build": " (development)",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -2,7 +2,7 @@
   <b-navbar toggleable="lg" fixed="top" id="navbar">
     <b-navbar-brand :to="username ? '/dashboard' : '/'" class="td-brand">
       <b-img src="@/assets/threatdragon_logo_image.svg" class="td-brand-img" alt="Threat Dragon Logo" />
-      Threat Dragon v{{this.$store.state.packageVersion}}
+      Threat Dragon v{{this.$store.state.packageVersion}}{{this.$store.state.packageBuild}}
     </b-navbar-brand>
 
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>

--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -2,7 +2,7 @@
   <b-navbar toggleable="lg" fixed="top" id="navbar">
     <b-navbar-brand :to="username ? '/dashboard' : '/'" class="td-brand">
       <b-img src="@/assets/threatdragon_logo_image.svg" class="td-brand-img" alt="Threat Dragon Logo" />
-      Threat Dragon
+      Threat Dragon v{{this.$store.state.packageVersion}}
     </b-navbar-brand>
 
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>

--- a/td.vue/src/store/index.js
+++ b/td.vue/src/store/index.js
@@ -12,11 +12,17 @@ import threatmodel from './modules/threatmodel.js';
 import vuexPersist from '../plugins/vuex-persist.js';
 
 let store = null;
+const version = require('../../package.json').version;
+const build = require('../../package.json').build;
 
 const get = () => {
     if (store === null) {
         Vue.use(Vuex);
         store = new Vuex.Store({
+            state: {
+                packageVersion: version,
+                packageBuild: build
+            },
             modules: {
                 auth,
                 branch,


### PR DESCRIPTION
**Summary**
As described by @jeronomy in issue 'v2-Info Versioning' #408, we need to display the version number info in the main screen/page of the app

**Description for the changelog**
version added to nav bar for both web app and desktop app. The about box in desktop drop down menu shows the version as well (but only for desktop app)

**Other info**
attached screenshot shows what this does:
<img width="1367" alt="version-in-threat-dragon-nav-bar" src="https://user-images.githubusercontent.com/29352392/163381183-54c50e5c-87ef-458b-b1d5-a028e8f3b134.png">

