### PR TITLE
Adding Incident Page to Docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       jekyll (~> 4.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -76,4 +76,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.32
+   2.3.11

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,6 @@ The theme provides the header bar for the documentation site (such as flask, clo
 * Install jekyll, webrick etc: `bundle update`
 * Run the docs server: `bundle exec jekyll serve`
 * Navigate in a browser to server address: http://127.0.0.1:4000/
+
+
+If you do not already have Ruby installed, see [Jekyll's Guide](https://jekyllrb.com/docs/installation/)

--- a/docs/home/trust/incidents.md
+++ b/docs/home/trust/incidents.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Incidents
+nav_order: 5
+path: /security/Incidents
+group: Trust
+---
+
+# Incident Response
+Threat Dragon maintains a [Demo Instance](https://www.threatdragon.com/) that is hosted on [Heroku](https://www.heroku.com/).  We strongly recommend using a self-hosted instance or the desktop application as the most secure options. Threat Dragon can authenticate to GitHub repositories using a GitHub OAuth application as noted in the [environment setup](development/env) page.  
+
+Threat Dragon is open source software and contains many other open source components.  Threat Dragon's community strives to stay abreast of security vulnerabilities and incidents impacting upstream providers or Threat Dragon itself.  If there is a high impact or high profile incident or vulnerability, the Threat Dragon community/maintainers will create a [GitHub Issue](https://www.github.com/owasp/threat-dragon/issues) and leave it pinned for as long as it is relevant to the community.  This issue will have the "security" tag, and is intended to serve as a transparency report, not necessarially a real-time feed of incident response. 
+
+Because Threat Dragon is maintained by a community of volunteers, it will not always be possible to immediately investigate or respond to incidents immediately.  Please only report security vulnerabilities found within Threat Dragon by following the process in the [Security Policy](https://github.com/OWASP/threat-dragon/blob/main/SECURITY.md).  Every effort will be made to resolve security concerns as they arise.

--- a/docs/usage/install/web.md
+++ b/docs/usage/install/web.md
@@ -31,7 +31,7 @@ To install use pnpm (rather than npm):
 
 ### Environment variables
 
-See the (environment)[development/env] page for details on configuring your environment variables.
+See the [environment](development/env) page for details on configuring your environment variables.
 
 ### Running the application
 


### PR DESCRIPTION
**Summary**
What does Threat Dragon do when we are impacted by a security incident?

**Description for the changelog**
closes #419 

**Other info**
Updated gems, fixed link that had incorrect syntax, added jekyll installation instructions to readme.
