### PR TITLE
Fix typo in logger service name settings

### DIFF
--- a/td.server/src/helpers/logger.helper.js
+++ b/td.server/src/helpers/logger.helper.js
@@ -28,7 +28,7 @@ const _logger = winston.createLogger({
         format.splat(),
         format.json()
     ),
-    defaultMeta: { service: 'threat-drgaon' },
+    defaultMeta: { service: 'threat-dragon' },
     transports: [
         new transports.File({
             filename: 'audit.log',


### PR DESCRIPTION
**Summary**
Just noticed the typo in the logs while running the service

**Description for the changelog**
threat-drgaon => threat-dragon in logger service name settings

**Other info**
Note that the same typo exists in `main` and `v2-development` branches