### PR TITLE
move to node 18 for github workflows

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2

--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -146,10 +146,10 @@ jobs:
             -e SERVER_API_PROTOCOL='http' \
             ${{ env.image_name }}
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -199,10 +199,10 @@ jobs:
             -e SERVER_API_PROTOCOL='http' \
             ${{ env.image_name }}
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -146,10 +146,10 @@ jobs:
             -e SERVER_API_PROTOCOL='http' \
             ${{ env.image_name }}
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2
@@ -199,10 +199,10 @@ jobs:
             -e SERVER_API_PROTOCOL='http' \
             ${{ env.image_name }}
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,10 +84,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '18'
 
       - name: Cache NPM dir
         uses: actions/cache@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,10 +84,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 16.14.0
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v2
         with:
-          node-version: '16.14.0'
+          node-version: '17'
 
       - name: Cache NPM dir
         uses: actions/cache@v2


### PR DESCRIPTION
**Summary**
There is [a known bug in npm](https://github.com/nodejs/node/issues/42397) versions 16.14.1 and 16.14.2. The github workflows were fixed at node version 16.14.0 until a fix was in place. Node 18.2.0 is now released and stable, so moving to that version instead

**Description for the changelog**
move to node 18 for github workflows

**Other info**
This reverts the change that temporarily fixed the node version to 16.14.0 in commit 82c9d49d2d3a315650a7aed7e1b3a3308a7b44a7
