### PR TITLE
Rate limiting only for production environments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ The theme provides the header bar for the documentation site (such as flask, clo
 
 ### Running Locally
 * From a terminal navigate to this `docs` directory
-* Install/update bundle: `pnpm add -g bundle`
+* Install/update bundle: `npm add --location=global bundle`
 * Install jekyll, webrick etc: `bundle update`
 * Run the docs server: `bundle exec jekyll serve`
 * Navigate in a browser to server address: http://127.0.0.1:4000/

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -34,7 +34,12 @@ const create = () => {
 
         const app = expressHelper.getInstance();
         app.set('trust proxy', true);
-        app.use(limiter);
+        // rate limiting only for production environemnts, otherwise automated e2e tests fail
+        if (process.env.NODE_ENV === 'production') {
+            app.use(limiter);
+        } else {
+            logger.warn('Rate limiting only when running in production environments');
+        }
 
         //security headers
         securityHeaders.config(app);


### PR DESCRIPTION
**Summary**
Rate limiting is stopping some automated end-to-end tests to fail
Provide rate limiting only when running in production environments

**Description for the changelog**
rate limiting only for production environments

**Other info**

