### PR TITLE
no rate-limiting for test environments

### DIFF
--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -15,10 +15,10 @@ import { upDir } from './helpers/path.helper.js';
 const siteDir = path.join(__dirname, upDir, upDir, 'dist');
 const docsDir = path.join(__dirname, upDir, upDir, 'docs');
 
-// set up rate limiter: maximum of 100 requests per 15 minutes
+// set up rate limiter: maximum of 300 requests per 15 minutes
 const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    max: 300,
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 });
@@ -35,10 +35,10 @@ const create = () => {
         const app = expressHelper.getInstance();
         app.set('trust proxy', true);
         // rate limiting only for production environemnts, otherwise automated e2e tests fail
-        if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV !== 'development') {
             app.use(limiter);
         } else {
-            logger.warn('Rate limiting disabled for test environments');
+            logger.warn('Rate limiting disabled for development environments');
         }
 
         //security headers

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -35,7 +35,7 @@ const create = () => {
         const app = expressHelper.getInstance();
         app.set('trust proxy', true);
         // rate limiting only for production environemnts, otherwise automated e2e tests fail
-        if (process.env.NODE_ENV !== ‘test’) {
+        if (process.env.NODE_ENV !== 'test') {
             app.use(limiter);
         } else {
             logger.warn('Rate limiting disabled for test environments');

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -35,7 +35,7 @@ const create = () => {
         const app = expressHelper.getInstance();
         app.set('trust proxy', true);
         // rate limiting only for production environemnts, otherwise automated e2e tests fail
-        if (process.env.NODE_ENV !== 'test') {
+        if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'development') {
             app.use(limiter);
         } else {
             logger.warn('Rate limiting disabled for test environments');

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -35,10 +35,10 @@ const create = () => {
         const app = expressHelper.getInstance();
         app.set('trust proxy', true);
         // rate limiting only for production environemnts, otherwise automated e2e tests fail
-        if (process.env.NODE_ENV === 'production') {
+        if (process.env.NODE_ENV !== ‘test’) {
             app.use(limiter);
         } else {
-            logger.warn('Rate limiting only when running in production environments');
+            logger.warn('Rate limiting disabled for test environments');
         }
 
         //security headers


### PR DESCRIPTION
**Summary**
This reapplies the rate limiting if process.env.NODE_ENV 'development' is used, so rate limiting is only disabled if process.env.NODE_ENV === 'test'

**Description for the changelog**
no rate-limiting for test environments

**Other info**

