### PR TITLE
Fix some multi line issues

### DIFF
--- a/td.vue/src/components/printed-report/ExecutiveSummary.vue
+++ b/td.vue/src/components/printed-report/ExecutiveSummary.vue
@@ -51,6 +51,7 @@
 .page {
     display: flex;
     flex-direction: column;
+    white-space: pre-wrap;
 }
 </style>
 

--- a/td.vue/src/components/printed-report/ReportEntity.vue
+++ b/td.vue/src/components/printed-report/ReportEntity.vue
@@ -35,6 +35,7 @@
 .report-box {
     display: flex;
     flex-direction: column;
+    white-space: pre-wrap;
 }
 
 .entity-title {
@@ -46,6 +47,7 @@
 
 .entity-description {
     padding: 15px;
+    white-space: pre-wrap;
 }
 </style>
 

--- a/td.vue/src/components/report/ReportEntity.vue
+++ b/td.vue/src/components/report/ReportEntity.vue
@@ -29,6 +29,7 @@
 <style lang="scss" scoped>
 .td-threat-data {
     width: 99%;
+    white-space: pre-wrap;
 }
 </style>
 


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
This fixes some multi line display issues like as follows:
1. When you review the report, `mitigations` inside of table don't support multi-line.
2. When you print the analyzed report out , `High level system description` and table under the diagram don't support it.

It's related with https://github.com/OWASP/threat-dragon/issues/468

**Description for the changelog**
<!--
A short (one line) summary that describes the changes in this
pull request for inclusion in the change log
If this is a bug fix, your description sahould include "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number
-->
I added CSS for the issue to fix.

**Other info**
<!--
Thanks for submitting a pull request!
Please make sure you read our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
