### PR TITLE
always allow logout using GET

### DIFF
--- a/td.server/src/config/routes.config.js
+++ b/td.server/src/config/routes.config.js
@@ -17,9 +17,9 @@ const unauthRoutes = (router) => {
     router.get('/healthz', healthcheck.healthz);
 
     router.get('/api/login/:provider', auth.login);
+    router.get('/api/logout', auth.logout);
     router.get('/api/oauth/return', auth.oauthReturn);
     router.get('/api/oauth/:provider', auth.completeLogin);
-    router.post('/api/token/refresh', auth.refresh);
 };
 
 /**
@@ -30,12 +30,15 @@ const unauthRoutes = (router) => {
  */
 const routes = (router) => {
     router.post('/api/logout', auth.logout);
+    router.post('/api/token/refresh', auth.refresh);
+
     router.get('/api/threatmodel/repos', threatmodelController.repos);
     router.get('/api/threatmodel/:organisation/:repo/branches', threatmodelController.branches);
     router.get('/api/threatmodel/:organisation/:repo/:branch/models', threatmodelController.models);
     router.get('/api/threatmodel/:organisation/:repo/:branch/:model/data', threatmodelController.model);
-    
+
     router.delete('/api/threatmodel/:organisation/:repo/:branch/:model', threatmodelController.deleteModel);
+
     router.put('/api/threatmodel/:organisation/:repo/:branch/:model/create', threatmodelController.create);
     router.put('/api/threatmodel/:organisation/:repo/:branch/:model/update', threatmodelController.update);
 };
@@ -44,6 +47,7 @@ const config = (app) => {
     const router = express.Router();
     unauthRoutes(router);
 
+    // routes protected by authorization
     router.use(bearer.middleware);
     routes(router);
 

--- a/td.server/src/controllers/auth.js
+++ b/td.server/src/controllers/auth.js
@@ -59,13 +59,12 @@ const logout = (req, res) => responseWrapper.sendResponse(() => {
     try {
         const refreshToken = req.body.refreshToken;
         if (!refreshToken) {
-            logger.audit('Attempting to log out without a refresh token');
-            // Return OK even though it's not really ok
-            // If this happens, it could be a client error, or it could be
-            // something more nefarious. 
+            logger.audit('Log out without a refresh token');
+            // Return OK, it could be a client error or an expired token 
             return '';
         }
 
+        logger.debug('Remove refresh token');
         tokenRepo.remove(refreshToken);
         return '';
     } catch (e) {

--- a/td.server/src/controllers/homecontroller.js
+++ b/td.server/src/controllers/homecontroller.js
@@ -1,25 +1,12 @@
+// index page
+
 import loggerHelper from '../helpers/logger.helper.js';
-import path from 'path';
 
 const logger = loggerHelper.get('controllers/homecontroller.js');
 
-import { upDir } from '../helpers/path.helper.js';
-
-/**
- * The path to the index.html file
- * @type {String}
- */
-const indexHtmlPath = path.join(__dirname, upDir, upDir, upDir, 'dist', 'index.html');
-
-/**
- * Serves the index.html page for the SPA
- * @param {Object} req
- * @param {Object} res
- * @returns {Object}
- */
 const index = (req, res) => {
-    logger.debug('API index request, sendFile ' + indexHtmlPath);
-    res.sendFile(indexHtmlPath);
+    logger.debug('index request');
+    res.send('Threat Dragon back-end server');
 };
 
 

--- a/td.server/test/controllers/homecontroller.spec.js
+++ b/td.server/test/controllers/homecontroller.spec.js
@@ -24,8 +24,8 @@ describe('homecontroller tests', () => {
             homeController.index(mockRequest, mockResponse);
         });
 
-        it('should send the home page file', () => {
-            expect(mockResponse.sendFile).to.have.been.calledWith(sinon.match(/index\.html$/));
+        it('should send the home page', () => {
+            expect(mockResponse.send).to.have.been.calledOnce;
         });
     });
 });


### PR DESCRIPTION
**Summary**
Allow logout for unauthenticated / expired sessions

**Description for the changelog**
allow logout without authorisation

**Other info**
POST, PUT and DELETE will always require authentication
logout using GET will now succeed