### PR TITLE
add cancel button for new threat

### DIFF
--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -78,7 +78,7 @@ export default {
             stencil.get(this.graph, this.$refs.stencil_container);
         },
         threatSelected(threatId) {
-            this.$refs.threatEditModal.show(threatId);
+            this.$refs.threatEditModal.showModal(threatId);
         },
         saved() {
             const updated = Object.assign({}, this.diagram);

--- a/td.vue/src/components/ThreatEditModal.vue
+++ b/td.vue/src/components/ThreatEditModal.vue
@@ -108,7 +108,7 @@
             <template #modal-footer>
                 <div class="w-100">
                 <b-button
-                    v-show=!newThreat
+                    v-if="!newThreat"
                     variant="danger"
                     class="float-left"
                     @click="confirmDelete()"
@@ -116,12 +116,12 @@
                     {{ $t('forms.delete') }}
                 </b-button>
                 <b-button
-                    v-show=newThreat
+                    v-if="newThreat"
                     variant="danger"
                     class="float-left"
                     @click="immediateDelete()"
                 >
-                    {{ $t('forms.cancel') }}
+                    {{ $t('forms.remove') }}
                 </b-button>
                  <b-button
                     variant="secondary"
@@ -131,7 +131,7 @@
                     {{ $t('forms.apply') }}
                 </b-button>
                 <b-button
-                    v-show=!newThreat
+                    v-if="!newThreat"
                     variant="secondary"
                     class="float-right"
                     @click="hideModal()"
@@ -204,9 +204,10 @@ export default {
             } else {
                 this.$refs.editModal.show();
             }
+            this.newThreat = this.threat.new;
         },
         updateThreat() {
-            const threatRef = this.cellRef.data.threats.find(x => x.id === this.threat.id);
+            const threatRef = this.threat;
 
             if (threatRef) {
                 threatRef.status = this.threat.status;
@@ -216,6 +217,7 @@ export default {
                 threatRef.description = this.threat.description;
                 threatRef.mitigation = this.threat.mitigation;
                 threatRef.modelType = this.threat.modelType;
+                threatRef.new = false;
                 
                 this.$store.dispatch(CELL_DATA_UPDATED, this.cellRef.data);
                 dataChanged.updateStyleAttrs(this.cellRef);
@@ -229,7 +231,6 @@ export default {
             dataChanged.updateStyleAttrs(this.cellRef);
         },
         hideModal() {
-            this.newThreat = false;
             this.$refs.editModal.hide();
         },
         async confirmDelete() {

--- a/td.vue/src/service/threats/index.js
+++ b/td.vue/src/service/threats/index.js
@@ -61,7 +61,8 @@ export const createNewTypedThreat = function(modelType, cellType) {
         type: type,
         description: tc('threats.description'),
         mitigation: tc('threats.mitigation'),
-        modelType: modelType
+        modelType: modelType,
+        new: true
     };
 };
 

--- a/td.vue/tests/unit/components/graph.spec.js
+++ b/td.vue/tests/unit/components/graph.spec.js
@@ -32,7 +32,7 @@ describe('components/GraphButtons.vue', () => {
         threatEditStub = {
             render: jest.fn(),
             methods: {
-                show: jest.fn()
+                showModal: jest.fn()
             }
         };
 
@@ -112,7 +112,7 @@ describe('components/GraphButtons.vue', () => {
 
     it('shows the threat edit modal', () => {
         wrapper.vm.threatSelected('asdf');
-        expect(threatEditStub.methods.show).toHaveBeenCalledWith('asdf');
+        expect(threatEditStub.methods.showModal).toHaveBeenCalledWith('asdf');
     });
 
     it('saves the threat model diagram', () => {

--- a/td.vue/tests/unit/components/threatEditModal.spec.js
+++ b/td.vue/tests/unit/components/threatEditModal.spec.js
@@ -17,6 +17,7 @@ describe('components/ThreatEditModal.vue', () => {
         type: 'Information Disclosure',
         mitigation: 'we will mitigate it eventually',
         modelType: 'CIA',
+        new: false,
         id: threatId
     });
 

--- a/td.vue/tests/unit/components/threatEditModal.spec.js
+++ b/td.vue/tests/unit/components/threatEditModal.spec.js
@@ -47,7 +47,7 @@ describe('components/ThreatEditModal.vue', () => {
             modal = wrapper.findComponent(BModal);
             wrapper.vm.$refs.editModal.show = jest.fn();
             wrapper.vm.$refs.editModal.hide = jest.fn();
-            wrapper.vm.show(getThreatData().id);
+            wrapper.vm.showModal(getThreatData().id);
         });
 
         it('has a bootstrap modal', () => {
@@ -139,7 +139,7 @@ describe('components/ThreatEditModal.vue', () => {
                 dataChanged.updateStyleAttrs = jest.fn();
                 mockStore.dispatch = jest.fn();
                 wrapper.vm.$refs.editModal.show = jest.fn();
-                await wrapper.vm.show(threatId);
+                await wrapper.vm.showModal(threatId);
                 await wrapper.vm.confirmDelete();
             }); 
 
@@ -161,14 +161,15 @@ describe('components/ThreatEditModal.vue', () => {
         });
     });
 
-    describe('updateData', () => {
+    describe('updateThreat', () => {
         beforeEach(() => {
             wrapper = getWrapper();
             wrapper.vm.$refs.editModal.show = jest.fn();
+            wrapper.vm.$refs.editModal.hide = jest.fn();
             mockStore.dispatch = jest.fn();
             dataChanged.updateStyleAttrs = jest.fn();
-            wrapper.vm.show(threatId);
-            wrapper.vm.updateData();
+            wrapper.vm.showModal(threatId);
+            wrapper.vm.updateThreat();
         });
 
         it('updates the data', () => {


### PR DESCRIPTION
**Summary**
It would be good to have a 'Cancel' button for new threats, so that it is a one click delete rather than the confirm dialog box for the normal 'Delete'

**Description for the changelog**
Add a new button 'Cancel' if it is a new threat, not an existing threat

**Other info**

