### PR TITLE
revert name change for threat model version

### DIFF
--- a/td.server/test/controllers/threatmodelcontroller.spec.js
+++ b/td.server/test/controllers/threatmodelcontroller.spec.js
@@ -21,7 +21,7 @@ describe('controllers/threatmodelcontroller.js threat model', () => {
                 organisation: 'test org',
                 repo: 'test repo',
                 branch: 'test branch',
-                model: { tdVersion: '2.0' }
+                model: { version: '2.0' }
             },
             query: {
                 page: 'test page'

--- a/td.vue/src/service/demo/v2-threat-model.js
+++ b/td.vue/src/service/demo/v2-threat-model.js
@@ -1107,7 +1107,7 @@ export default {
                         ]
                     }
                 ],
-                'tdVersion': '2.0',
+                'version': '2.0',
                 'title': 'Main Request Data Flow',
                 'thumbnail': './public/content/images/thumbnail.stride.jpg',
                 'diagramType': 'STRIDE',
@@ -1116,5 +1116,5 @@ export default {
         ],
         'reviewer': 'Jane Smith'
     },
-    'tdVersion': '2.0'
+    'version': '2.0'
 };

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -21,14 +21,14 @@ const drawV1 = (diagram, graph) => {
 };
 
 const upgradeAndDraw = (diagram, graph) => {
-    if (diagram.tdVersion === '2.0') {
+    if (diagram.version === '2.0') {
         graph.fromJSON(diagram);
         return;
     }
 
     drawV1(diagram, graph);
     const updated = graph.toJSON();
-    updated.tdVersion = '2.0';
+    updated.version = '2.0';
     updated.title = diagram.title;
     updated.thumbnail = diagram.thumbnail;
     updated.id = diagram.id;

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -120,7 +120,7 @@ const mutations = {
 
         // TODO: This does NOT belong here, but is a placeholder until update/save are implemented
         // https://github.com/OWASP/threat-dragon/issues/340
-        Vue.set(state.data, 'tdVersion', '2.0');
+        Vue.set(state.data, 'version', '2.0');
     },
     [THREATMODEL_FETCH]: (state, threatModel) => setThreatModel(state, threatModel),
     [THREATMODEL_FETCH_ALL]: (state, models) => {
@@ -147,7 +147,7 @@ const getters = {
         return contribs.map(x => x.name);
     },
     modelChanged: (state) => JSON.stringify(state.data) !== state.immutableCopy,
-    isV1Model: (state) => Object.keys(state.data).length > 0 && state.data.tdVersion !== '2.0'
+    isV1Model: (state) => Object.keys(state.data).length > 0 && state.data.version !== '2.0'
 };
 
 export default {

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -16,7 +16,7 @@ export default {
     mounted() {
         this.$store.dispatch(tmActions.clear);
         const newTm = {
-            tdVersion: '2.0',
+            version: '2.0',
             summary: {
                 title: 'New Threat Model',
                 owner: '',

--- a/td.vue/tests/e2e/specs/data/demo.js
+++ b/td.vue/tests/e2e/specs/data/demo.js
@@ -1108,7 +1108,7 @@ export default `
             ]
           }
         ],
-        "tdVersion": "2.0",
+        "version": "2.0",
         "title": "Main Request Data Flow",
         "thumbnail": "./public/content/images/thumbnail.jpg",
         "id": 0
@@ -1116,5 +1116,5 @@ export default `
     ],
     "reviewer": "Jane Smith"
   },
-  "tdVersion": "2.0"
+  "version": "2.0"
 }`;

--- a/td.vue/tests/unit/service/migration/diagram.spec.js
+++ b/td.vue/tests/unit/service/migration/diagram.spec.js
@@ -82,7 +82,7 @@ describe('service/migration/diagram.js', () => {
 
         describe('v2', () => {
             beforeEach(() => {
-                diagramMock.tdVersion = '2.0';
+                diagramMock.version = '2.0';
                 diagram.draw(null, diagramMock);
             });
 
@@ -94,7 +94,7 @@ describe('service/migration/diagram.js', () => {
 
     describe('edit', () => {
         beforeEach(() => {
-            diagramMock.tdVersion = '2.0';
+            diagramMock.version = '2.0';
             diagram.edit(null, diagramMock);
         });
 

--- a/td.vue/tests/unit/store/modules/threatmodel.spec.js
+++ b/td.vue/tests/unit/store/modules/threatmodel.spec.js
@@ -457,7 +457,7 @@ describe('store/modules/threatmodel.js', () => {
             });
 
             it('returns false when the version is set to 2.0', () => {
-                const state = { data: { tdVersion: '2.0' }};
+                const state = { data: { version: '2.0' }};
                 expect(threatmodelModule.getters.isV1Model(state)).toEqual(false);
             });
 


### PR DESCRIPTION
**Summary**
The change to 'tdVersion' from 'version' breaks stuff - so revert it back to 'version'

**Description for the changelog**
revert name change for threat model version

**Other info**

