### PR TITLE
disable new threat button and enable reason text if out of scope

### DIFF
--- a/td.vue/src/components/GraphMeta.vue
+++ b/td.vue/src/components/GraphMeta.vue
@@ -13,6 +13,7 @@
                     {{ $t('threatmodel.threats') }}
 
                     <b-btn
+                        :disabled="disableNewThreat"
                         @click="newThreat()"
                         v-if="!!cellRef"
                         variant="primary"
@@ -86,7 +87,10 @@ export default {
     computed: mapState({
         cellRef: (state) => state.cell.ref,
         threats: (state) => state.cell.threats,
-        diagram: (state) => state.threatmodel.selectedDiagram
+        diagram: (state) => state.threatmodel.selectedDiagram,
+        disableNewThreat: function (state) {
+            return state.cell.ref.data.outOfScope || state.cell.ref.data.isTrustBoundary || state.cell.ref.data.type === 'tm.Text';
+        }
     }),
     components: {
         TdGraphProperties,

--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -83,6 +83,7 @@
                         :label="$t('threatmodel.properties.reasonOutOfScope')"
                         label-for="reasonoutofscope">
                         <b-form-textarea
+                            :disabled="inScope"
                             id="reasonoutofscope"
                             v-model="cellRef.data.reasonOutOfScope"
                         ></b-form-textarea>
@@ -214,7 +215,8 @@ import { mapState } from 'vuex';
 export default {
     name: 'TdGraphProperties',
     computed: mapState({
-        cellRef: (state) => state.cell.ref
+        cellRef: (state) => state.cell.ref,
+        inScope: (state) => !state.cell.ref.data.outOfScope,
     })
 };
 </script>


### PR DESCRIPTION
**Summary**
Disables 'New Threat' button if diagram component is out of scope, and disables Reason text box if in scope

**Description for the changelog**
disable new threat button and enable reason text if out of scope

**Other info**
