### PR TITLE
Trust Boundary box to background and default Data Flow label

### DIFF
--- a/td.vue/src/service/entity/default-properties.js
+++ b/td.vue/src/service/entity/default-properties.js
@@ -25,7 +25,7 @@ const boundaryBox = {
 
 const flow = {
     type: 'tm.Flow',
-    name: '',
+    name: 'Data Flow',
     description: '',
     outOfScope: false,
     reasonOutOfScope: '',

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -59,6 +59,10 @@ const cellAdded = (graph) => ({ cell }) => {
     }
 
     removeCellTools({ cell });
+    // boundary boxes must not overlap other diagram components
+    if (cell.shape === 'trust-boundary-box') {
+        cell.zIndex = -1;
+    }
 
     dataChanged.updateStyleAttrs(cell);
     if (!cell.data) {

--- a/td.vue/tests/unit/entity/default-properties.spec.js
+++ b/td.vue/tests/unit/entity/default-properties.spec.js
@@ -76,8 +76,8 @@ describe('service/entity/default-properties.js', () => {
             expect(defaultProperties.flow.type).toEqual('tm.Flow');
         });
 
-        it('has a blank name', () => {
-            expect(defaultProperties.flow.name).toEqual('');
+        it('has a name', () => {
+            expect(defaultProperties.flow.name).toEqual('Data Flow');
         });
 
         it('has a blank description', () => {


### PR DESCRIPTION
**Summary**
This provides a default label for Data Flows and ensures that Trust Boundary Boxes are in the background

**Description for the changelog**
Trust Boundary box to background and default Data Flow label

**Other info**
