### PR TITLE
move delete button away from commonly used ones

### DIFF
--- a/td.vue/src/components/GraphButtons.vue
+++ b/td.vue/src/components/GraphButtons.vue
@@ -1,6 +1,12 @@
 <template>
     <b-btn-group>
         <td-form-button
+            :onBtnClick="deleteSelected"
+            icon="trash"
+            :title="$t('threatmodel.buttons.delete')"
+            text="" />
+
+        <td-form-button
             :onBtnClick="noOp"
             v-b-modal.shortcuts
             icon="keyboard"
@@ -29,12 +35,6 @@
             :onBtnClick="zoomOut"
             icon="search-minus"
             :title="$t('threatmodel.buttons.zoomOut')"
-            text="" />
-
-        <td-form-button
-            :onBtnClick="deleteSelected"
-            icon="trash"
-            :title="$t('forms.delete')"
             text="" />
 
         <td-form-button

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -124,12 +124,13 @@ const en = {
             publicNetwork: 'Public Network'
         },
         buttons: {
-            shortcuts: 'Keyboard Shortcuts',
-            undo: 'Undo',
-            redo: 'Redo',
-            zoomIn: 'Zoom In',
-            zoomOut: 'Zoom Out',
-            toggleGrid: 'Toggle Grid'
+            delete: 'Delete selected',
+            redo: 'Redo edit',
+            shortcuts: 'Keyboard shortcuts',
+            toggleGrid: 'Toggle grid',
+            undo: 'Undo edit',
+            zoomIn: 'Zoom in',
+            zoomOut: 'Zoom out'
         },
         shortcuts: {
             title: 'Shortcuts',


### PR DESCRIPTION
**Summary**
Move the delete button away from the commonly used buttons, rely on redo/undo instead of a delete confirmation modal

**Description for the changelog**
move delete button away from commonly used ones

**Other info**

