### PR TITLE
preparation for desktop save of models

### DIFF
--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -49,6 +49,7 @@ import TdThreatEditModal from '@/components/ThreatEditModal.vue';
 
 import { getProviderType } from '@/service/provider/providers.js';
 import diagramService from '@/service/migration/diagram.js';
+import env from '@/service/env.js';
 import stencil from '@/service/x6/stencil.js';
 import tmActions from '@/store/actions/threatmodel.js';
 
@@ -84,7 +85,14 @@ export default {
             const updated = Object.assign({}, this.diagram);
             updated.cells = this.graph.toJSON().cells;
             this.$store.dispatch(tmActions.diagramUpdated, updated);
-            this.$store.dispatch(tmActions.save);
+            if (env.isElectron()) {
+                // desktop version always saves locally
+                console.warn('Save for desktop version is not yet implemented');
+                this.$toast.warning(this.$t('threatmodel.errors.save'));
+            } else {
+                // web app version saves to repo or as a download file
+                this.$store.dispatch(tmActions.save);
+            }
         },
         async closed() {
             const diagramChanged = JSON.stringify(this.graph.toJSON().cells) !== JSON.stringify(this.diagram.cells);

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -62,7 +62,7 @@ export default {
     },
     computed: mapState({
         diagram: (state) => state.threatmodel.selectedDiagram,
-        providerType: state => getProviderType(state.provider.selected)
+        providerType: (state) => getProviderType(state.provider.selected)
     }),
     data() {
         return {

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -40,14 +40,6 @@ const setThreatModel = (theState, threatModel) => {
     theState.immutableCopy = JSON.stringify(threatModel);
 };
 
-const pickerFileOptions = {
-    suggestedName: 'new-model.json',
-    types: [
-        { description: 'Threat models', accept: { 'text/*': ['.json'] } }
-    ],
-    multiple: false
-};
-
 const actions = {
     [THREATMODEL_CLEAR]: ({ commit }) => commit(THREATMODEL_CLEAR),
     [THREATMODEL_CREATE]: ({ commit }, threatModel) => commit(THREATMODEL_CREATE, threatModel),
@@ -98,47 +90,6 @@ const actions = {
                     state.data
                 );
                 Vue.$toast.success(i18n.get().t('threatmodel.saved'));
-            } else if ('showSaveFilePicker' in window) {
-                let fileHandle = state.fileHandle;
-                if (fileHandle) {
-                    console.log('save with the existing fileHandle');
-                } else {
-                    fileHandle = await window.showSaveFilePicker(pickerFileOptions);
-                    console.log('save without an existing fileHandle');
-                    dispatch(THREATMODEL_UPDATE, { fileHandle: fileHandle });
-                    const file = await fileHandle.getFile();
-                    const contents = await file.text();
-                    console.log('file contents ' + contents);
-                }
-                if ((await fileHandle.queryPermission()) === 'granted')
-                {
-                    console.log('permission granted for existing file fileHandle');
-                    const writable = await fileHandle.createWritable();
-                } else {
-                    console.log('NO permissions for existing file fileHandle');
-                }
-                if ((await fileHandle.queryPermission({ mode: 'read' })) === 'granted')
-                {
-                    console.log('read permissions for existing file fileHandle');
-                } else {
-                    console.log('NO read permissions for existing file fileHandle');
-                }
-                if ((await fileHandle.queryPermission({ mode: 'readwrite' })) === 'granted')
-                {
-                    console.log('readwrite permissions for existing file fileHandle');
-                } else {
-                    console.log('NO readwrite permissions for existing file fileHandle');
-                    await fileHandle.requestPermission(pickerFileOptions);
-	                if ((await fileHandle.queryPermission({ mode: 'readwrite' })) === 'granted')
-	                {
-	                    console.log('readwrite permissions for existing file fileHandle on retry');
-	                } else {
-	                    console.log('NO readwrite permissions for existing file fileHandle on retry');
-	                }
-                }
-                 //const writableStream = await fileHandle.createWritable();
-                 //await writableStream.write(state.data);
-                 //await writableStream.close();
             } else {
                 console.log('save as a download file');
                 save.local(state.data, `${state.data.summary.title}.json`);

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -86,9 +86,9 @@ export default {
         };
     },
     methods: {
-        onDropFile(e) {
-            if (e.dataTransfer.files.length === 1) {
-                let file = e.dataTransfer.files[0];
+        onDropFile(event) {
+            if (event.dataTransfer.files.length === 1) {
+                let file = event.dataTransfer.files[0];
                 if (file.name.endsWith('.json')) {
                     file.text()
                         .then(text => {
@@ -149,8 +149,8 @@ export default {
                 } catch (e) {
                     // the error is most likely due to the picker being cancelled
                     this.$toast.error(this.$t('threatmodel.errors.open'));
-                    // ToDo: does this really need to be treated as an error?
-                    console.error(e);
+                    // just warning: most likely benign
+                    console.warn(e);
                 }
             } else {
                 this.$toast.error('File picker is not yet supported on this browser: use Paste or Drag and Drop');

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -76,7 +76,7 @@ export default {
     },
     computed: {
         ...mapState({
-            providerType: state => getProviderType(state.provider.selected)
+            providerType: (state) => getProviderType(state.provider.selected)
         }),
         prompt() { return '{ ' + this.$t('threatmodel.dragAndDrop') + this.$t('threatmodel.jsonPaste') + ' ... }'; }
     },

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -147,7 +147,9 @@ export default {
                         this.$toast.error(this.$t('threatmodel.errors.onlyJsonAllowed'));
                     }
                 } catch (e) {
+                    // the error is most likely due to the picker being cancelled
                     this.$toast.error(this.$t('threatmodel.errors.open'));
+                    // ToDo: does this really need to be treated as an error?
                     console.error(e);
                 }
             } else {

--- a/td.vue/src/views/MainDashboard.vue
+++ b/td.vue/src/views/MainDashboard.vue
@@ -41,7 +41,7 @@ export default {
         TdDashboardAction
     },
     computed: mapState({
-        actions: state => getDashboardActions(state.provider.selected)
+        actions: (state) => getDashboardActions(state.provider.selected)
     })
 };
 </script>

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -11,8 +11,8 @@ import tmActions from '@/store/actions/threatmodel.js';
 export default {
     name: 'NewThreatModel',
     computed: mapState({
-        providerType: state => getProviderType(state.provider.selected),
-        version: 'packageBuildVersion'
+        providerType: (state) => getProviderType(state.provider.selected),
+        version: (state) => state.packageBuildVersion
     }),
     mounted() {
         this.$store.dispatch(tmActions.clear);

--- a/td.vue/src/views/OauthReturn.vue
+++ b/td.vue/src/views/OauthReturn.vue
@@ -12,7 +12,7 @@ import loginApi from '@/service/api/loginApi.js';
 export default {
     name: 'OAuthReturn',
     computed: mapState({
-        provider: state => state.provider.selected
+        provider: (state) => state.provider.selected
     }),
     async mounted() {
         try {

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -102,7 +102,7 @@ export default {
     },
     computed: mapState({
         model: (state) => state.threatmodel.data,
-        providerType: state => getProviderType(state.provider.selected)
+        providerType: (state) => getProviderType(state.provider.selected)
     }),
     methods: {
         onEditClick(evt) {

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -175,6 +175,7 @@ select-diagram-type {
 <script>
 import { mapState } from 'vuex';
 
+import env from '@/service/env.js';
 import { getProviderType } from '@/service/provider/providers.js';
 import TdFormButton from '@/components/FormButton.vue';
 import { THREATMODEL_CONTRIBUTORS_UPDATED, THREATMODEL_RESTORE, THREATMODEL_SAVE } from '@/store/actions/threatmodel.js';
@@ -186,9 +187,11 @@ export default {
     },
     computed: {
         ...mapState({
+            fileHandle: (state) => state.threatmodel.fileHandle,
+            fileName: (state) => state.threatmodel.fileName,
             model: (state) => state.threatmodel.data,
-            providerType: state => getProviderType(state.provider.selected),
-            version: state => state.packageBuildVersion
+            providerType: (state) => getProviderType(state.provider.selected),
+            version: (state) => state.packageBuildVersion
         }),
         contributors: {
             get() {
@@ -205,7 +208,14 @@ export default {
         },
         async onSaveClick(evt) {
             evt.preventDefault();
-            await this.$store.dispatch(THREATMODEL_SAVE);
+            if (env.isElectron()) {
+                // desktop version always saves locally
+                console.warn('Save for desktop version is not yet implemented');
+                this.$toast.warning(this.$t('threatmodel.errors.save'));
+            } else {
+                // web app version saves to repo or as a download file
+                await this.$store.dispatch(THREATMODEL_SAVE);
+            }
             this.$router.push({ name: `${this.providerType}ThreatModel`, params: this.$route.params });
         },
         async onReloadClick(evt) {
@@ -282,4 +292,5 @@ export default {
         }
     }
 };
+
 </script>

--- a/td.vue/src/views/UpgradeDiagram.vue
+++ b/td.vue/src/views/UpgradeDiagram.vue
@@ -78,8 +78,8 @@ export default {
     computed: {
         ...mapState({
             model: (state) => state.threatmodel.data,
-            providerType: state => getProviderType(state.provider.selected),
-            version: state => state.packageBuildVersion
+            providerType: (state) => getProviderType(state.provider.selected),
+            version: (state) => state.packageBuildVersion
         })
     },
     mounted() {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -31,10 +31,10 @@ export default {
         TdSelectionPage
     },
     computed: mapState({
-        branches: state => state.branch.all,
-        provider: state => state.provider.selected,
-        providerType: state => getProviderType(state.provider.selected),
-        repoName: state => state.repo.selected
+        branches: (state) => state.branch.all,
+        provider: (state) => state.provider.selected,
+        providerType: (state) => getProviderType(state.provider.selected),
+        repoName: (state) => state.repo.selected
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -21,9 +21,9 @@ export default {
         TdSelectionPage
     },
     computed: mapState({
-        provider: state => state.provider.selected,
-        providerType: state => getProviderType(state.provider.selected),
-        repositories: state => state.repo.all
+        provider: (state) => state.provider.selected,
+        providerType: (state) => getProviderType(state.provider.selected),
+        repositories: (state) => state.repo.all
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -35,12 +35,12 @@ export default {
         TdSelectionPage
     },
     computed: mapState({
-        branch: state => state.branch.selected,
-        provider: state => state.provider.selected,
-        providerType: state => getProviderType(state.provider.selected),
-        repoName: state => state.repo.selected,
-        threatModels: state => state.threatmodel.all,
-        selectedModel: state => state.threatmodel.data
+        branch: (state) => state.branch.selected,
+        provider: (state) => state.provider.selected,
+        providerType: (state) => getProviderType(state.provider.selected),
+        repoName: (state) => state.repo.selected,
+        threatModels: (state) => state.threatmodel.all,
+        selectedModel: (state) => state.threatmodel.data
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {


### PR DESCRIPTION
**Summary**
When using the desktop it is desirable that models are saved without a dialog box being shown - unless it is SaveAs. the browser security model stops this, so the desktop saves will have to be done in the backend electron server.

**Description for the changelog**
preparation for desktop save of models

**Other info**

