### PR TITLE
Provide diagram description fix

### DIFF
--- a/td.vue/src/i18n/cn.js
+++ b/td.vue/src/i18n/cn.js
@@ -65,6 +65,8 @@ const cn = {
         title: '标题',
         diagrams: '图表',
         addNewDiagram: '添加新图表...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         threats: '威胁',
         properties: {
             title: '特性',

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -65,6 +65,8 @@ const el = {
         title: 'Τίτλος',
         diagrams: 'Διαγράμματα',
         addNewDiagram: 'Προσθέστε ένα νέο διάγραμμα...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         threats: 'Απειλές',
         properties: {
             title: 'Ιδιότητες',

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -67,6 +67,8 @@ const en = {
         title: 'Title',
         diagrams: 'Diagrams',
         addNewDiagram: 'Add a new diagram...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         threats: 'Threats',
         properties: {
             title: 'Properties',

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -55,6 +55,8 @@ const es = {
         title: 'Título',
         diagrams: 'Diagramas',
         addNewDiagram: 'Agregar un nuevo diagrama...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         properties: {
             title: 'Propiedades',
             emptyState: 'Seleccione un elemento del diagrama para modificar sus propiedades',

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -64,6 +64,8 @@ const fr = {
         title: 'Titre',
         diagrams: 'Diagrammes',
         addNewDiagram: 'Ajouter un nouveau diagramme...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         threats: 'Menaces',
         properties: {
             title: 'Propriétés',

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -54,6 +54,8 @@ const pt = {
         title: 'Título',
         diagrams: 'Diagramas',
         addNewDiagram: 'Adicionar um novo diagrama...',
+        diagramTitle: 'Title',
+        diagramDescription: 'Diagram Description',
         properties: {
             title: 'Propriedades',
             emptyState: 'Selecione um elemento do diagrama para modificar suas propriedades',

--- a/td.vue/src/service/demo/demo-threat-model.js
+++ b/td.vue/src/service/demo/demo-threat-model.js
@@ -17,6 +17,7 @@ export default {
         'diagrams': [
             {
                 'title': 'Main Request Data Flow',
+                'description': 'This is the main request data flow diagram',
                 'thumbnail': './public/content/images/thumbnail.jpg',
                 'id': 0,
                 'diagramJson': {

--- a/td.vue/src/service/demo/legacy-desktop-model.js
+++ b/td.vue/src/service/demo/legacy-desktop-model.js
@@ -17,6 +17,7 @@ export default {
         'diagrams': [
             {
                 'title': 'Main Request Data Flow',
+                'description': 'This is the main request data flow diagram',
                 'thumbnail': './public/content/images/thumbnail.jpg',
                 'id': 0,
                 'diagramJson': {

--- a/td.vue/src/service/demo/legacy-model-2.js
+++ b/td.vue/src/service/demo/legacy-model-2.js
@@ -15,6 +15,7 @@ export default {
         'diagrams': [
             {
                 'title': 'Main Request Flow',
+                'description': 'This is the main request flow diagram',
                 'thumbnail': './public/content/images/thumbnail.jpg',
                 'id': 0,
                 '$$hashKey': 'object:160',

--- a/td.vue/src/service/demo/legacy-model.js
+++ b/td.vue/src/service/demo/legacy-model.js
@@ -17,6 +17,7 @@ export default {
         'diagrams': [
             {
                 'title': 'Main Request Data Flow',
+                'description': 'This is the main request data flow diagram',
                 'thumbnail': './public/content/images/thumbnail.jpg',
                 'id': 0,
                 'diagramJson': {

--- a/td.vue/src/service/demo/v2-threat-model.js
+++ b/td.vue/src/service/demo/v2-threat-model.js
@@ -1109,6 +1109,7 @@ export default {
                 ],
                 'version': '2.0',
                 'title': 'Main Request Data Flow',
+                'description': 'This is the main request data flow diagram',
                 'thumbnail': './public/content/images/thumbnail.jpg',
                 'id': 0
             }

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -30,6 +30,7 @@ const upgradeAndDraw = (diagram, graph) => {
     const updated = graph.toJSON();
     updated.version = '2.0';
     updated.title = diagram.title;
+    updated.description = diagram.description;
     updated.thumbnail = diagram.thumbnail;
     updated.id = diagram.id;
     graph.getCells().forEach((cell) => dataChanged.updateStyleAttrs(cell));

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -36,13 +36,9 @@
                             </a>
                         </h6>
                     </template>
-                    <!-- "thumbnail": "./public/content/images/thumbnail.jpg", -->
-                    <a href="javascript:void(0)" @click="editDiagram(diagram)">
-                        <b-img-lazy
-                            class="m-auto d-block td-diagram-thumb"
-                            :src="require(`../assets/${diagram.thumbnail ? diagram.thumbnail.split('/').pop() : 'thumbnail.jpg'}`)"
-                            :alt="diagram.title" />
-                    </a>
+                    <h6 class="diagram-header-text diagram-">
+                        {{ diagram.description }}
+                    </h6>
                 </b-card>
             </b-col>
         </b-row>

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -98,17 +98,30 @@
                                 :label-for="`diagram-${idx}`"
                                 class="mb-3"
                             >
-                                <b-form-input
-                                    v-model="model.detail.diagrams[idx].title"
-                                    type="text"
-                                    class="td-diagram"
-                                ></b-form-input>
-                                <b-input-group-append>
-                                    <b-button variant="secondary" class="td-remove-diagram" @click="onRemoveDiagramClick(idx)">
-                                        <font-awesome-icon icon="times"></font-awesome-icon>
-                                        {{ $t('forms.remove') }}
-                                    </b-button>
-                                </b-input-group-append>
+                                <b-col md=4>
+                                    <b-form-input
+                                        :placeholder="$t('threatmodel.diagramTitle')"
+                                        v-model="model.detail.diagrams[idx].title"
+                                        type="text"
+                                        class="td-diagram"
+                                    ></b-form-input>
+                                </b-col>
+                                <b-col md=4>
+                                    <b-form-textarea
+                                        :placeholder="$t('threatmodel.diagramDescription')"
+                                        v-model="model.detail.diagrams[idx].description"
+                                        type="text"
+                                        class="td-diagram-description"
+                                    ></b-form-textarea>
+                                </b-col>
+                                <b-col md=4>
+                                    <b-input-group-append>
+                                        <b-button variant="secondary" class="td-remove-diagram" @click="onRemoveDiagramClick(idx)">
+                                            <font-awesome-icon icon="times"></font-awesome-icon>
+                                            {{ $t('forms.remove') }}
+                                        </b-button>
+                                    </b-input-group-append>
+                                </b-col>
                             </b-input-group>
                         </b-col>
 

--- a/td.vue/tests/unit/views/threatmodel.spec.js
+++ b/td.vue/tests/unit/views/threatmodel.spec.js
@@ -13,8 +13,8 @@ describe('views/Threatmodel.vue', () => {
     const title = 'title';
     const description = 'Something about a threat model';
     const diagrams = [
-        { title: 'd1', diagramType: 'CIA' },
-        { title: 'd2', diagramType: 'STRIDE' }
+        { title: 'd1', description: 'd1 description', diagramType: 'CIA' },
+        { title: 'd2', description: 'd2 description', diagramType: 'STRIDE' }
     ];
     const path = '/git/github/foo/bar/baz';
 

--- a/td.vue/tests/unit/views/threatmodelEdit.spec.js
+++ b/td.vue/tests/unit/views/threatmodelEdit.spec.js
@@ -12,8 +12,8 @@ describe('views/Threatmodel.vue', () => {
     const title = 'title';
     const description = 'Something about a threat model';
     const diagrams = [
-        { title: 'd1', diagramType: 'CIA' },
-        { title: 'd2', diagramType: 'STRIDE' }
+        { title: 'd1', description: 'd1 description', diagramType: 'CIA' },
+        { title: 'd2', description: 'd2 description', diagramType: 'STRIDE' }
     ];
     const path = '/git/github/foo/bar/baz';
 


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Add a description for each diagram, so that on the main threat model page it is obvious which diagram is associated with which activity. Fixes [#553](https://github.com/OWASP/threat-dragon/issues/553)

**Description for the changelog**
<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
If this is a bug fix your description should include "fixes #xxxx",
or "closes #xxxx", where #xxxx is the issue number
-->
[#553](https://github.com/OWASP/threat-dragon/issues/553) - Add description field on thread model edit page and replace the threat model image with the newly added description.

**Other info**
<!--
Thanks for submitting a pull request!
Please make sure you read our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
Nothing else to add.