### PR TITLE
remove LGTM and add CodeQL badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=SG1sSFpJeUJ0M1pmY1hrM2F0dVNLclRPSzdCb3lLN253MzcrV0liZWd1bz0tLWxXQWdQaTJRcVF1TVEwS2FWbXJxcHc9PQ==--41330f50fd1c2bd4ac8eaac4a36ebfb1577be89b)](https://automate.browserstack.com/public-build/SG1sSFpJeUJ0M1pmY1hrM2F0dVNLclRPSzdCb3lLN253MzcrV0liZWd1bz0tLWxXQWdQaTJRcVF1TVEwS2FWbXJxcHc9PQ==--41330f50fd1c2bd4ac8eaac4a36ebfb1577be89b)
 [![Deploy](https://github.com/OWASP/threat-dragon/actions/workflows/deploy.yaml/badge.svg)](https://github.com/OWASP/threat-dragon/actions/workflows/deploy.yaml)
 [![GitHub license](https://img.shields.io/github/license/owasp/threat-dragon.svg)](LICENSE.txt)
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/OWASP/threat-dragon.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/OWASP/threat-dragon/context:javascript)
+[![CodeQL](https://github.com/OWASP/threat-dragon/workflows/CodeQL/badge.svg)](https://github.com/OWASP/threat-dragon/actions?query=workflow%3ACodeQL)
 [![Trivy Scan](https://github.com/OWASP/threat-dragon/actions/workflows/trivy.yaml/badge.svg)](https://github.com/OWASP/threat-dragon/actions/workflows/trivy.yaml)
 
 # OWASP Threat Dragon

--- a/docs/development/actions/codeql.md
+++ b/docs/development/actions/codeql.md
@@ -8,6 +8,6 @@ group: Actions
 # CodeQL
 
 
-[CodeQL aka LGTM.com](https://securitylab.github.com/tools/codeql/) is a static analysis scanner provided by GitHub.
+[CodeQL](https://securitylab.github.com/tools/codeql/) is a static analysis scanner provided by GitHub.
 This tool is a Static Analysis Security Tool (SAST) that Threat Dragon uses as an additional measure to identify vulnerabilities.
 This is another check that is run against pull requests going into the main branch.

--- a/docs/home/trust/sast.md
+++ b/docs/home/trust/sast.md
@@ -8,5 +8,5 @@ group: Trust
 
 # Static Application Security Testing (SAST)
 Static application security testing is the process of examining code at rest to identify potential vulnerabilities and misconfigurations.
-This is provided by [LGTM](https://lgtm.com/) and is run as part of every pull request.
-Pull requests will LGTM failures will not be accepted unless the alert is proven to be a false/positive.
+This is provided by [CodeQL](https://securitylab.github.com/tools/codeql/) and is run as part of every pull request.
+Pull requests with CodeQL failures will not be accepted unless the alert is proven to be a false/positive.


### PR DESCRIPTION
**Summary**
removes remaining references to LGTM, and adds the CodeQL badge to the project read-me file
Closes #557 


**Description for the changelog**
remove LGTM and add CodeQL badge

**Other info**
Note that CodeQL has been running on Threat Dragon for some time now - reporting Highs and Criticals but not Mediums and Lows
