### PR TITLE
remove stubbed out codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,6 @@ jobs:
       - name: Unit Test
         run: npm run test:unit
 
-      - name: Upload codecov report
-        run: npm run codecov
-
   site_unit_tests:
     runs-on: ubuntu-latest
     defaults:
@@ -80,9 +77,6 @@ jobs:
 
       - name: Unit Test
         run: npm run test:unit
-
-      - name: Upload codecov report
-        run: npm run codecov
 
   build_docker_image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,9 +44,6 @@ jobs:
       - name: Unit Test
         run: npm run test:unit
 
-      - name: Upload codecov report
-        run: npm run codecov
-
   site_unit_tests:
     runs-on: ubuntu-latest
     defaults:
@@ -81,9 +78,6 @@ jobs:
       - name: Unit Test
         run: npm run test:unit
 
-      - name: Upload codecov report
-        run: npm run codecov
-
   desktop_unit_tests:
     runs-on: ubuntu-latest
     defaults:
@@ -117,9 +111,6 @@ jobs:
   
       - name: Unit Test
         run: npm run test:desktop
-
-      - name: Upload codecov report
-        run: npm run codecov
 
   release_desktop:
     runs-on: ${{ matrix.config.os }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 </p>
 
 [![Build](https://github.com/OWASP/threat-dragon/actions/workflows/ci.yaml/badge.svg)](https://github.com/OWASP/threat-dragon/actions/workflows/ci.yaml)
-[![codecov.io](http://codecov.io/github/owasp/threat-dragon/coverage.svg?branch=main)](http://codecov.io/github/owasp/threat-dragon?branch=main)
 [![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=SG1sSFpJeUJ0M1pmY1hrM2F0dVNLclRPSzdCb3lLN253MzcrV0liZWd1bz0tLWxXQWdQaTJRcVF1TVEwS2FWbXJxcHc9PQ==--41330f50fd1c2bd4ac8eaac4a36ebfb1577be89b)](https://automate.browserstack.com/public-build/SG1sSFpJeUJ0M1pmY1hrM2F0dVNLclRPSzdCb3lLN253MzcrV0liZWd1bz0tLWxXQWdQaTJRcVF1TVEwS2FWbXJxcHc9PQ==--41330f50fd1c2bd4ac8eaac4a36ebfb1577be89b)
 [![Deploy](https://github.com/OWASP/threat-dragon/actions/workflows/deploy.yaml/badge.svg)](https://github.com/OWASP/threat-dragon/actions/workflows/deploy.yaml)
 [![GitHub license](https://img.shields.io/github/license/owasp/threat-dragon.svg)](LICENSE.txt)

--- a/docs/development/actions/ci.md
+++ b/docs/development/actions/ci.md
@@ -19,8 +19,8 @@ there is a concurrency group that prevents concurrent runs of the same action.
 {:.table .table-striped}
 |Name|Description|Dependencies|
 |---|---|---|
-|server_unit_tests|Runs the `td.server` unit tests and reports coverage to codecov.io|N/A|
-|site_unit_tests|Runs the `td.vue` unit tests and reports coverage to codecov.io|N/A|
+|server_unit_tests|Runs the `td.server` unit tests|N/A|
+|site_unit_tests|Runs the `td.vue` unit tests|N/A|
 |docker_build_and_publish|Builds the docker image from source and pushes it to a specific tag that is reserved for testing.|`site_unit_tests`, `server_unit_tests`|
 |e2e_smokes|Runs the E2E smoke tests against the freshly built web app.  Videos of the E2E tests are added as a build artifact|`docker_build_and_publish`|
 |e2e_tests|Runs the E2E tests against the freshly built web app.  Videos of the E2E tests are added as a build artifact|`docker_build_and_publish`|

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "clean:server": "cd td.server && npm run clean",
         "clean:root": "rimraf node_modules/",
         "clean:vue": "cd td.vue && npm run clean",
-        "codecov": "echo 'Disabled for now: codecov'",
         "dev:vue": "cd td.vue && npm run dev",
         "dev:server": "cd td.server && npm run dev",
         "preinstall": "npx only-allow pnpm",

--- a/td.server/package.json
+++ b/td.server/package.json
@@ -6,7 +6,6 @@
     "build": "npm-run-all clean:dist transpile",
     "clean": "rimraf *.log .nyc_output/ coverage/ dist/ node_modules/",
     "clean:dist": "rimraf dist",
-    "codecov": "echo 'Disabled for now: codecov'",
     "dev": "nodemon dev.js --exec babel-node",
     "start": "npm run dev",
     "start:serve": "pm2 --name td.server start 'nodemon dev.js --exec babel-node'",

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "codecov": "echo 'Disabled for now: codecov'",
     "dev": "vue-cli-service serve --port 8080",
     "cypress:open": "cypress open",
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
**Summary**
Removes references to codecov, as this has been stubbed out
No longer using codecov and unlikely to use it in the future

**Description for the changelog**
remove references to codecov

**Other info**
Closes #446 
