### PR TITLE
support multiple diagrams

### DIFF
--- a/ThreatDragonModels/v2-new-model.json
+++ b/ThreatDragonModels/v2-new-model.json
@@ -9,6 +9,7 @@
   "detail": {
     "contributors": [],
     "diagrams": [],
+    "diagramTop": 0,
     "reviewer": "",
     "threatTop": 0
   }

--- a/ThreatDragonModels/v2-threat-model.json
+++ b/ThreatDragonModels/v2-threat-model.json
@@ -1114,6 +1114,7 @@
         "id": 0
       }
     ],
+    "diagramTop": 0,
     "reviewer": "Jane Smith",
     "threatTop": 50
   },

--- a/docs/development/example-store.json
+++ b/docs/development/example-store.json
@@ -109,6 +109,7 @@
             "version": "2.0.0"
           }
         ],
+        "diagramTop": 0,
         "reviewer": "",
         "threatTop": 0
       }

--- a/docs/development/schema/owasp.threat-dragon.schema.json
+++ b/docs/development/schema/owasp.threat-dragon.schema.json
@@ -408,6 +408,11 @@
             "required": [ "diagramType", "id", "size", "thumbnail", "title", "diagramJson" ]
           }
         },
+        "diagramTop": {
+          "description": "The highest diagram number in the threat model",
+          "type": "integer",
+          "minimum": 0
+        },
         "reviewer": {
           "description": "The reviewer of the overall threat model",
           "type": "string"

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -37,7 +37,7 @@
   "author": "OWASP",
   "license": "Apache-2.0",
   "homepage": "https://www.threatdragon.com/docs/",
-  "buildState": "-demo",
+  "buildState": "-beta",
   "repository": {
     "type": "git",
     "url": "git://github.com/OWASP/threat-dragon.git"

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -76,6 +76,7 @@ export default {
         init() {
             this.graph = diagramService.edit(this.$refs.graph_container, this.diagram);
             stencil.get(this.graph, this.$refs.stencil_container);
+            console.debug('diagram ID: ' + this.diagram.id);
         },
         threatSelected(threatId) {
             this.$refs.threatEditDialog.showModal(threatId);

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -28,7 +28,7 @@
 
     <div>
         <td-keyboard-shortcuts />
-        <td-threat-edit-modal ref="threatEditModal" />
+        <td-threat-edit-dialog ref="threatEditDialog" />
     </div>
   </div>
 </template>
@@ -45,7 +45,7 @@ import { mapState } from 'vuex';
 import TdGraphButtons from '@/components/GraphButtons.vue';
 import TdGraphMeta from '@/components/GraphMeta.vue';
 import TdKeyboardShortcuts from '@/components/KeyboardShortcuts.vue';
-import TdThreatEditModal from '@/components/ThreatEditModal.vue';
+import TdThreatEditDialog from '@/components/ThreatEditDialog.vue';
 
 import { getProviderType } from '@/service/provider/providers.js';
 import diagramService from '@/service/migration/diagram.js';
@@ -58,7 +58,7 @@ export default {
         TdGraphButtons,
         TdGraphMeta,
         TdKeyboardShortcuts,
-        TdThreatEditModal
+        TdThreatEditDialog
     },
     computed: mapState({
         diagram: (state) => state.threatmodel.selectedDiagram,
@@ -78,7 +78,7 @@ export default {
             stencil.get(this.graph, this.$refs.stencil_container);
         },
         threatSelected(threatId) {
-            this.$refs.threatEditModal.showModal(threatId);
+            this.$refs.threatEditDialog.showModal(threatId);
         },
         saved() {
             const updated = Object.assign({}, this.diagram);

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -166,7 +166,7 @@ import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
 
 export default {
-    name: 'TdThreatEditModal',
+    name: 'TdThreatEditDialog',
     computed: {
         ...mapState({
             cellRef: (state) => state.cell.ref,

--- a/td.vue/src/service/demo/v2-new-model.js
+++ b/td.vue/src/service/demo/v2-new-model.js
@@ -9,6 +9,7 @@ export default{
     'detail': {
         'contributors': [],
         'diagrams': [],
+        'diagramTop': 0,
         'reviewer': '',
         'threatTop': 0
     }

--- a/td.vue/src/service/demo/v2-threat-model.js
+++ b/td.vue/src/service/demo/v2-threat-model.js
@@ -1115,6 +1115,7 @@ export default {
                 'id': 0
             }
         ],
+        'diagramTop': 0,
         'reviewer': 'Jane Smith',
         'threatTop': 0
     },

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -124,12 +124,14 @@ const mutations = {
     },
     [THREATMODEL_DIAGRAM_SELECTED]: (state, diagram) => {
         state.selectedDiagram = diagram;
+        console.debug('Threatmodel diagram selected: ' + state.selectedDiagram.id);
     },
     [THREATMODEL_DIAGRAM_UPDATED]: (state, diagram) => {
         const idx = state.data.detail.diagrams.findIndex(x => x.id === diagram.id);
         Vue.set(state, 'selectedDiagram', diagram);
         Vue.set(state.data.detail.diagrams, idx, diagram);
         Vue.set(state.data, 'version', diagram.version);
+        console.debug('Threatmodel diagram updated: ' + diagram.id + ' at index: ' + idx);
         setThreatModel(state, state.data);
     },
     [THREATMODEL_FETCH]: (state, threatModel) => setThreatModel(state, threatModel),
@@ -145,6 +147,9 @@ const mutations = {
     [THREATMODEL_UPDATE]: (state, update) => {
         if (update.version) {
             Vue.set(state.data, 'version', update.version);
+        }
+        if (update.diagramTop) {
+            Vue.set(state.data.detail, 'diagramTop', update.diagramTop);
         }
         if (update.threatTop) {
             Vue.set(state.data.detail, 'threatTop', update.threatTop);

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -28,6 +28,7 @@ export default {
             detail: {
                 contributors: [],
                 diagrams: [],
+                diagramTop: 0,
                 reviewer: '',
                 threatTop: 0
             }

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -100,7 +100,7 @@ import { mapState } from 'vuex';
 import { getProviderType } from '@/service/provider/providers.js';
 import TdFormButton from '@/components/FormButton.vue';
 import TdThreatModelSummaryCard from '@/components/ThreatModelSummaryCard.vue';
-import { THREATMODEL_CLEAR, THREATMODEL_DIAGRAM_SELECTED } from '@/store/actions/threatmodel.js';
+import { THREATMODEL_CLEAR, THREATMODEL_DIAGRAM_SELECTED, THREATMODEL_UPDATE } from '@/store/actions/threatmodel.js';
 
 export default {
     name: 'ThreatModel',
@@ -110,7 +110,8 @@ export default {
     },
     computed: mapState({
         model: (state) => state.threatmodel.data,
-        providerType: (state) => getProviderType(state.provider.selected)
+        providerType: (state) => getProviderType(state.provider.selected),
+        version: (state) => state.packageBuildVersion
     }),
     methods: {
         onEditClick(evt) {
@@ -137,6 +138,14 @@ export default {
             const path = `${this.$route.path}/edit/${encodeURIComponent(diagram.title)}`;
             this.$router.push(path);
         }
+    },
+    mounted() {
+        // make sure we are compatible with version 1.x and early 2.x
+        let threatTop = this.model.detail.threatTop === undefined ? 100 : this.model.detail.threatTop;
+        let diagramTop = this.model.detail.diagramTop === undefined ? 10 : this.model.detail.diagramTop;
+        let update = { diagramTop: diagramTop, version: this.version, threatTop: threatTop };
+        console.debug('updates: ' + JSON.stringify(update));
+        this.$store.dispatch(THREATMODEL_UPDATE, update);
     }
 };
 </script>

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -183,7 +183,7 @@ import { mapState } from 'vuex';
 
 import { getProviderType } from '@/service/provider/providers.js';
 import TdFormButton from '@/components/FormButton.vue';
-import { THREATMODEL_CONTRIBUTORS_UPDATED, THREATMODEL_RESTORE, THREATMODEL_SAVE } from '@/store/actions/threatmodel.js';
+import { THREATMODEL_CONTRIBUTORS_UPDATED, THREATMODEL_RESTORE, THREATMODEL_SAVE, THREATMODEL_UPDATE } from '@/store/actions/threatmodel.js';
 
 export default {
     name: 'ThreatModelEdit',
@@ -196,6 +196,7 @@ export default {
             fileName: (state) => state.threatmodel.fileName,
             model: (state) => state.threatmodel.data,
             providerType: (state) => getProviderType(state.provider.selected),
+            diagramTop: (state) => state.threatmodel.data.detail.diagramTop,
             version: (state) => state.packageBuildVersion
         }),
         contributors: {
@@ -229,13 +230,14 @@ export default {
         onAddDiagramClick(evt) {
             evt.preventDefault();
             let newDiagram = {
-                name: '',
+                id: this.diagramTop,
                 title: this.$t('threatmodel.diagram.stride.defaultTitle'),
                 diagramType: 'STRIDE',
                 placeholder: this.$t('threatmodel.diagram.stride.defaultDescription'),
                 thumbnail: './public/content/images/thumbnail.stride.jpg',
                 version: this.version
             };
+            this.$store.dispatch(THREATMODEL_UPDATE, { diagramTop: this.diagramTop + 1 });
             this.model.detail.diagrams.push(newDiagram);
         },
         onDiagramTypeClick(idx, type) {

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -84,6 +84,7 @@ export default {
                 detail: {
                     contributors: [],
                     diagrams: [],
+                    diagramTop: 0,
                     reviewer: '',
                     threatTop: 0
                 }

--- a/td.vue/tests/e2e/fixtures/v2-model.json
+++ b/td.vue/tests/e2e/fixtures/v2-model.json
@@ -227,6 +227,7 @@
         ]
       }
     ],
+    "diagramTop": 0,
     "reviewer": "Jane Smith",
     "threatTop": 1
   }

--- a/td.vue/tests/e2e/fixtures/v2-new-model.json
+++ b/td.vue/tests/e2e/fixtures/v2-new-model.json
@@ -9,6 +9,7 @@
   "detail": {
     "contributors": [],
     "diagrams": [],
+    "diagramTop": 0,
     "reviewer": "",
     "threatTop": 0
   }

--- a/td.vue/tests/unit/components/graph.spec.js
+++ b/td.vue/tests/unit/components/graph.spec.js
@@ -6,7 +6,7 @@ import TdGraph from '@/components/Graph.vue';
 import TdGraphButtons from '@/components/GraphButtons.vue';
 import TdGraphMeta from '@/components/GraphMeta.vue';
 import TdKeyboardShortcuts from '@/components/KeyboardShortcuts.vue';
-import TdThreatEditModal from '@/components/ThreatEditModal.vue';
+import TdThreatEditDialog from '@/components/ThreatEditDialog.vue';
 
 import diagramService from '@/service/migration/diagram.js';
 import stencilService from '@/service/x6/stencil.js';
@@ -59,7 +59,7 @@ describe('components/GraphButtons.vue', () => {
         wrapper = shallowMount(TdGraph, {
             localVue,
             stubs: {
-                'td-threat-edit-modal': threatEditStub
+                'td-threat-edit-dialog': threatEditStub
             },
             store: storeMock,
             mocks: {
@@ -97,8 +97,8 @@ describe('components/GraphButtons.vue', () => {
             .toEqual(true);
     });
 
-    it('has the threat edit modal', () => {
-        expect(wrapper.findComponent(TdThreatEditModal).exists())
+    it('has the threat edit modal dialog', () => {
+        expect(wrapper.findComponent(TdThreatEditDialog).exists())
             .toEqual(true);
     });
 
@@ -110,7 +110,7 @@ describe('components/GraphButtons.vue', () => {
         expect(diagramService.edit).toHaveBeenCalled();
     });
 
-    it('shows the threat edit modal', () => {
+    it('shows the threat edit modal dialog', () => {
         wrapper.vm.threatSelected('asdf');
         expect(threatEditStub.methods.showModal).toHaveBeenCalledWith('asdf');
     });

--- a/td.vue/tests/unit/components/threatEditModal.spec.js
+++ b/td.vue/tests/unit/components/threatEditModal.spec.js
@@ -3,9 +3,9 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import dataChanged from '@/service/x6/graph/data-changed.js';
-import TdThreatEditModal from '@/components/ThreatEditModal.vue';
+import TdThreatEditDialog from '@/components/ThreatEditDialog.vue';
 
-describe('components/ThreatEditModal.vue', () => {
+describe('components/ThreatEditDialog.vue', () => {
     let localVue, mockStore, wrapper;
     const threatId = 'asdf-asdf-asdf-asdf';
 
@@ -34,7 +34,7 @@ describe('components/ThreatEditModal.vue', () => {
         localVue.use(BootstrapVue);
     });
 
-    const getWrapper = () => shallowMount(TdThreatEditModal, {
+    const getWrapper = () => shallowMount(TdThreatEditDialog, {
         localVue,
         mocks: {
             $t: key => key


### PR DESCRIPTION
**Summary**
Multiple diagrams are not (yet) supported by version 2.x.  Any save of diagrams is folded into the first diagram
This pull request adds diagram.id to version 2.x, in the same way as the existing version 1.x, and provides for the diagram ID to be unique for the lifetime of the model

**Description for the changelog**
support multiple diagrams

**Other info**
Closes #582 "First diagram overwritten when creating multiple diagrams" and  also closes #583 "Reinstate diagram IDs"
