### PR TITLE
fix up for renaming of docs environment page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Pnpm (rather than npm) is used to install from the top directory of the project 
 
 Threat Dragon uses GitHub to store threat models, so you need to go to your GitHub account and
 register it as a GitHub application. There is a
-[step by step guide](https://www.threatdragon.com/docs/development/env.html) on how to do this.
+[step by step guide](https://www.threatdragon.com/docs/development/environment.html) on how to do this.
 
 You will also have to provide other environment variables, again following
-[the documentation](https://www.threatdragon.com/docs/development/env.html) on this.
+[the documentation](https://www.threatdragon.com/docs/development/environment.html) on this.
 
 If running Threat Dragon locally then the front-end to server communication will
 probably need to be HTTP rather than HTTPS.
@@ -118,7 +118,7 @@ from the top directory with command `pnpm stop`. Otherwise break out of both the
 ### Docker (local build)
 
 To run Threat Dragon in a docker container,
-first configure your [environment using dotenv](https://www.threatdragon.com/docs/development/env.html)
+first configure your [environment using dotenv](https://www.threatdragon.com/docs/development/environment.html)
 and run from the top directory of the project:
 
 - `docker build -t owasp-threat-dragon:dev .`

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -86,7 +86,7 @@ ___
 
 The application will throw an error if a required environment variable is missing during application start:
 
-`GITHUB_CLIENT_ID is a required property.  Threat Dragon server cannot start without it.  Please see setup-env.md for more information`
+`GITHUB_CLIENT_ID is a required property.  Threat Dragon server cannot start without it.  Please see docs/development/environment.md for more information`
 
 ___
 

--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -12,7 +12,7 @@ group: Local
 1. Clone the repository: `git clone https://github.com/OWASP/threat-dragon.git`
 1. [Install pnpm](https://pnpm.io/installation) and use node 16
 1. Run `pnpm install`
-1. Configure your [environment](./env)
+1. Configure your [environment](./environment)
 1. Run `pnpm dev:server`
 1. In another terminal, run `pnpm dev:vue`
 1. Visit [http://localhost:8080](http://localhost:8080/)

--- a/docs/development/testing/adhoc.md
+++ b/docs/development/testing/adhoc.md
@@ -13,7 +13,7 @@ in an ad-hoc way which is not part of the unit and end-to-end tests.
 
 ## Back-end server
 The web application express server can be run locally using command `pnpm start:server` from the top level directory.
-The server will need access to environment variables as shown in [environment setup](development/env).
+The server will need access to environment variables as shown in [environment setup](development/environment).
 
 When running locally it may be that HTTPS certificates are not present; consider using these environment variables:
 

--- a/docs/home/about/about.md
+++ b/docs/home/about/about.md
@@ -45,6 +45,10 @@ The following translations are built into the Threat Dragon application:
 - português (por-BR)
 - 中文 (zho-CN)
 
+### Demonstration site
+Threat Dragon maintains a [Demo Instance](https://www.threatdragon.com/) that is hosted on [Heroku](https://www.heroku.com/).
+We strongly recommend using a self-hosted instance or the desktop application as the most secure options.
+Threat Dragon can authenticate to GitHub repositories using a GitHub OAuth application as noted in the [environment setup](development/environment) page. 
 ____
 <p>
 <sup><a name="footnote1">1</a>: Spoofing, Tampering, Repudiation, Information disclosure, DoS, Elevation of privilege</sup><br>

--- a/docs/home/trust/incidents.md
+++ b/docs/home/trust/incidents.md
@@ -7,10 +7,6 @@ group: Trust
 ---
 
 # Incident Response
-Threat Dragon maintains a [Demo Instance](https://www.threatdragon.com/) that is hosted on [Heroku](https://www.heroku.com/).
-We strongly recommend using a self-hosted instance or the desktop application as the most secure options.
-Threat Dragon can authenticate to GitHub repositories using a GitHub OAuth application as noted in the [environment setup](development/env) page.  
-
 Threat Dragon is open source software and contains many other open source components.
 Threat Dragon's community strives to stay abreast of security vulnerabilities and incidents impacting upstream providers or Threat Dragon itself.
 If there is a high impact or high profile incident or vulnerability,

--- a/docs/usage/install/docker.md
+++ b/docs/usage/install/docker.md
@@ -15,10 +15,10 @@ The web application can be run from a docker container.
 
 ### Environment variables
 
-See the [environment]({{ 'development/env.html' | relative_url }}) page for details on what environment variables are expected.
+See the [environment]({{ 'development/environment.html' | relative_url }}) page for details on what environment variables are expected.
 Threat Dragon currently supports [dotenv](https://github.com/motdotla/dotenv),
 as well as file-based loading by setting environment variables with the `_FILE` postfix, eg: `ENCRYPTION_KEYS_FILE=/run/secrets/td_encryption_keys`
-This is also shown in the docker-compose section of the env documentation.
+This is also shown in the docker-compose section of the environment documentation.
 
 ### Running the application
 

--- a/docs/usage/install/web.md
+++ b/docs/usage/install/web.md
@@ -34,7 +34,7 @@ To install use pnpm (rather than npm):
 
 ### Environment variables
 
-See the [environment]({{ 'development/env.html' | relative_url }}) page for details on configuring your environment variables.
+See the [environment]({{ 'development/environment.html' | relative_url }}) page for details on configuring your environment variables.
 
 ### Running the application
 

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -9,7 +9,7 @@ class ThreatDragonEnv extends Env {
         return '';
     }
 
-    // if any  of the defaults are changed then ensure docs are updated at docs/development/env.md
+    // if any  of the defaults are changed then ensure docs are updated at docs/development/environment.md
     get properties () {
         return [
             { key: 'NODE_ENV', required: false },

--- a/td.server/src/helpers/encryption.helper.js
+++ b/td.server/src/helpers/encryption.helper.js
@@ -87,7 +87,7 @@ const decryptData = (cipherText, key, iv) => {
 /**
  * Encrypts a plaintext to a ciphertext
  * This uses the configured encryption keys
- * See setup-env.md for more information
+ * See docs/development/environment.md for more information
  * @param {String} plainText
  * @returns {Promise<Object>}
  */
@@ -101,7 +101,7 @@ const encryptPromise = (plainText) => {
 
 /**
  * Decrypts a ciphertext using the configured encryption keys
- * See setup-env.md for more information
+ * See docs/development/environment.md for more information
  * @param {Object} encryptedData
  * @returns {String}
  */

--- a/td.server/src/providers/index.js
+++ b/td.server/src/providers/index.js
@@ -23,7 +23,7 @@ const get = (name) => {
     }
 
     if (!provider.isConfigured()) {
-        throw new Error(`Provider ${name} is not configured. See docs env.md for more info`);
+        throw new Error(`Provider ${name} is not configured. See docs/development/environment.md for more info`);
     }
 
     return provider;


### PR DESCRIPTION
**Summary**
The renaming of docs/development/environment.md was not implemented correctly, resulting in many broken links

**Description for the changelog**
fix up for renaming of docs environment page

**Other info**
closes #587 
