### PR TITLE
implement opening of recent threat model files

### DIFF
--- a/td.vue/src/desktop/desktop.js
+++ b/td.vue/src/desktop/desktop.js
@@ -101,6 +101,14 @@ app.on('ready', async () => {
     createWindow();
 });
 
+// this is emitted when a 'recent document' is opened
+app.on('open-file', function(event, path) {
+    // handle this event
+    event.preventDefault();
+    logger.log.debug('Open file from recent documents: ' + path);
+    menu.readModelData(path);
+});
+
 function handleUpdateMenu (_event, locale) {
     logger.log.debug('Re-labeling the menu system for: ' + locale);
     menu.setLocale(locale);

--- a/td.vue/tests/unit/desktop/menu.spec.js
+++ b/td.vue/tests/unit/desktop/menu.spec.js
@@ -135,6 +135,13 @@ describe('desktop/menu.js', () => {
                 expect(model.isOpen).not.toBeDefined();
             });
 
+            it('readModelData() should send open-model to renderer with file path', () => {
+                // TODO: need to mock mainWindow
+                // readModelData('another/file/path');
+                //expect(model).toEqual( expect.objectContaining({fileDirectory: 'another/file/', filePath: 'path'}) );
+                expect(model.isOpen).not.toBeDefined();
+            });
+
             it('saveModel() should send save-model to renderer with a file path', () => {
                 // TODO: click on the server menu item for saveModel()
                 expect(model).toEqual( expect.objectContaining({fileDirectory: 'test directory', filePath: 'test path'}) );

--- a/td.vue/tests/unit/views/homePage.spec.js
+++ b/td.vue/tests/unit/views/homePage.spec.js
@@ -79,8 +79,9 @@ describe('HomePage.vue', () => {
             });
         });
     });
-/* TODO: this needs to be fixed: issue #560 'Desktop: create unit tests'
-    describe('desktop', () => {
+
+    describe.skip('desktop', () => {
+        // TODO: this needs to be reinstated
         beforeEach(() => {
             localVue = createLocalVue();
             localVue.use(Vuex);
@@ -118,5 +119,5 @@ describe('HomePage.vue', () => {
             });
         });
     });
-*/
+
 });


### PR DESCRIPTION
**Summary**
The recent document list of recently accessed threat models was ignored - it could be selected but the models were not opened

**Description for the changelog**
implement opening of recent threat model files

**Other info**
Closes #590 
