### PR TITLE
[T/t]hreat dragon -> Threat Dragon

### DIFF
--- a/docs/development/local.md
+++ b/docs/development/local.md
@@ -77,7 +77,7 @@ This runs the desktop application in development mode that will relaunch the app
 
 ## Docker
 A Dockerfile is provided that can be used to create a docker image:
-* checkout the threat dragon source repo
+* checkout the Threat Dragon source repo
 * from the root directory build the docker image using `docker build -t owasp-threat-dragon:dev .`
 * wait for the docker image to build
 * create a `.env` environment variable file using the example `example.env` as a template

--- a/docs/home/about/credits.md
+++ b/docs/home/about/credits.md
@@ -21,7 +21,7 @@ group: About
 
 [Mike Goodwin](mailto:mike.goodwin@owasp.org) is the originator, founder and leader of OWASP Threat Dragon.
 The [first commit](https://github.com/mike-goodwin/owasp-threat-dragon/commit/942bdff78191ef0eae40f7610b8397739749d8b8)
-to the original threat dragon repository was made on 9th October 2015, so that is Threat Dragon's birthday.
+to the original Threat Dragon repository was made on 9th October 2015, so that is Threat Dragon's birthday.
 
 Some years later we found that using JointJS for the diagramming library was not proving sustainable,
 so [Leo Reading](mailto:leo.reading@owasp.org) migrated the project to Vue/Express using the drawing library antv/x6.

--- a/docs/usage/collaboration/linking.md
+++ b/docs/usage/collaboration/linking.md
@@ -11,7 +11,7 @@ Threat Dragon supports the concept of deep linking.  The deep links have changed
 the addition of identity providers. Please take note of the new structure.
 
 ## Provider Types
-Threat dragon supports multiple provider types.  Each provider "type" can have multiple providers,
+Threat Dragon supports multiple provider types.  Each provider "type" can have multiple providers,
 but they fall under the same category as far as deep linking is concerned.
 More providers and provider types will be added in the future.
 


### PR DESCRIPTION
**Summary**
In some parts of the docs Threat Dragon is not cased as a proper noun.

**Description for the changelog**
Ensure usage of "Threat Dragon" is as a proper noun in docs

**Other info**
Note: There is one more occurrence in `threat-dragon/docs/development/cli.md` however I can't find in the current v2 branch the CLI setup. Unsure if described functionality still exists. If it does please point me to the right location.  
https://github.com/OWASP/threat-dragon/blob/6893bcb89beca16e0d2a070765a2abd507a0fea7/docs/development/cli.md?plain=1#L58 
