### PR TITLE
Report layout fixes

### DIFF
--- a/td.vue/src/components/report/Coversheet.vue
+++ b/td.vue/src/components/report/Coversheet.vue
@@ -2,8 +2,8 @@
     <div class="no-print">
         <b-row class="mb-2 td-branding">
             <b-col>
-                <em class="td-brand-text">
-                    {{ new Date().toDateString() }} <span v-if="branding">| OWASP Threat Dragon </span>
+                <em>
+                    {{ new Date().toDateString() }} <span v-if="branding" class="td-brand-text">| OWASP Threat Dragon </span>
                 </em>
             </b-col>
         </b-row>

--- a/td.vue/src/components/report/Coversheet.vue
+++ b/td.vue/src/components/report/Coversheet.vue
@@ -15,12 +15,6 @@
     </div>
 </template>
 
-<style lang="scss" scoped>
-.td-branding {
-    margin-top: 60px;
-}
-</style>
-
 <script>
 import TdThreatModelSummaryCard from '@/components/ThreatModelSummaryCard.vue';
 export default {

--- a/td.vue/src/components/report/Coversheet.vue
+++ b/td.vue/src/components/report/Coversheet.vue
@@ -2,8 +2,8 @@
     <div class="no-print">
         <b-row class="mb-2 td-branding">
             <b-col>
-                <em v-if="branding" class="td-brand-text">
-                    {{ new Date().toDateString() }} | OWASP Threat Dragon 
+                <em class="td-brand-text">
+                    {{ new Date().toDateString() }} <span v-if="branding">| OWASP Threat Dragon </span>
                 </em>
             </b-col>
         </b-row>

--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="td-report">
-        <b-row class="no-print td-report-options fixed">
+        <b-row class="no-print td-report-options sticky">
             <b-col>
                 <b-form class="">
                     <b-form-row>
@@ -129,11 +129,11 @@
 }
 
 .td-report-container {
-    margin-top: 85px;
+    margin-top: 5px;
 }
 
-.fixed {
-    position: fixed;
+.sticky {
+    position: sticky;
     top: 45px;
     width: 100%;
     background-color: $white;


### PR DESCRIPTION
**Summary**
Swaps usage of `fixed` to `sticky` so that content is pushed down by correct space and not hidden by the report options.  

**Description for the changelog**
Resolves layout issues at the top of web report. Closes #598, closes #597 

**Other info**
I'm unsure what the projects minimum browser support is. Please check and confirm if support is satisfactory https://caniuse.com/css-sticky 

![image](https://user-images.githubusercontent.com/1075126/218452188-690130ca-b4fb-4090-9b33-9c39edb25c49.png)

