### PR TITLE
Dashboard actions kept to equal height

### DIFF
--- a/td.vue/src/components/DashboardAction.vue
+++ b/td.vue/src/components/DashboardAction.vue
@@ -1,6 +1,6 @@
 <template>    
     <b-col lg>
-        <b-jumbotron class="text-center">
+        <b-jumbotron class="text-center action-pane">
             <router-link :to="to">
                 <font-awesome-icon
                 :icon="[iconPreface, icon]"
@@ -18,6 +18,11 @@
 .action-icon {
     color: $orange;
     margin-bottom: 15px;
+}
+
+.action-pane {
+    min-height: 100%;
+    margin-bottom: 0px;
 }
 </style>
 

--- a/td.vue/src/views/MainDashboard.vue
+++ b/td.vue/src/views/MainDashboard.vue
@@ -9,8 +9,8 @@
                 </b-jumbotron>
             </b-col>
         </b-row>
-        <b-row>
-            <td-dashboard-action
+        <b-row >
+            <td-dashboard-action class="dashboard-action"
                 v-for="(action, idx) in actions"
                 :key="idx"
                 :to="action.to"
@@ -27,6 +27,11 @@
     color: $orange;
     margin-bottom: 15px;
 }
+
+.dashboard-action {
+    padding-bottom: 2rem;
+}
+
 </style>
 
 <script>


### PR DESCRIPTION
**Summary**
By applying height 100% we can get actions to have equal height. Remaining changes move the `2rem` from margin and places it as outer padding.

**Description for the changelog**
Dashboard actions kept to equal height. Closes #603 