### PR TITLE
stop text overwriting cupcake

### DIFF
--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -9,7 +9,7 @@ const deu = {
     home: {
         title: 'OWASP Threat Dragon',
         imgAlt: 'Threat Dragon Logo',
-        description: 'Threat Dragon is an open-source threat modeling tool from OWASP. It can be used as a standalone desktop app for Windows, MacOS and Linux or as a web application. Use the desktop application if you do not want it to access your GitHub repos, and if you choose the online version you get to unleash the awesome power of GitHub on your threat models! To do this you need to log in first.',
+        description: 'OWASP Threat Dragon is a free, open-source, cross-platform application for creating threat models. Use it to draw threat modeling diagrams and to identify threats for your system. With an emphasis on flexibility and simplicity it is easily accessible for all types of users.',
         loginWith: 'Login with'
     },
     providers: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -9,7 +9,7 @@ const eng = {
     home: {
         title: 'OWASP Threat Dragon',
         imgAlt: 'Threat Dragon Logo',
-        description: 'Threat Dragon is an open-source threat modeling tool from OWASP. It can be used as a standalone desktop app for Windows, MacOS and Linux or as a web application. Use the desktop application without if you do not want it to access your GitHub repos, and if you choose the online version you get to unleash the awesome power of GitHub on your threat models! To do this you need to log in first.',
+        description: 'OWASP Threat Dragon is a free, open-source, cross-platform application for creating threat models. Use it to draw threat modeling diagrams and to identify threats for your system. With an emphasis on flexibility and simplicity it is easily accessible for all types of users.',
         loginWith: 'Login with'
     },
     providers: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -9,7 +9,7 @@ const rus = {
     home: {
         title: 'OWASP Threat Dragon',
         imgAlt: 'Threat Dragon Logo',
-        description: 'Threat Dragon is an open-source threat modeling tool from OWASP. It can be used as a standalone desktop app for Windows, MacOS and Linux or as a web application. Use the desktop application if you do not want it to access your GitHub repos, and if you choose the online version you get to unleash the awesome power of GitHub on your threat models! To do this you need to log in first.',
+        description: 'OWASP Threat Dragon is a free, open-source, cross-platform application for creating threat models. Use it to draw threat modeling diagrams and to identify threats for your system. With an emphasis on flexibility and simplicity it is easily accessible for all types of users.',
         loginWith: 'Login with'
     },
     providers: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -9,7 +9,7 @@ const ukr = {
     home: {
         title: 'OWASP Threat Dragon',
         imgAlt: 'Threat Dragon Logo',
-        description: 'Threat Dragon is an open-source threat modeling tool from OWASP. It can be used as a standalone desktop app for Windows, MacOS and Linux or as a web application. Use the desktop application if you do not want it to access your GitHub repos, and if you choose the online version you get to unleash the awesome power of GitHub on your threat models! To do this you need to log in first.',
+        description: 'OWASP Threat Dragon is a free, open-source, cross-platform application for creating threat models. Use it to draw threat modeling diagrams and to identify threats for your system. With an emphasis on flexibility and simplicity it is easily accessible for all types of users.',
         loginWith: 'Login with'
     },
     providers: {

--- a/td.vue/src/views/HomePage.vue
+++ b/td.vue/src/views/HomePage.vue
@@ -8,7 +8,7 @@
       </b-row>
       <b-row>
         <b-col md="4">
-          <b-img
+          <b-img class="td-cupcake"
             id="home-td-logo"
             :alt="$t('home.imgAlt')"
             src="@/assets/threatdragon_logo_image.svg"
@@ -43,6 +43,15 @@
 
 .td-description {
   font-size: 20px;
+  margin-right: 20px;
+  margin-left: 170px;
+}
+
+.td-cupcake {
+  margin-top: 10px;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
 }
 </style>
 

--- a/td.vue/tests/e2e/specs/home.cy.js
+++ b/td.vue/tests/e2e/specs/home.cy.js
@@ -7,7 +7,7 @@ describe('home', () => {
         });
     
         it('describes the application', () => {
-            cy.contains('open-source threat modeling tool');
+            cy.contains('OWASP Threat Dragon is');
         });
     
         it('shows the threat dragon logo', () => {


### PR DESCRIPTION
**Summary**
This pull-request provides margins around the cupcake image to stop the text over-writing it
Also updates the text to be more welcoming

**Description for the changelog**
stop text overwriting cupcake

**Other info**
Closes #602 
Closes #604 
