### PR TITLE
GitHub Actions: Limit run to source repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,7 @@ jobs:
     name: build docker image
     runs-on: ubuntu-22.04
     needs: [site_unit_tests, server_unit_tests]
+    if: github.repository == 'OWASP/threat-dragon'
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,7 @@ jobs:
   publish_docker:
     name: publish docker
     runs-on: ubuntu-22.04
+    if: github.repository == 'OWASP/threat-dragon'
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0


### PR DESCRIPTION
By adding if check to these two jobs it will prevent spurious errors been reported from forked repos. 

Closes #616 