### PR TITLE
Fix #631 error while creation of threat model when using GitHub

### DIFF
--- a/td.server/src/config/routes.config.js
+++ b/td.server/src/config/routes.config.js
@@ -42,7 +42,7 @@ const routes = (router) => {
     // removed because of security denial of service concerns (denial of models)
     //router.delete('/api/threatmodel/:organisation/:repo/:branch/:model', threatmodelController.deleteModel);
 
-    router.put('/api/threatmodel/:organisation/:repo/:branch/:model/create', threatmodelController.create);
+    router.post('/api/threatmodel/:organisation/:repo/:branch/:model/create', threatmodelController.create);
     router.put('/api/threatmodel/:organisation/:repo/:branch/:model/update', threatmodelController.update);
 };
 

--- a/td.server/test/config/routes.config.spec.js
+++ b/td.server/test/config/routes.config.spec.js
@@ -87,35 +87,35 @@ describe('config/routes.config.js routes', () => {
                 threatmodelController.repos
             );
         });
-        
+
         it('routes GET /api/threatmodel/:organisation/:repo/branches', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/threatmodel/:organisation/:repo/branches',
                 threatmodelController.branches
             );
         });
-        
+
         it('routes GET /api/threatmodel/organisation', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/threatmodel/organisation',
                 threatmodelController.organisation
             );
         });
-        
+
         it('routes GET /api/threatmodel/:organisation/:repo/:branch/models', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/threatmodel/:organisation/:repo/:branch/models',
                 threatmodelController.models
             );
         });
-        
+
         it('routes GET /api/threatmodel/:organisation/:repo/:branch/:model/data', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/threatmodel/:organisation/:repo/:branch/:model/data',
                 threatmodelController.model
             );
         });
-        
+
         // removed because of security denial of service concerns (denial of models)
         /* it('routes DELETE /api/threatmodel/:organisation/:repo/:branch/:model', () => {
             expect(mockRouter.delete).to.have.been.calledWith(
@@ -123,14 +123,14 @@ describe('config/routes.config.js routes', () => {
                 threatmodelController.deleteModel
             );
         });*/
-        
-        it('routes PUT /api/threatmodel/:organisation/:repo/:branch/:model/create', () => {
-            expect(mockRouter.put).to.have.been.calledWith(
+
+        it('routes POST /api/threatmodel/:organisation/:repo/:branch/:model/create', () => {
+            expect(mockRouter.post).to.have.been.calledWith(
                 '/api/threatmodel/:organisation/:repo/:branch/:model/create',
                 threatmodelController.create
             );
         });
-        
+
         it('routes PUT /api/threatmodel/:organisation/:repo/:branch/:model/update', () => {
             expect(mockRouter.put).to.have.been.calledWith(
                 '/api/threatmodel/:organisation/:repo/:branch/:model/update',

--- a/td.vue/src/router/git.js
+++ b/td.vue/src/router/git.js
@@ -30,9 +30,9 @@ export const gitRoutes = [
         component: () => import(/* webpackChunkName: "new-threatmodel" */ '../views/NewThreatModel.vue')
     },
     {
-      path: `/${providerType}/:provider/:repository/:branch/:threatmodel/create`,
-      name: `${providerType}ThreatModelCreate`,
-      component: () => import(/* webpackChunkName: "threatmodel-edit" */ '../views/ThreatModelEdit.vue')
+        path: `/${providerType}/:provider/:repository/:branch/:threatmodel/create`,
+        name: `${providerType}ThreatModelCreate`,
+        component: () => import(/* webpackChunkName: "threatmodel-edit" */ '../views/ThreatModelEdit.vue')
     },
     {
         path: `/${providerType}/:provider/:repository/:branch/:threatmodel/edit`,

--- a/td.vue/src/router/git.js
+++ b/td.vue/src/router/git.js
@@ -1,4 +1,4 @@
-import { providerTypes } from '../service/provider/providerTypes.js';
+import { providerTypes } from '@/service/provider/providerTypes';
 
 const providerType = providerTypes.git;
 
@@ -28,6 +28,11 @@ export const gitRoutes = [
         path: `/${providerType}/:provider/:repository/:branch/new`,
         name: `${providerType}NewThreatModel`,
         component: () => import(/* webpackChunkName: "new-threatmodel" */ '../views/NewThreatModel.vue')
+    },
+    {
+      path: `/${providerType}/:provider/:repository/:branch/:threatmodel/create`,
+      name: `${providerType}ThreatModelCreate`,
+      component: () => import(/* webpackChunkName: "threatmodel-edit" */ '../views/ThreatModelEdit.vue')
     },
     {
         path: `/${providerType}/:provider/:repository/:branch/:threatmodel/edit`,

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -57,7 +57,7 @@ const modelAsync = (fullRepoName, branch, model) => {
 const createAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
     return api.postAsync(`${resource}/${org}/${repo}/${branch}/${modelName}/create`, threatModel);
-}
+};
 
 const updateAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -54,6 +54,11 @@ const modelAsync = (fullRepoName, branch, model) => {
     return api.getAsync(`${resource}/${org}/${repo}/${branch}/${model}/data`);
 };
 
+const createAsync = (fullRepoName, branch, modelName, threatModel) => {
+    const { org, repo } = extractRepoParts(fullRepoName);
+    return api.postAsync(`${resource}/${org}/${repo}/${branch}/${modelName}/create`, threatModel);
+}
+
 const updateAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
     return api.putAsync(`${resource}/${org}/${repo}/${branch}/${modelName}/update`, threatModel);
@@ -65,5 +70,6 @@ export default {
     modelsAsync,
     organisationAsync,
     reposAsync,
+    createAsync,
     updateAsync
 };

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -140,7 +140,6 @@ const actions = {
 
 const mutations = {
     [THREATMODEL_CLEAR]: (state) => clearState(state),
-    [THREATMODEL_CREATE]: (state, threatModel) => setThreatModel(state, threatModel),
     [THREATMODEL_CONTRIBUTORS_UPDATED]: (state, contributors) => {
         state.data.detail.contributors.length = 0;
         contributors.forEach((name, idx) => Vue.set(state.data.detail.contributors, idx, { name }));

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -42,7 +42,11 @@ export default {
             // tell the desktop server that the model has changed
             window.electronAPI.modelOpened(newTm.summary.title);
         }
-        this.$router.push({ name: `${this.providerType}ThreatModelCreate`, params });
+        if (this.providerType === 'local') {
+            this.$router.push({ name: `${this.providerType}ThreatModelEdit`, params });
+        } else {
+            this.$router.push({ name: `${this.providerType}ThreatModelCreate`, params });
+        }
     }
 };
 </script>

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -42,7 +42,7 @@ export default {
             // tell the desktop server that the model has changed
             window.electronAPI.modelOpened(newTm.summary.title);
         }
-        this.$router.push({ name: `${this.providerType}ThreatModelEdit`, params });
+        this.$router.push({ name: `${this.providerType}ThreatModelCreate`, params });
     }
 };
 </script>

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -215,7 +215,7 @@ export default {
         async onSaveClick(evt) {
             evt.preventDefault();
             if (this.$route.name === 'gitThreatModelCreate') {
-              await this.$store.dispatch(THREATMODEL_CREATE);
+                await this.$store.dispatch(THREATMODEL_CREATE);
             } else {
                 await this.$store.dispatch(THREATMODEL_SAVE);
             }

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -173,7 +173,7 @@
     font-size: 12px;
 }
 
-select-diagram-type {
+.select-diagram-type {
     font-size: 12px;
 }
 </style>
@@ -183,7 +183,7 @@ import { mapState } from 'vuex';
 
 import { getProviderType } from '@/service/provider/providers.js';
 import TdFormButton from '@/components/FormButton.vue';
-import { THREATMODEL_CONTRIBUTORS_UPDATED, THREATMODEL_RESTORE, THREATMODEL_SAVE, THREATMODEL_UPDATE } from '@/store/actions/threatmodel.js';
+import { THREATMODEL_CONTRIBUTORS_UPDATED, THREATMODEL_CREATE, THREATMODEL_RESTORE, THREATMODEL_SAVE, THREATMODEL_UPDATE } from '@/store/actions/threatmodel.js';
 
 export default {
     name: 'ThreatModelEdit',
@@ -214,7 +214,11 @@ export default {
         },
         async onSaveClick(evt) {
             evt.preventDefault();
-            await this.$store.dispatch(THREATMODEL_SAVE);
+            if (this.$route.name === 'gitThreatModelCreate') {
+              await this.$store.dispatch(THREATMODEL_CREATE);
+            } else {
+                await this.$store.dispatch(THREATMODEL_SAVE);
+            }
             this.$router.push({ name: `${this.providerType}ThreatModel`, params: this.$route.params });
         },
         async onReloadClick(evt) {

--- a/td.vue/tests/unit/store/modules/threatmodel.spec.js
+++ b/td.vue/tests/unit/store/modules/threatmodel.spec.js
@@ -79,7 +79,7 @@ describe('store/modules/threatmodel.js', () => {
             expect(mocks.commit).toHaveBeenCalledWith(THREATMODEL_DIAGRAM_SELECTED, diagram);
         });
 
-        it('create action with the data', () => {
+        describe('create action with the data', () => {
             const data = 'foobar';
 
             beforeEach(() => {
@@ -87,18 +87,11 @@ describe('store/modules/threatmodel.js', () => {
                     success: jest.fn(),
                     error: jest.fn()
                 };
-            });
-
-            describe('local provider', () => {
-                beforeEach(async () => {
-                    save.local = jest.fn();
-                    mocks.rootState.provider.selected = 'local';
-                    await threatmodelModule.actions[THREATMODEL_CREATE](mocks, 'tm');
-                });
-
-                it('saves the file locally', () => {
-                    expect(save.local).toHaveBeenCalledTimes(1);
-                });
+                mocks.state.data = {
+                    summary: {
+                        title: 'New Threat Model'
+                    }
+                };
             });
 
             describe('git provider', () => {
@@ -338,14 +331,6 @@ describe('store/modules/threatmodel.js', () => {
 
             it('resets the selectedDiagram property', () => {
                 expect(threatmodelModule.state.selectedDiagram).toEqual({});
-            });
-        });
-
-        describe('create', () => {
-            it('sets the threat model', () => {
-                const tm = { foo: 'bar' };
-                threatmodelModule.mutations[THREATMODEL_CREATE](threatmodelModule.state, tm);
-                expect(threatmodelModule.state.data).toEqual(tm);
             });
         });
 

--- a/td.vue/tests/unit/views/newThreatModel.spec.js
+++ b/td.vue/tests/unit/views/newThreatModel.spec.js
@@ -16,7 +16,6 @@ describe('NewThreatModel.vue', () => {
                 },
                 actions: {
                     'THREATMODEL_CLEAR': () => {},
-                    'THREATMODEL_CREATE': () => {},
                     'THREATMODEL_SELECTED': () => {}
                 }
             });
@@ -45,6 +44,52 @@ describe('NewThreatModel.vue', () => {
         it('navigates to the edit page', () => {
             expect(router.push).toHaveBeenCalledWith({
                 name: 'localThreatModelEdit',
+                params: {
+                    foo: 'bar',
+                    threatmodel: 'New Threat Model'
+                }
+            });
+        });
+    });
+
+    describe('git provider', () => {
+        beforeEach(() => {
+            localVue = createLocalVue();
+            localVue.use(Vuex);
+            mockStore = new Vuex.Store({
+                state: {
+                    provider: { selected: 'github' }
+                },
+                actions: {
+                    'THREATMODEL_CLEAR': () => {},
+                    'THREATMODEL_SELECTED': () => {}
+                }
+            });
+            jest.spyOn(mockStore, 'dispatch');
+            router = { push: jest.fn() };
+            shallowMount(NewThreatModel, {
+                localVue,
+                store: mockStore,
+                mocks: {
+                    $router: router,
+                    $route: {
+                        params: { foo: 'bar' }
+                    }
+                }
+            });
+        });
+
+        it('clears the current threat model', () => {
+            expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_CLEAR');
+        });
+
+        it('selects the new threatModel', () => {
+            expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_SELECTED', expect.anything());
+        });
+
+        it('navigates to the edit page for creation', () => {
+            expect(router.push).toHaveBeenCalledWith({
+                name: 'gitThreatModelCreate',
                 params: {
                     foo: 'bar',
                     threatmodel: 'New Threat Model'


### PR DESCRIPTION
**Summary**
This PR fixes #631

**Description for the changelog**
Allow the creation of a threat model while using GitHub as a provider by making the ThreatModelEdit call the create method of the server when on /create url.

**Other info**
- Creation of ThreatModelCreate (/crete) url for ThreatModelEdit component to differentiate when on creation from editing a threat model.
- Change THREATMODEL_CREATE action of the threatmodel store so the new threat model gets created.
- Creation of createAsync method on threatmodelApi to call /create api endpoint.
- Change from PUT to POST of /create api endpoint of server routes.
