### PR TITLE
add threat type and score to report

### DIFF
--- a/td.vue/src/components/printed-report/ReportEntity.vue
+++ b/td.vue/src/components/printed-report/ReportEntity.vue
@@ -10,8 +10,10 @@
                 <tr>
                     <th>{{ $t('threats.properties.number') }}</th>
                     <th>{{ $t('threats.properties.title') }}</th>
+                    <th>{{ $t('threats.properties.type') }}</th>
                     <th>{{ $t('threats.properties.priority') }}</th>
                     <th>{{ $t('threats.properties.status') }}</th>
+                    <th>{{ $t('threats.properties.score') }}</th>
                     <th>{{ $t('threats.properties.description') }}</th>
                     <th>{{ $t('threats.properties.mitigation') }}</th>
                 </tr>
@@ -23,8 +25,10 @@
                 >
                     <td>{{ threat.number }}</td>
                     <td>{{ threat.title }}</td>
+                    <td>{{ threat.type }}</td>
                     <td>{{ threat.severity }}</td>
                     <td>{{ threat.status }}</td>
+                    <td>{{ threat.score }}</td>
                     <td>{{ threat.description }}</td>
                     <td>{{ threat.mitigation }}</td>
                 </tr>

--- a/td.vue/src/components/report/ReportEntity.vue
+++ b/td.vue/src/components/report/ReportEntity.vue
@@ -66,8 +66,10 @@ export default {
                 return {
                     [this.$t('threats.properties.number')]: threat.number,
                     [this.$t('threats.properties.title')]: threat.title,
+                    [this.$t('threats.properties.type')]: threat.type,
                     [this.$t('threats.properties.priority')]: threat.severity,
                     [this.$t('threats.properties.status')]: threat.status,
+                    [this.$t('threats.properties.score')]: threat.score,
                     [this.$t('threats.properties.description')]: threat.description,
                     [this.$t('threats.properties.mitigation')]: threat.mitigation
 

--- a/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
@@ -14,16 +14,22 @@ describe('components/printed-report/ReportEntity.vue', () => {
                 description: 'Some actor doing some things',
                 threats: [
                     {
+                        number: '1',
                         title: 't1',
                         severity: 'High',
+                        score: '10',
                         status: 'Open',
+                        type: 'type1',
                         description: 'Threat 1',
                         mitigation: 'We did things'
                     },
                     {
+                        number: '2',
                         title: 't2',
                         severity: 'Medium',
+                        score: '20',
                         status: 'Mitigated',
+                        type: 'type2',
                         description: 'Threat 2',
                         mitigation: 'We did other things'
                     },
@@ -71,6 +77,14 @@ describe('components/printed-report/ReportEntity.vue', () => {
             .toEqual(propsData.entity.data.description);
     });
 
+    it('shows the first threat', () => {
+        expect(tableHasCellWithText('1')).toEqual(true);
+    });
+
+    it('shows the second threat', () => {
+        expect(tableHasCellWithText('2')).toEqual(true);
+    });
+
     it('shows the first threat title', () => {
         expect(tableHasCellWithText('t1')).toEqual(true);
     });
@@ -87,12 +101,28 @@ describe('components/printed-report/ReportEntity.vue', () => {
         expect(tableHasCellWithText('Medium')).toEqual(true);
     });
 
+    it('shows the first score', () => {
+        expect(tableHasCellWithText('10')).toEqual(true);
+    });
+
+    it('shows the second score', () => {
+        expect(tableHasCellWithText('20')).toEqual(true);
+    });
+
     it('shows the open status', () => {
         expect(tableHasCellWithText('Open')).toEqual(true);
     });
 
     it('shows the mitigated status', () => {
         expect(tableHasCellWithText('Mitigated')).toEqual(true);
+    });
+
+    it('shows the first type', () => {
+        expect(tableHasCellWithText('type1')).toEqual(true);
+    });
+
+    it('shows the second type', () => {
+        expect(tableHasCellWithText('type2')).toEqual(true);
     });
 
     it('shows the threat description for t1', () => {

--- a/td.vue/tests/unit/components/report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/report/reportEntity.spec.js
@@ -15,16 +15,22 @@ describe('components/report/ReportEntity.vue', () => {
                 description: 'Some actor doing some things',
                 threats: [
                     {
+                        number: '1',
                         title: 't1',
                         severity: 'High',
+                        score: '10',
                         status: 'Open',
+                        type: 'type1',
                         description: 'Threat 1',
                         mitigation: 'We did things'
                     },
                     {
+                        number: '2',
                         title: 't2',
                         severity: 'Medium',
+                        score: '20',
                         status: 'Mitigated',
+                        type: 'type2',
                         description: 'Threat 2',
                         mitigation: 'We did other things'
                     },


### PR DESCRIPTION
**Summary**
The diagram threat attributes are added to both the printed report and the PDF report

**Description for the changelog**
add threat type and score to report

**Other info**
closes #646 