### PR TITLE
add repo select page query param

### DIFF
--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -46,6 +46,11 @@
                 </b-list-group>
             </b-col>
         </b-row>
+        <div class="pagination" v-if="pageNext || pagePrev">
+			<button @click="previous(page-1)" :disabled="!pagePrev">Previous</button>
+            <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
+			<button @click="paginate(page+1)" :disabled="!pageNext">Next</button>
+		</div>
     </b-container>    
 </template>
 
@@ -60,6 +65,21 @@ export default {
     props: {
         items: {
             required: true
+        },
+        page: {
+            required: true
+        },
+        pageNext: {
+            required: true,
+            type: Boolean
+        },
+        pagePrev: {
+            required: true,
+            type: Boolean
+        },
+        paginate: {
+            required: true,
+            type: Function
         },
         onItemClick: {
             required: true,

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -49,9 +49,9 @@
         <b-row>
             <b-col md=6 offset=3>
                 <div class="pagination">
-                    <button @click="paginate(page-1)" :disabled="!pagePrev">Previous</button>
+                    <button @click="paginate(--page)" :disabled="!pagePrev">Previous</button>
                     <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
-                    <button @click="paginate(page+1)" :disabled="!pageNext">Next</button>
+                    <button @click="paginate(++page)" :disabled="!pageNext">Next</button>
                 </div>
             </b-col>
         </b-row>

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -49,9 +49,9 @@
         <b-row>
             <b-col md=6 offset=3>
                 <div class="pagination">
-                    <button @click="paginate(page-1)" :disabled="!pagePrev">Previous</button>
+                    <button @click="paginate(--pageRef)" :disabled="!pagePrev">Previous</button>
                     <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
-                    <button @click="paginate(1 + page)" :disabled="!pageNext">Next</button>
+                    <button @click="paginate(++pageRef)" :disabled="!pageNext">Next</button>
                 </div>
             </b-col>
         </b-row>
@@ -63,7 +63,8 @@ export default {
     name: 'TdSelectionPage',
     data() {
         return {
-            filter: ''
+            filter: '',
+            pageRef: this.page
         };
     },
     props: {
@@ -72,18 +73,21 @@ export default {
         },
         page: {
             required: false,
-            type: Number
+            type: Number,
+            default: 1
         },
         pageNext: {
             required: false,
-            type: Boolean
+            type: Boolean,
+            default: false
         },
         pagePrev: {
             required: false,
-            type: Boolean
+            type: Boolean,
+            default: false
         },
         paginate: {
-            required: true,
+            required: false,
             type: Function
         },
         onItemClick: {

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -64,7 +64,7 @@ export default {
     data() {
         return {
             filter: '',
-            pageRef: this.$route.query.page ? this.$route.query.page : this.page
+            pageRef: this.page
         };
     },
     props: {

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -46,11 +46,15 @@
                 </b-list-group>
             </b-col>
         </b-row>
-        <div class="pagination" v-if="pageNext || pagePrev">
-			<button @click="previous(page-1)" :disabled="!pagePrev">Previous</button>
-            <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
-			<button @click="paginate(page+1)" :disabled="!pageNext">Next</button>
-		</div>
+        <b-row>
+            <b-col md=6 offset=3>
+                <div class="pagination">
+                    <button @click="previous(page-1)" :disabled="!pagePrev">Previous</button>
+                    <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
+                    <button @click="paginate(page+1)" :disabled="!pageNext">Next</button>
+                </div>
+            </b-col>
+        </b-row>
     </b-container>    
 </template>
 

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -49,7 +49,7 @@
         <b-row>
             <b-col md=6 offset=3>
                 <div class="pagination">
-                    <button @click="previous(page-1)" :disabled="!pagePrev">Previous</button>
+                    <button @click="paginate(page-1)" :disabled="!pagePrev">Previous</button>
                     <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
                     <button @click="paginate(page+1)" :disabled="!pageNext">Next</button>
                 </div>
@@ -71,7 +71,8 @@ export default {
             required: true
         },
         page: {
-            required: true
+            required: true,
+            type: Number
         },
         pageNext: {
             required: true,

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -71,15 +71,15 @@ export default {
             required: true
         },
         page: {
-            required: true,
+            required: false,
             type: Number
         },
         pageNext: {
-            required: true,
+            required: false,
             type: Boolean
         },
         pagePrev: {
-            required: true,
+            required: false,
             type: Boolean
         },
         paginate: {

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -49,9 +49,9 @@
         <b-row>
             <b-col md=6 offset=3>
                 <div class="pagination">
-                    <button @click="paginate(--page)" :disabled="!pagePrev">Previous</button>
+                    <button @click="paginate(page-1)" :disabled="!pagePrev">Previous</button>
                     <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
-                    <button @click="paginate(++page)" :disabled="!pageNext">Next</button>
+                    <button @click="paginate(1 + page)" :disabled="!pageNext">Next</button>
                 </div>
             </b-col>
         </b-row>

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -50,7 +50,7 @@
             <b-col md=6 offset=3>
                 <div class="pagination">
                     <button @click="paginate(--pageRef)" :disabled="!pagePrev">Previous</button>
-                    <button class="btn" data-toggle="buttons" disabled="true">{{page}}</button>
+                    <button class="btn" data-toggle="buttons" disabled="true">{{pageRef}}</button>
                     <button @click="paginate(++pageRef)" :disabled="!pageNext">Next</button>
                 </div>
             </b-col>
@@ -64,7 +64,7 @@ export default {
     data() {
         return {
             filter: '',
-            pageRef: this.page
+            pageRef: this.$route.query.page ? this.$route.query.page : this.page
         };
     },
     props: {

--- a/td.vue/src/service/api/api.js
+++ b/td.vue/src/service/api/api.js
@@ -6,8 +6,8 @@ import clientFactory from '../httpClient.js';
  * @param {String} url
  * @returns Promise
  */
-const getAsync = async (url) => {
-    const res = await clientFactory.get().get(url);
+const getAsync = async (url, query) => {
+    const res = await clientFactory.get().get(url, query);
     return res.data;
 };
 

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -20,8 +20,7 @@ const organisationAsync = () => api.getAsync(`${resource}/organisation`);
  * @returns {Promise}
  */
 const reposAsync = (page = 1) => {
-
-    api.getAsync(`${resource}/repos`, { params: { page: page } });
+    return api.getAsync(`${resource}/repos`, { params: { page: page } });
 }
 
 /**

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -19,7 +19,10 @@ const organisationAsync = () => api.getAsync(`${resource}/organisation`);
  * Gets the repos for the given user
  * @returns {Promise}
  */
-const reposAsync = () => api.getAsync(`${resource}/repos`);
+const reposAsync = (page = 1) => {
+
+    api.getAsync(`${resource}/repos`, { params: { page: page } });
+}
 
 /**
  * Gets the branches for the given repository

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -28,9 +28,9 @@ const reposAsync = (page = 1) => {
  * @param {String} fullRepoName
  * @returns {Promise}
  */
-const branchesAsync = (fullRepoName) => {
+const branchesAsync = (fullRepoName, page = 1) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.getAsync(`${resource}/${org}/${repo}/branches`);
+    return api.getAsync(`${resource}/${org}/${repo}/branches`, { params: { page: page } });
 };
 
 /**

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -21,7 +21,7 @@ const organisationAsync = () => api.getAsync(`${resource}/organisation`);
  */
 const reposAsync = (page = 1) => {
     return api.getAsync(`${resource}/repos`, { params: { page: page } });
-}
+};
 
 /**
  * Gets the branches for the given repository

--- a/td.vue/src/service/provider/providers.js
+++ b/td.vue/src/service/provider/providers.js
@@ -1,6 +1,7 @@
 import githubProvider from './github.provider.js';
 import localProvider from './local.provider.js';
 import { providerTypes } from './providerTypes.js';
+import env from '../env/Env.js';
 
 const providers = {
     github: {
@@ -32,6 +33,20 @@ export const providerNames = (() => {
 export const getDisplayName = (providerKey) => providers[providerKey].displayName;
 
 export const getProviderType = (providerKey) => providers[providerKey].type;
+
+export const getProviderUri = (providerKey) => {
+    if (providerKey == providers.github.key) {
+        const enterpriseHostname = env.get().config.GITHUB_ENTERPRISE_HOSTNAME;
+        if (enterpriseHostname) {
+            const port = env.get().config.GITHUB_ENTERPRISE_PORT;
+            const protocol = env.get().config.GITHUB_ENTERPRISE_PROTOCOL;
+    
+            return protocol + "://" + enterpriseHostname + ":" + port;
+        }
+
+        return "https://github.com"
+    }
+}
 
 /**
  * Gets the dashboard actions based on the selected provider

--- a/td.vue/src/service/provider/providers.js
+++ b/td.vue/src/service/provider/providers.js
@@ -1,7 +1,6 @@
 import githubProvider from './github.provider.js';
 import localProvider from './local.provider.js';
 import { providerTypes } from './providerTypes.js';
-import env from '../../../../td.server/src/env/Env.js';
 
 const providers = {
     github: {
@@ -33,20 +32,6 @@ export const providerNames = (() => {
 export const getDisplayName = (providerKey) => providers[providerKey].displayName;
 
 export const getProviderType = (providerKey) => providers[providerKey].type;
-
-export const getProviderUri = (providerKey) => {
-    if (providerKey == providers.github.key) {
-        const enterpriseHostname = env.get().config.GITHUB_ENTERPRISE_HOSTNAME;
-        if (enterpriseHostname) {
-            const port = env.get().config.GITHUB_ENTERPRISE_PORT;
-            const protocol = env.get().config.GITHUB_ENTERPRISE_PROTOCOL;
-    
-            return protocol + "://" + enterpriseHostname + ":" + port;
-        }
-
-        return "https://github.com"
-    }
-}
 
 /**
  * Gets the dashboard actions based on the selected provider

--- a/td.vue/src/service/provider/providers.js
+++ b/td.vue/src/service/provider/providers.js
@@ -1,7 +1,7 @@
 import githubProvider from './github.provider.js';
 import localProvider from './local.provider.js';
 import { providerTypes } from './providerTypes.js';
-import env from '../env/Env.js';
+import env from '../../../../td.server/src/env/Env.js';
 
 const providers = {
     github: {

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -10,9 +10,9 @@ import threatmodelApi from '../../service/api/threatmodelApi.js';
 export const clearState = (state) => {
     state.all.length = 0;
     state.selected = '';
-    state.page = 1,
-    state.pageNext = false,
-    state.pagePrev = false
+    state.page = 1;
+    state.pageNext = false;
+    state.pagePrev = false;
 };
 
 const state = {

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -25,9 +25,9 @@ const state = {
 
 const actions = {
     [BRANCH_CLEAR]: ({ commit }) => commit(BRANCH_CLEAR),
-    [BRANCH_FETCH]: async ({ commit, dispatch, rootState }) => {
+    [BRANCH_FETCH]: async ({ commit, dispatch, rootState }, page = 1) => {
         dispatch(BRANCH_CLEAR);
-        const resp = await threatmodelApi.branchesAsync(rootState.repo.selected);
+        const resp = await threatmodelApi.branchesAsync(rootState.repo.selected, page);
         commit(BRANCH_FETCH, { 
             'branches': resp.data.branches,
             'page': resp.data.pagination.page,

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -10,11 +10,17 @@ import threatmodelApi from '../../service/api/threatmodelApi.js';
 export const clearState = (state) => {
     state.all.length = 0;
     state.selected = '';
+    state.page = 1,
+    state.pageNext = false,
+    state.pagePrev = false
 };
 
 const state = {
     all: [],
-    selected: ''
+    selected: '',
+    page: 1,
+    pageNext: false,
+    pagePrev: false
 };
 
 const actions = {
@@ -22,15 +28,23 @@ const actions = {
     [BRANCH_FETCH]: async ({ commit, dispatch, rootState }) => {
         dispatch(BRANCH_CLEAR);
         const resp = await threatmodelApi.branchesAsync(rootState.repo.selected);
-        commit(BRANCH_FETCH, resp.data.branches);
+        commit(BRANCH_FETCH, { 
+            'branches': resp.data.branches,
+            'page': resp.data.pagination.page,
+            'pageNext': resp.data.pagination.next,
+            'pagePrev': resp.data.pagination.prev
+        });
     },
     [BRANCH_SELECTED]: ({ commit }, branch) => commit(BRANCH_SELECTED, branch)
 };
 
 const mutations = {
     [BRANCH_CLEAR]: (state) => clearState(state),
-    [BRANCH_FETCH]: (state, branches) => {
+    [BRANCH_FETCH]: (state, {branches, page, pageNext, pagePrev }) => {
         branches.forEach((branch, idx) => Vue.set(state.all, idx, branch));
+        state.page = page;
+        state.pageNext = pageNext;
+        state.pagePrev = pagePrev;
     },
     [BRANCH_SELECTED]: (state, repo) => {
         state.selected = repo;

--- a/td.vue/src/store/modules/provider.js
+++ b/td.vue/src/store/modules/provider.js
@@ -6,15 +6,18 @@ import {
     PROVIDER_SELECTED
 } from '../actions/provider.js';
 import providers from '../../service/provider/providers.js';
+import threatmodelApi from '../../service/api/threatmodelApi.js';
 
 export const clearState = (state) => {
     state.all.length = 0;
     state.selected = '';
+    state.providerUri = '';
 };
 
 const state = {
     all: [],
-    selected: ''
+    selected: '',
+    providerUri: ''
 };
 
 const actions = {
@@ -24,11 +27,13 @@ const actions = {
         // TODO: Get a list of configured providers from the backend
         commit(PROVIDER_FETCH, Object.keys(providers.providerNames));
     },
-    [PROVIDER_SELECTED]: ({ commit }, providerName) => {
+    [PROVIDER_SELECTED]: async ({ commit }, providerName) => {
         if (!providerName || !providers.providerNames[providerName]) {
             throw new Error(`Unknown provider: ${providerName}`);
         }
-        commit(PROVIDER_SELECTED, providerName);
+        const resp = await threatmodelApi.organisationAsync();
+        const providerUri = `${resp.protocol}://${resp.hostname}${resp.port ? ':' + resp.port : ''}`;
+        commit(PROVIDER_SELECTED, {'providerName': providerName, 'providerUri': providerUri});
     }
 };
 
@@ -38,8 +43,9 @@ const mutations = {
         state.all.length = 0;
         providers.forEach((provider, idx) => Vue.set(state.all, idx, provider));
     },
-    [PROVIDER_SELECTED]: (state, provider) => {
+    [PROVIDER_SELECTED]: (state, {provider, providerUri}) => {
         state.selected = provider;
+        state.providerUri;
     }
 };
 

--- a/td.vue/src/store/modules/provider.js
+++ b/td.vue/src/store/modules/provider.js
@@ -33,7 +33,7 @@ const actions = {
         }
         const resp = await threatmodelApi.organisationAsync();
         const providerUri = `${resp.protocol}://${resp.hostname}${resp.port ? ':' + resp.port : ''}`;
-        commit(PROVIDER_SELECTED, {'providerName': providerName, 'providerUri': providerUri});
+        commit(PROVIDER_SELECTED, { 'providerName': providerName, 'providerUri': providerUri });
     }
 };
 
@@ -43,9 +43,9 @@ const mutations = {
         state.all.length = 0;
         providers.forEach((provider, idx) => Vue.set(state.all, idx, provider));
     },
-    [PROVIDER_SELECTED]: (state, {provider, providerUri}) => {
-        state.selected = provider;
-        state.providerUri;
+    [PROVIDER_SELECTED]: (state, { providerName, providerUri }) => {
+        state.selected = providerName;
+        state.providerUri = providerUri;
     }
 };
 

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -29,14 +29,19 @@ const actions = {
     [REPOSITORY_FETCH]: async ({ commit, dispatch }, page=1) => {
         dispatch(REPOSITORY_CLEAR);
         const resp = await threatmodelApi.reposAsync(page);
-        commit(REPOSITORY_FETCH, resp.data.repos, resp.data.pagination.page, resp.data.pagination.next, resp.data.pagination.prev);
+        commit(REPOSITORY_FETCH, { 
+            'repos': resp.data.repos,
+            'page': resp.data.pagination.page,
+            'pageNext': resp.data.pagination.next,
+            'pagePrev': resp.data.pagination.prev
+        });
     },
     [REPOSITORY_SELECTED]: ({ commit }, repo) => commit(REPOSITORY_SELECTED, repo)
 };
 
 const mutations = {
     [REPOSITORY_CLEAR]: (state) => clearState(state),
-    [REPOSITORY_FETCH]: (state, repos, page, pageNext, pagePrev) => {
+    [REPOSITORY_FETCH]: (state, { repos, page, pageNext, pagePrev }) => {
         state.all.length = 0;
         repos.forEach((repo, idx) => Vue.set(state.all, idx, repo));
         state.page = page;

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -19,19 +19,22 @@ const state = {
 
 const actions = {
     [REPOSITORY_CLEAR]: ({ commit }) => commit(REPOSITORY_CLEAR),
-    [REPOSITORY_FETCH]: async ({ commit, dispatch }) => {
+    [REPOSITORY_FETCH]: async ({ commit, dispatch }, page=1) => {
         dispatch(REPOSITORY_CLEAR);
-        const resp = await threatmodelApi.reposAsync();
-        commit(REPOSITORY_FETCH, resp.data.repos);
+        const resp = await threatmodelApi.reposAsync(page);
+        commit(REPOSITORY_FETCH, resp.data.repos, resp.data.pagination.page, resp.data.pagination.next, resp.data.pagination.prev);
     },
     [REPOSITORY_SELECTED]: ({ commit }, repo) => commit(REPOSITORY_SELECTED, repo)
 };
 
 const mutations = {
     [REPOSITORY_CLEAR]: (state) => clearState(state),
-    [REPOSITORY_FETCH]: (state, repos) => {
+    [REPOSITORY_FETCH]: (state, repos, page, pageNext, pagePrev) => {
         state.all.length = 0;
         repos.forEach((repo, idx) => Vue.set(state.all, idx, repo));
+        state.page = page;
+        state.pageNext = pageNext;
+        state.pagePrev = pagePrev;
     },
     [REPOSITORY_SELECTED]: (state, repo) => {
         state.selected = repo;

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -10,7 +10,11 @@ import threatmodelApi from '../../service/api/threatmodelApi.js';
 export const clearState = (state) => {
     state.all.length = 0;
     state.selected = '';
+    state.page = 1,
+    state.pageNext = false,
+    state.pagePrev = false
 };
+
 
 const state = {
     all: [],

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -10,9 +10,9 @@ import threatmodelApi from '../../service/api/threatmodelApi.js';
 export const clearState = (state) => {
     state.all.length = 0;
     state.selected = '';
-    state.page = 1,
-    state.pageNext = false,
-    state.pagePrev = false
+    state.page = 1;
+    state.pageNext = false;
+    state.pagePrev = false;
 };
 
 

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -14,7 +14,10 @@ export const clearState = (state) => {
 
 const state = {
     all: [],
-    selected: ''
+    selected: '',
+    page: 1,
+    pageNext: false,
+    pagePrev: false
 };
 
 const actions = {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -4,8 +4,9 @@
         :page="page"
         :pageNext="pageNext"
         :pagePrev="pagePrev"
-        :onItemClick="onBranchClick">
-        :paginate="paginate"
+        :onItemClick="onBranchClick"
+        :paginate="paginate">
+        
         {{ $t('branch.select') }}
         <!-- Fixme: The href should get the configured hostname from env -->
         <a
@@ -54,7 +55,7 @@ export default {
             this.$store.dispatch(repoActions.selected, this.$route.params.repository);
         }
 
-        this.$store.dispatch(branchActions.fetch);
+        this.$store.dispatch(branchActions.fetch, 1);
     },
     methods: {
         selectRepoClick() {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -5,6 +5,7 @@
         :pageNext="pageNext"
         :pagePrev="pagePrev"
         :onItemClick="onBranchClick">
+        :paginate="paginate"
         {{ $t('branch.select') }}
         <!-- Fixme: The href should get the configured hostname from env -->
         <a
@@ -69,6 +70,9 @@ export default {
             const routeName = `${this.providerType}${this.$route.query.action === 'create' ? 'NewThreatModel' : 'ThreatModelSelect'}`;
 
             this.$router.push({ name: routeName, params });
+        },
+        paginate(page) {
+            this.$store.dispatch(branchActions.fetch, page);
         }
     }
 };

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -6,7 +6,7 @@
         <!-- Fixme: The href should get the configured hostname from env -->
         <a
             id="repo_link"
-            :href="`https://www.github.com/${repoName}`"
+            :href="`${providerUri}/${repoName}`"
             target="_blank"
             rel="noopener noreferrer"
         >{{ repoName }}</a>
@@ -21,7 +21,7 @@
 import { mapState } from 'vuex';
 
 import branchActions from '@/store/actions/branch.js';
-import { getProviderType } from '@/service/provider/providers.js';
+import { getProviderType, getProviderUri } from '@/service/provider/providers.js';
 import providerActions from '@/store/actions/provider.js';
 import repoActions from '@/store/actions/repository.js';
 import TdSelectionPage from '@/components/SelectionPage.vue';
@@ -35,6 +35,7 @@ export default {
         branches: (state) => state.branch.all,
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
+        providerUri: (state) => getProviderUri(state.provider.selected),
         repoName: (state) => state.repo.selected
     }),
     mounted() {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -59,7 +59,7 @@ export default {
     },
     methods: {
         selectRepoClick() {
-            //this.$store.dispatch(repoActions.clear);
+            this.$store.dispatch(repoActions.clear);
             this.$router.push({ name: `${this.providerType}Repository` });
         },
         onBranchClick(branch) {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -59,7 +59,7 @@ export default {
     },
     methods: {
         selectRepoClick() {
-            this.$store.dispatch(repoActions.clear);
+            //this.$store.dispatch(repoActions.clear);
             this.$router.push({ name: `${this.providerType}Repository` });
         },
         onBranchClick(branch) {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -1,6 +1,9 @@
 <template>
     <td-selection-page
         :items="branches"
+        :page="page"
+        :pageNext="pageNext"
+        :pagePrev="pagePrev"
         :onItemClick="onBranchClick">
         {{ $t('branch.select') }}
         <!-- Fixme: The href should get the configured hostname from env -->
@@ -36,7 +39,10 @@ export default {
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
         providerUri: (state) => state.provider.providerUri,
-        repoName: (state) => state.repo.selected
+        repoName: (state) => state.repo.selected,
+        page: (state) => state.branch.page,
+        pageNext: (state) => state.branch.pageNext,
+        pagePrev: (state) => state.branch.pagePrev
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -25,7 +25,7 @@
 import { mapState } from 'vuex';
 
 import branchActions from '@/store/actions/branch.js';
-import { getProviderType, getProviderUri } from '@/service/provider/providers.js';
+import { getProviderType } from '@/service/provider/providers.js';
 import providerActions from '@/store/actions/provider.js';
 import repoActions from '@/store/actions/repository.js';
 import TdSelectionPage from '@/components/SelectionPage.vue';

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -35,7 +35,7 @@ export default {
         branches: (state) => state.branch.all,
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
-        providerUri: (state) => getProviderUri(state.provider.selected),
+        providerUri: (state) => state.provider.providerUri,
         repoName: (state) => state.repo.selected
     }),
     mounted() {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -1,7 +1,11 @@
 <template>
     <td-selection-page
         :items="repositories"
+        :page="page"
+        :pageNext="pageNext"
+        :pagePrev="pagePrev"
         :onItemClick="onRepoClick"
+        :paginate="paginate"
         :emptyStateText="`${$t('repository.noneFound')} ${$t('providers.' + provider + '.displayName')}`">
         {{ $t('repository.select') }} {{ $t(`providers.${provider}.displayName`) }} {{ $t('repository.from') }}
     </td-selection-page>
@@ -23,7 +27,10 @@ export default {
     computed: mapState({
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
-        repositories: (state) => state.repo.all
+        repositories: (state) => state.repo.all,
+        page: (state) => state.page,
+        pageNext: (state) => state.pageNext,
+        pagePrev: (state) => state.pagePrev
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {
@@ -40,6 +47,9 @@ export default {
             });
             this.$router.push({ name: `${this.providerType}Branch`, params, query: this.$route.query });
         },
+        paginate(page) {
+            this.$store.dispatch(repoActions.fetch, page);
+        }
     }
 };
 </script>

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -36,8 +36,14 @@ export default {
         if (this.provider !== this.$route.params.provider) {
             this.$store.dispatch(providerActions.selected, this.$route.params.provider);
         }
+        const page = 1;
+        if (this.$route.query.page) {
+            page = this.$route.query.page;
+        } else if(this.$store.state.repo.page) {
+            page = this.$store.state.repo.page;
+        }
 
-        this.$store.dispatch(repoActions.fetch, 1);
+        this.$store.dispatch(repoActions.fetch, page);
     },
     methods: {
         onRepoClick(repoName) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -37,7 +37,7 @@ export default {
             this.$store.dispatch(providerActions.selected, this.$route.params.provider);
         }
 
-        this.$store.dispatch(repoActions.fetch);
+        this.$store.dispatch(repoActions.fetch, 1);
     },
     methods: {
         onRepoClick(repoName) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -39,7 +39,7 @@ export default {
         let page = 1;
         if (this.$route.query.page) {
             page = this.$route.query.page;
-        } else if(this.$store.state.repo.page) {
+        } else if(this.$store.state.repo.page && window.history.state.back.endsWith("/branch")) {
             page = this.$store.state.repo.page;
         }
 

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -28,7 +28,7 @@ export default {
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
         repositories: (state) => state.repo.all,
-        page: (state) => state.repo.page,
+        page: (state) => { route.query.page ? route.query.page : state.repo.page },
         pageNext: (state) => state.repo.pageNext,
         pagePrev: (state) => state.repo.pagePrev
     }),

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -28,7 +28,7 @@ export default {
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
         repositories: (state) => state.repo.all,
-        page: (state) => { this.$route.query.page ? this.$route.query.page : state.repo.page },
+        page: (state) => state.repo.page,
         pageNext: (state) => state.repo.pageNext,
         pagePrev: (state) => state.repo.pagePrev
     }),

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -28,7 +28,7 @@ export default {
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
         repositories: (state) => state.repo.all,
-        page: (state) => { route.query.page ? route.query.page : state.repo.page },
+        page: (state) => { this.$route.query.page ? this.$route.query.page : state.repo.page },
         pageNext: (state) => state.repo.pageNext,
         pagePrev: (state) => state.repo.pagePrev
     }),

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -36,7 +36,7 @@ export default {
         if (this.provider !== this.$route.params.provider) {
             this.$store.dispatch(providerActions.selected, this.$route.params.provider);
         }
-        const page = 1;
+        let page = 1;
         if (this.$route.query.page) {
             page = this.$route.query.page;
         } else if(this.$store.state.repo.page) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -28,9 +28,9 @@ export default {
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
         repositories: (state) => state.repo.all,
-        page: (state) => state.page,
-        pageNext: (state) => state.pageNext,
-        pagePrev: (state) => state.pagePrev
+        page: (state) => state.repo.page,
+        pageNext: (state) => state.repo.pageNext,
+        pagePrev: (state) => state.repo.pagePrev
     }),
     mounted() {
         if (this.provider !== this.$route.params.provider) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -39,8 +39,6 @@ export default {
         let page = 1;
         if (this.$route.query.page) {
             page = this.$route.query.page;
-        } else if(this.$store.state.repo.page && window.history.state.back.endsWith("/branch")) {
-            page = this.$store.state.repo.page;
         }
 
         this.$store.dispatch(repoActions.fetch, page);

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -7,7 +7,7 @@
             {{ $t('threatmodelSelect.select') }}
             <!-- Fixme: The href should get the configured hostname from env -->
             <a
-                :href="`https://www.github.com/${repoName}`"
+                :href="`${providerUri}/${repoName}`"
                 target="_blank"
                 rel="noopener noreferrer"
             >{{ `${repoName}/${branch}` }}</a>
@@ -39,6 +39,7 @@ export default {
         branch: (state) => state.branch.selected,
         provider: (state) => state.provider.selected,
         providerType: (state) => getProviderType(state.provider.selected),
+        providerUri: (state) => state.provider.providerUri,
         repoName: (state) => state.repo.selected,
         threatModels: (state) => state.threatmodel.all,
         selectedModel: (state) => state.threatmodel.data

--- a/td.vue/tests/unit/service/api/api.spec.js
+++ b/td.vue/tests/unit/service/api/api.spec.js
@@ -3,6 +3,7 @@ import httpClient from '@/service/httpClient.js';
 
 describe('service/api.js', () => {
     const url = 'http://threatdragon.org/api/foobar';
+    const query = {page: 1};
     const mockResp = { data: 'foo' };
     const mockClient = {
         get: () => mockResp,
@@ -21,11 +22,11 @@ describe('service/api.js', () => {
 
     describe('getAsync', () => {
         beforeEach(async () => {
-            res = await api.getAsync(url);
+            res = await api.getAsync(url, query);
         });
 
         it('calls client.get', () => {
-            expect(mockClient.get).toHaveBeenCalledWith(url);
+            expect(mockClient.get).toHaveBeenCalledWith(url, query);
         });
 
         it('returns the data', () => {

--- a/td.vue/tests/unit/service/api/threatmodelApi.spec.js
+++ b/td.vue/tests/unit/service/api/threatmodelApi.spec.js
@@ -23,7 +23,7 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the repos endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/repos');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/repos', {"params": {"page": 1}});
         });
     });
 
@@ -35,7 +35,7 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the branches endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/threat-dragon/branches');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/threat-dragon/branches', {"params": {"page": 1}});
         });
     });
 

--- a/td.vue/tests/unit/store/modules/branch.spec.js
+++ b/td.vue/tests/unit/store/modules/branch.spec.js
@@ -33,6 +33,18 @@ describe('store/modules/branch.js', () => {
         it('defines a selected string', () => {
             expect(branchModule.state.selected).toEqual('');
         });
+
+        it('defines a page number', () => {
+            expect(branchModule.state.page).toEqual(1);
+        });
+
+        it('defines a pageNext bool', () => {
+            expect(branchModule.state.pageNext).toEqual(false);
+        });
+
+        it('defines a pagePrev bool', () => {
+            expect(branchModule.state.pagePrev).toEqual(false);
+        });
     });
 
     describe('actions', () => {
@@ -43,9 +55,14 @@ describe('store/modules/branch.js', () => {
 
         describe('fetch', () => {
             const branches = [ 'foo', 'bar' ];
+            const pagination = {
+                page: 1,
+                next: true,
+                prev: false
+            }
 
             beforeEach(async () => {
-                jest.spyOn(threatmodelApi, 'branchesAsync').mockResolvedValue({ data: { branches }});
+                jest.spyOn(threatmodelApi, 'branchesAsync').mockResolvedValue({ data: { branches, pagination }});
                 await branchModule.actions[BRANCH_FETCH](mocks);
             });
 
@@ -56,7 +73,12 @@ describe('store/modules/branch.js', () => {
             it('commits the fetch action', () => {
                 expect(mocks.commit).toHaveBeenCalledWith(
                     BRANCH_FETCH,
-                    branches
+                    {
+                        'branches': branches,
+                        'page': pagination.page,
+                        'pageNext': pagination.next,
+                        'pagePrev': pagination.prev
+                    } 
                 );
             });
         });
@@ -74,6 +96,9 @@ describe('store/modules/branch.js', () => {
                 branchModule.state.all.push('test1');
                 branchModule.state.all.push('test2');
                 branchModule.state.selected = 'test5';
+                branchModule.state.page = 1;
+                branchModule.state.pageNext = false;
+                branchModule.state.pagePrev = false;
                 branchModule.mutations[BRANCH_CLEAR](branchModule.state);
             });
 
@@ -83,6 +108,18 @@ describe('store/modules/branch.js', () => {
 
             it('resets the selected property', () => {
                 expect(branchModule.state.selected).toEqual('');
+            });
+
+            it('resets the page property', () => {
+                expect(branchModule.state.page).toEqual(1);
+            });
+
+            it('resets the pageNext property', () => {
+                expect(branchModule.state.pageNext).toEqual(false);
+            });
+
+            it('resets the pagePrev property', () => {
+                expect(branchModule.state.pagePrev).toEqual(false);
             });
         });
 

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -1,6 +1,7 @@
 import { PROVIDER_CLEAR, PROVIDER_FETCH, PROVIDER_SELECTED } from '@/store/actions/provider.js';
 import providerModule, { clearState } from '@/store/modules/provider.js';
 import providerService from '@/service/provider/providers.js';
+import threatmodelApi from '@/service/api/threatmodelApi.js';
 
 describe('store/modules/provider.js', () => {
     const mocks = {

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -56,11 +56,6 @@ describe('store/modules/provider.js', () => {
         });
         
         describe('selected', () => {
-            const organization = {
-                'protocol': 'https',
-                'hostname': 'github.com',
-                'port': ''
-            };
             beforeEach(async () => {
                 jest.spyOn(threatmodelApi, 'organisationAsync').mockResolvedValue(
                     { 

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -26,6 +26,10 @@ describe('store/modules/provider.js', () => {
         it('defines a selected string', () => {
             expect(providerModule.state.selected).toEqual('');
         });
+
+        it('defines a providerUri string', () => {
+            expect(providerModule.state.providerUri).toEqual('');
+        });
     });
 
     describe('actions', () => {
@@ -53,26 +57,34 @@ describe('store/modules/provider.js', () => {
         
         describe('selected', () => {
             const organization = {
-                'protocol': 'http',
+                'protocol': 'https',
                 'hostname': 'github.com',
                 'port': ''
             };
             beforeEach(async () => {
-                jest.spyOn(threatmodelApi, 'organisationAsync').mockResolvedValue({ data: organization});
-                await providerModule.actions[PROVIDER_SELECTED](mocks);
+                jest.spyOn(threatmodelApi, 'organisationAsync').mockResolvedValue(
+                    { 
+                        'protocol': 'https',
+                        'hostname': 'github.com',
+                        'port': ''
+                    });
             });
 
-            it('throws an error if providerName is falsy', () => {
-                expect(() => providerModule.actions[PROVIDER_SELECTED](mocks)).toThrowError();
+            it('throws an error if providerName is falsy', async () => {
+                await expect(() => providerModule.actions[PROVIDER_SELECTED](mocks)).rejects.toThrowError();
             });
 
-            it('throws an error for an unknown provider', () => {
-                expect(() => providerModule.actions[PROVIDER_SELECTED](mocks, 'fake')).toThrowError();
+            it('throws an error for an unknown provider', async () => {
+                await expect(() => providerModule.actions[PROVIDER_SELECTED](mocks, 'fake')).rejects.toThrowError();
             });
 
-            it('commits the selected provider', () => {
-                providerModule.actions[PROVIDER_SELECTED](mocks, providerService.providerNames.github);
-                expect(mocks.commit).toHaveBeenCalledWith(PROVIDER_SELECTED, providerService.providerNames.github);
+            it('commits the selected provider', async () => {
+                await providerModule.actions[PROVIDER_SELECTED](mocks, providerService.providerNames.github);
+                expect(mocks.commit).toHaveBeenCalledWith(PROVIDER_SELECTED, 
+                    { 
+                        'providerName': providerService.providerNames.github, 
+                        'providerUri': 'https://github.com' 
+                    });
             });
         });
     });
@@ -83,6 +95,7 @@ describe('store/modules/provider.js', () => {
                 providerModule.state.all.push('test1');
                 providerModule.state.all.push('test2');
                 providerModule.state.selected = 'github';
+                providerModule.state.providerUri = 'https://github.com';
                 providerModule.mutations[PROVIDER_CLEAR](providerModule.state);
             });
 
@@ -92,6 +105,10 @@ describe('store/modules/provider.js', () => {
 
             it('resets the selected property', () => {
                 expect(providerModule.state.selected).toEqual('');
+            });
+
+            it('resets the providerUri property', () => {
+                expect(providerModule.state.providerUri).toEqual('');
             });
         });
 
@@ -110,13 +127,18 @@ describe('store/modules/provider.js', () => {
 
         describe('selected', () => {
             const provider = 'test';
+            const providerUri = 'https://github.com';
 
             beforeEach(() => {
-                providerModule.mutations[PROVIDER_SELECTED](providerModule.state, provider);
+                providerModule.mutations[PROVIDER_SELECTED](providerModule.state, {'providerName': provider, 'providerUri': providerUri});
             });
 
             it('sets the provider prop', () => {
                 expect(providerModule.state.selected).toEqual(provider);
+            });
+
+            it('sets the providerUri prop', () => {
+                expect(providerModule.state.providerUri).toEqual(providerUri);
             });
         });
     });

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -51,6 +51,16 @@ describe('store/modules/provider.js', () => {
         });
         
         describe('selected', () => {
+            const organization = {
+                'protocol': 'http',
+                'hostname': 'github.com',
+                'port': ''
+            };
+            beforeEach(async () => {
+                jest.spyOn(threatmodelApi, 'organisationAsync').mockResolvedValue({ data: organization});
+                await providerModule.actions[PROVIDER_SELECTED](mocks);
+            });
+
             it('throws an error if providerName is falsy', () => {
                 expect(() => providerModule.actions[PROVIDER_SELECTED](mocks)).toThrowError();
             });

--- a/td.vue/tests/unit/store/modules/repository.spec.js
+++ b/td.vue/tests/unit/store/modules/repository.spec.js
@@ -73,8 +73,8 @@ describe('store/modules/repository.js', () => {
                     {
                         'repos': repos,
                         'page': pagination.page,
-                        'pageNext': pagination.pageNext,
-                        'pagePrev': pagination.pagePrev
+                        'pageNext': pagination.next,
+                        'pagePrev': pagination.prev
                     }
                 );
             });

--- a/td.vue/tests/unit/store/modules/repository.spec.js
+++ b/td.vue/tests/unit/store/modules/repository.spec.js
@@ -30,6 +30,18 @@ describe('store/modules/repository.js', () => {
         it('defines a selected string', () => {
             expect(repoModule.state.selected).toEqual('');
         });
+
+        it('defines a page number', () => {
+            expect(repoModule.state.page).toEqual(1);
+        });
+
+        it('defines a pageNext bool', () => {
+            expect(repoModule.state.pageNext).toEqual(false);
+        });
+
+        it('defines a pagePrev bool', () => {
+            expect(repoModule.state.pagePrev).toEqual(false);
+        });
     });
 
     describe('actions', () => {
@@ -40,10 +52,15 @@ describe('store/modules/repository.js', () => {
 
         describe('fetch', () => {
             const repos = [ 'foo', 'bar' ];
+            const pagination = {
+                page: 1,
+                next: true,
+                prev: false
+            }
 
             beforeEach(async () => {
-                jest.spyOn(threatmodelApi, 'reposAsync').mockResolvedValue({ data: { repos }});
-                await repoModule.actions[REPOSITORY_FETCH](mocks);
+                jest.spyOn(threatmodelApi, 'reposAsync').mockResolvedValue({ data: { repos, pagination }});
+                await repoModule.actions[REPOSITORY_FETCH](mocks, 1);
             });
 
             it('dispatches the clear event', () => {
@@ -53,7 +70,12 @@ describe('store/modules/repository.js', () => {
             it('commits the fetch action', () => {
                 expect(mocks.commit).toHaveBeenCalledWith(
                     REPOSITORY_FETCH,
-                    repos
+                    {
+                        'repos': repos,
+                        'page': pagination.page,
+                        'pageNext': pagination.pageNext,
+                        'pagePrev': pagination.pagePrev
+                    }
                 );
             });
         });
@@ -71,6 +93,9 @@ describe('store/modules/repository.js', () => {
                 repoModule.state.all.push('test1');
                 repoModule.state.all.push('test2');
                 repoModule.state.selected = 'github';
+                repoModule.state.page = 1;
+                repoModule.state.pageNext = false;
+                repoModule.state.pagePrev = false;
                 repoModule.mutations[REPOSITORY_CLEAR](repoModule.state);
             });
 
@@ -80,6 +105,18 @@ describe('store/modules/repository.js', () => {
 
             it('resets the selected property', () => {
                 expect(repoModule.state.selected).toEqual('');
+            });
+
+            it('resets the page property', () => {
+                expect(repoModule.state.page).toEqual(1);
+            });
+
+            it('resets the pageNext property', () => {
+                expect(repoModule.state.pageNext).toEqual(false);
+            });
+
+            it('resets the pagePrev property', () => {
+                expect(repoModule.state.pagePrev).toEqual(false);
             });
         });
 

--- a/td.vue/tests/unit/views/branchAccess.spec.js
+++ b/td.vue/tests/unit/views/branchAccess.spec.js
@@ -35,11 +35,17 @@ describe('views/BranchAccess.vue', () => {
     const getMockStore = () => new Vuex.Store({
         state: {
             repo: {
-                selected: repo
+                selected: repo,
+                page: 1,
+                pageNext: true,
+                pagePrev: false
             },
             branch: {
                 selected: 'someBranch',
-                all: ['b1', 'b2', 'b3']
+                all: ['b1', 'b2', 'b3'],
+                page: 1,
+                pageNext: true,
+                pagePrev: false
             },
             provider: {
                 selected: 'github'
@@ -82,7 +88,7 @@ describe('views/BranchAccess.vue', () => {
                     repository: mockStore.state.repo.selected
                 }
             });
-            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_FETCH);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_FETCH, 1);
         });
     });
 

--- a/td.vue/tests/unit/views/repositoryAccess.spec.js
+++ b/td.vue/tests/unit/views/repositoryAccess.spec.js
@@ -37,7 +37,10 @@ describe('views/RepositoryAccess.vue', () => {
             },
             repo: {
                 all: [],
-                selected: ''
+                selected: '',
+                page: 1,
+                pageNext: true,
+                pagePrev: false
             }
         },
         actions: {
@@ -53,6 +56,9 @@ describe('views/RepositoryAccess.vue', () => {
             getLocalVue({
                 params: {
                     provider: 'local'
+                },
+                query: {
+                    page: 1
                 }
             });
             expect(mockStore.dispatch).toHaveBeenCalledWith(PROVIDER_SELECTED, 'local');
@@ -62,9 +68,12 @@ describe('views/RepositoryAccess.vue', () => {
             getLocalVue({
                 params: {
                     provider: mockStore.state.provider.selected
+                },
+                query: {
+                    page: 1
                 }
             });
-            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, 1);
         });
     });
 
@@ -73,6 +82,9 @@ describe('views/RepositoryAccess.vue', () => {
             getLocalVue({
                 params: {
                     provider: mockStore.state.provider.selected
+                },
+                query: {
+                    page: 1
                 }
             });
         });

--- a/td.vue/tests/unit/views/repositoryAccess.spec.js
+++ b/td.vue/tests/unit/views/repositoryAccess.spec.js
@@ -108,7 +108,11 @@ describe('views/RepositoryAccess.vue', () => {
             };
 
             getLocalVue({
-                params: mockRoute
+                params: mockRoute,
+                query: {
+                    page: 1
+                }
+                
             });
             wrapper.vm.onRepoClick(repoName);
         });

--- a/td.vue/tests/unit/views/repositoryAccess.spec.js
+++ b/td.vue/tests/unit/views/repositoryAccess.spec.js
@@ -100,6 +100,9 @@ describe('views/RepositoryAccess.vue', () => {
 
     describe('onRepoClick', () => {
         const repoName = 'fakeRepo';
+        const query = {
+            page: 1
+        }
         let mockRoute;
 
         beforeEach(() => {
@@ -109,10 +112,7 @@ describe('views/RepositoryAccess.vue', () => {
 
             getLocalVue({
                 params: mockRoute,
-                query: {
-                    page: 1
-                }
-                
+                query
             });
             wrapper.vm.onRepoClick(repoName);
         });
@@ -123,7 +123,7 @@ describe('views/RepositoryAccess.vue', () => {
 
         it('navigates to the branch select page', () => {
             mockRoute.repository = repoName;
-            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitBranch', params: mockRoute });
+            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitBranch', params: mockRoute,  query});
         });
     });
 });


### PR DESCRIPTION
**Summary**:
Adds pagination to repository and branch selection screen. Currently only the first ~30 repositories a user has access to are shown with no way to view others. Fixes issue with repo URI being hardcoded to github.com on the same screens.

**Description for the changelog**:
Adds pagination to repository and branch selection screens.

**Other info**:
closes #547 

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
