### PR TITLE
Add await to provider selection call

### DIFF
--- a/td.vue/src/components/ProviderLoginButton.vue
+++ b/td.vue/src/components/ProviderLoginButton.vue
@@ -37,7 +37,7 @@ export default {
     },
     methods: {
         async onProviderClick() {
-            this.$store.dispatch(PROVIDER_SELECTED, this.provider.key);
+            await this.$store.dispatch(PROVIDER_SELECTED, this.provider.key);
 
             if (this.provider.key === providerNames.local) {
                 this.$store.dispatch(AUTH_SET_LOCAL);


### PR DESCRIPTION
**Summary**:
Small edge case race condition occurs when user logs out and then without refreshing clicks the local login button resulting in the provider not being set yet. This is due to a new async call being made in the provider selection action which would allow the dashboard render to occur before the provider state mutation was committed. 

**Description for the changelog**:
Add await to provider selection call to fix log out and network call cache edge case.

**Other info**:
Bug introduced in #688 


Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
