### PR TITLE
diagrams added on individual rows

### DIFF
--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -89,7 +89,7 @@
                     </b-form-row>
 
                     <b-form-row>
-                        <b-col md=6
+                        <b-col md=8
                             v-for="(diagram, idx) in model.detail.diagrams"
                             :key="idx"
                         >
@@ -125,7 +125,9 @@
                                 </b-input-group-append>
                             </b-input-group>
                         </b-col>
+                    </b-form-row>
 
+                    <b-form-row>
                         <b-col md=6>
                             <a href="javascript:void(0)" @click="onAddDiagramClick" class="add-diagram-link m-2">
                                 <font-awesome-icon icon="plus"></font-awesome-icon>


### PR DESCRIPTION
**Summary**:
When editing the threat model, the diagram attributes were displayed in two columns, which did not leave enough space for viewing the diagram descriptions

**Description for the changelog**:
one diagram per line when adding to threat model

**Other info**:
closes #699 

