### PR TITLE
bugfix for report crash on empty diagram

### DIFF
--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -241,7 +241,8 @@ export default {
                 diagramType: 'STRIDE',
                 placeholder: this.$t('threatmodel.diagram.stride.defaultDescription'),
                 thumbnail: './public/content/images/thumbnail.stride.jpg',
-                version: this.version
+                version: this.version,
+                cells: []
             };
             this.$store.dispatch(THREATMODEL_UPDATE, { diagramTop: this.diagramTop + 1 });
             this.model.detail.diagrams.push(newDiagram);


### PR DESCRIPTION
**Summary**:
The report feature crashed if the diagram had no cells defined, this pull request fixes this bug

**Description for the changelog**:
bugfix for report crash on empty diagram

**Other info**:
closes #704 
