### PR TITLE
Update jwt.helper.js to increase Github JWT Token duration

### DIFF
--- a/td.server/src/helpers/jwt.helper.js
+++ b/td.server/src/helpers/jwt.helper.js
@@ -11,11 +11,11 @@ const createAsync = async (providerName, providerOptions, user) => {
     };
     // Explore other options including issuer, scope, etc
     const accessToken = jsonwebtoken.sign({ provider, user }, env.get().config.ENCRYPTION_JWT_SIGNING_KEY, {
-        expiresIn: '5m'
+        expiresIn: '1d'
     });
 
     const refreshToken = jsonwebtoken.sign({ provider, user }, env.get().config.ENCRYPTION_JWT_REFRESH_SIGNING_KEY, {
-        expiresIn: '24h'
+        expiresIn: '7d'
     });
 
     return { accessToken, refreshToken };


### PR DESCRIPTION
**Summary**:
Currently Github users are logged out after 5 minutes. This makes it impossible to save changes without refreshing and losing all unsaved changes. As far as I can tell, refresh tokens have not been implemented currently. Increasing the JWT token duration to 1 day should make it more practical to edit Github models. A longer term solution is to finish implementation of refresh tokens.

**Description for the changelog**:
Update access token and refresh token duration.
Access token updated to 1 day from 5 minutes.
Refresh token updated to 7 days from 24 hours.

**Other info**:
None