### PR TITLE
Add GitHub search option/feature for #733

### DIFF
--- a/td.server/src/controllers/threatmodelcontroller.js
+++ b/td.server/src/controllers/threatmodelcontroller.js
@@ -8,8 +8,18 @@ const logger = loggerHelper.get('controllers/threatmodelcontroller.js');
 
 const repos = (req, res) => responseWrapper.sendResponseAsync(async () => {
     const page = req.query.page || 1;
-    const reposResp = await repository.reposAsync(page, req.provider.access_token);
-    const repos = reposResp[0];
+    var reposResp;
+    var repos;
+    if (env.get().config.GITHUB_USE_SEARCH === 'true') {
+        logger.debug('Using searchAsync');
+        const searchQuery = env.get().config.GITHUB_SEARCH_QUERY;
+        reposResp = await repository.searchAsync(page, req.provider.access_token, searchQuery);
+        repos = reposResp[0]['items'];
+    } else {
+        logger.debug('Using reposAsync');
+        reposResp = await repository.reposAsync(page, req.provider.access_token);
+        repos = reposResp[0];
+    }
     const headers = reposResp[1];
     logger.debug('API repos request: ' + req);
 

--- a/td.server/src/env/Github.js
+++ b/td.server/src/env/Github.js
@@ -16,7 +16,9 @@ class GithubEnv extends Env {
             { key: 'SCOPE', required: false },
             { key: 'ENTERPRISE_HOSTNAME', required: false },
             { key: 'ENTERPRISE_PROTOCOL', required: false },
-            { key: 'ENTERPRISE_PORT', required: false }
+            { key: 'ENTERPRISE_PORT', required: false },
+            { key: 'USE_SEARCH', required: false },
+            { key: 'SEARCH_QUERY', required: false }
         ];
     }
 }

--- a/td.server/src/repositories/threatmodelrepository.js
+++ b/td.server/src/repositories/threatmodelrepository.js
@@ -19,6 +19,9 @@ const getClient = (accessToken) => {
 const reposAsync = (page, accessToken) => getClient(accessToken).me().
 reposAsync(page);
 
+const searchAsync = (accessToken, searchQuery) => getClient(accessToken).search()
+    .reposAsync({ q: searchQuery });
+
 const userAsync = async (accessToken) => {
     const resp = await getClient(accessToken).me().
 infoAsync();
@@ -87,6 +90,7 @@ export default {
     modelAsync,
     modelsAsync,
     reposAsync,
+    searchAsync,
     updateAsync,
     userAsync
 };


### PR DESCRIPTION
**Summary**:
This is somewhat of a rough PoC for enabling the use of GitHub repo search, rather than relying on a list of all repos accessible to the user. In the future, there might be a more user-friendly way to do this.

This adds:
- Two new GitHub-related env vars:
  - `GITHUB_USE_SEARCH`: if `true`, uses octonode's `search.reposAsync` instead of `reposAsync` passing in a search query
  - `GITHUB_SEARCH_QUERY`: specifies the search query to use when searching for repos for Threat Dragon to use

- A conditional check in `threatmodelcontroller` determines whether to use `reposAsync` _or_ `search.reposAsync` based on the above.

- A wrapper function in `threatmodelrepository` to use octonode's `search.reposAsync`, passing in the aforementioned search query.

<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->

**Description for the changelog**:
Add two env var config options for using GitHub repo search (`GITHUB_USE_SEARCH`) and providing a query (`GITHUB_SEARCH_QUERY`).
<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->

**Other info**:
closes #733 
<!--
Add here any other information that may be of help to the reviewer
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
