### PR TITLE
Diagram style updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@
 !td.vue/src/service/provider/
 !td.vue/src/service/threats/
 !td.vue/src/service/x6/
+!td.vue/src/service/x6/graph/
+!td.vue/src/service/x6/shapes/
 !td.vue/src/store/
 !td.vue/src/store/actions/
 !td.vue/src/store/modules/

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,8 @@
 !td.vue/tests/unit/service/provider/
 !td.vue/tests/unit/service/threats/
 !td.vue/tests/unit/service/x6/
+!td.vue/tests/unit/service/x6/graph/
+!td.vue/tests/unit/service/x6/shapes/
 !td.vue/tests/unit/store/actions/
 !td.vue/tests/unit/store/modules/
 !td.vue/tests/unit/views/

--- a/ThreatDragonModels/test-reports.json
+++ b/ThreatDragonModels/test-reports.json
@@ -284,7 +284,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -323,7 +323,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": "5 2"
               }
@@ -362,7 +362,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -401,7 +401,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": "5 2"
               }
@@ -570,7 +570,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -795,7 +795,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }

--- a/ThreatDragonModels/test-reports.json
+++ b/ThreatDragonModels/test-reports.json
@@ -1,0 +1,952 @@
+{
+  "version": "2.0.3",
+  "summary": {
+    "title": "+test model+",
+    "owner": "+test owner+",
+    "description": "+testing report mechanisms+",
+    "id": 0
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [
+      {
+        "id": 0,
+        "title": "03 - test STRIDE diagram",
+        "diagramType": "STRIDE",
+        "placeholder": "New STRIDE diagram description",
+        "thumbnail": "./public/content/images/thumbnail.stride.jpg",
+        "version": "2.0.2",
+        "cells": [
+          {
+            "position": {
+              "x": 229.375,
+              "y": 80.0000000000004
+            },
+            "size": {
+              "width": 170,
+              "height": 90.66666666666667
+            },
+            "attrs": {
+              "text": {
+                "text": "Out of scope"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": "5 2"
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 1,
+            "id": "578b5170-74f1-401d-a72f-c06ccc966ca0",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Out of scope",
+              "description": "",
+              "outOfScope": true,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 471,
+              "y": 80.0000000000004
+            },
+            "size": {
+              "width": 168.75,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "In scope"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 2,
+            "id": "cd7b94a3-65af-489e-a0f5-d2d173d6e8fc",
+            "data": {
+              "type": "tm.Actor",
+              "name": "In scope",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 230,
+              "y": 265.0000000000001
+            },
+            "size": {
+              "width": 168.75,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Out of scope\nwith unmitigated threat"
+              },
+              "body": {
+                "stroke": "red",
+                "strokeWidth": 3,
+                "strokeDasharray": "5 2"
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 3,
+            "id": "82149a02-1bcb-4d06-a93b-d498d94efa68",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Out of scope\nwith unmitigated threat",
+              "description": "",
+              "outOfScope": true,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": true,
+              "threats": [
+                {
+                  "id": "a05d7240-9259-47b3-9d4b-4c8806db2fc0",
+                  "title": "Out of scope threat",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Spoofing",
+                  "description": "Provide a description for this threat",
+                  "mitigation": "Provide remediation for this threat or a reason if status is N/A",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 1,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 471,
+              "y": 265.0000000000001
+            },
+            "size": {
+              "width": 168.75,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "In scope\nwith unmitigated threat"
+              },
+              "body": {
+                "stroke": "red",
+                "strokeWidth": 3,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 4,
+            "id": "24e07ba1-cae4-4b8e-8a2d-b6a4a7279622",
+            "data": {
+              "type": "tm.Actor",
+              "name": "In scope\nwith unmitigated threat",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": true,
+              "threats": [
+                {
+                  "id": "cc9c55cf-bccf-491b-abe7-5a98f7df7e47",
+                  "title": "In scope threat",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Spoofing",
+                  "description": "Provide a description for this threat",
+                  "mitigation": "Provide remediation for this threat or a reason if status is N/A",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 2,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 230,
+              "y": 451.0000000000001
+            },
+            "size": {
+              "width": 168.75,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "Out of scope\nwith mitigated threat"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": "5 2"
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 5,
+            "id": "0f821963-ed5d-40ae-90c1-d3d7efa1ccdc",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Out of scope\nwith mitigated threat",
+              "description": "",
+              "outOfScope": true,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": [
+                {
+                  "id": "53b811d5-fdf3-4a3e-bbaf-a1b134eb0be1",
+                  "title": "Out of scope threat mitigated",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Spoofing",
+                  "description": "Provide a description for this threat",
+                  "mitigation": "Provide remediation for this threat or a reason if status is N/A",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 4,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "position": {
+              "x": 471,
+              "y": 451.0000000000001
+            },
+            "size": {
+              "width": 168.75,
+              "height": 90
+            },
+            "attrs": {
+              "text": {
+                "text": "In scope\nwith mitigated threat"
+              },
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 6,
+            "id": "1ce627a5-f18c-47cd-af71-164240ce1a3f",
+            "data": {
+              "type": "tm.Actor",
+              "name": "In scope\nwith mitigated threat",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": [
+                {
+                  "id": "b6c24c40-2582-4c53-9d1e-0039e46ca769",
+                  "title": "In scope threat mitigated",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Spoofing",
+                  "description": "Provide a description for this threat",
+                  "mitigation": "Provide remediation for this threat or a reason if status is N/A",
+                  "modelType": "STRIDE",
+                  "new": false,
+                  "number": 3,
+                  "score": ""
+                }
+              ]
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "a3be5eae-014b-408c-be0e-98f6e1204248",
+            "source": {
+              "cell": "24e07ba1-cae4-4b8e-8a2d-b6a4a7279622"
+            },
+            "target": {
+              "cell": "1ce627a5-f18c-47cd-af71-164240ce1a3f"
+            },
+            "labels": [
+              ""
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": "5 2"
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "",
+              "description": "",
+              "outOfScope": true,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "729cf6a4-3057-4b6c-97e4-f6c214a1ce80",
+            "source": {
+              "cell": "82149a02-1bcb-4d06-a93b-d498d94efa68"
+            },
+            "target": {
+              "cell": "0f821963-ed5d-40ae-90c1-d3d7efa1ccdc"
+            },
+            "labels": [
+              ""
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "In scope data flow",
+              "description": "this is an in scope data flow",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "2dfa2a5c-347c-465d-a48f-be0ef026b785",
+            "source": {
+              "cell": "cd7b94a3-65af-489e-a0f5-d2d173d6e8fc"
+            },
+            "target": {
+              "cell": "24e07ba1-cae4-4b8e-8a2d-b6a4a7279622"
+            },
+            "labels": [
+              "In scope data flow"
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": "5 2"
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Out of scope data flow",
+              "description": "this is an out of scope data flow",
+              "outOfScope": true,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "34a5bc53-9fa1-4c9a-9315-f97f1c9d0afa",
+            "source": {
+              "cell": "578b5170-74f1-401d-a72f-c06ccc966ca0"
+            },
+            "target": {
+              "cell": "82149a02-1bcb-4d06-a93b-d498d94efa68"
+            },
+            "labels": [
+              "Out of scope data flow"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "title": "01 - wide CIA diagram",
+        "diagramType": "CIA",
+        "placeholder": "New CIA diagram description",
+        "thumbnail": "./public/content/images/thumbnail.cia.jpg",
+        "version": "2.0.3",
+        "description": "a wide CIA diagram for landscape",
+        "cells": [
+          {
+            "position": {
+              "x": 1540,
+              "y": 120
+            },
+            "size": {
+              "width": 128,
+              "height": 60
+            },
+            "shape": "trust-boundary-box",
+            "id": "07d6b9e7-9ae9-486a-b891-c624a0789a1a",
+            "zIndex": -1,
+            "data": {
+              "type": "tm.BoundaryBox",
+              "name": "Trust Boundary",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            }
+          },
+          {
+            "position": {
+              "x": 20,
+              "y": 120
+            },
+            "size": {
+              "width": 112.5,
+              "height": 60
+            },
+            "attrs": {
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 1,
+            "id": "a3521f98-6f64-4f5d-bd86-f28899740c85",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Actor",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 540,
+              "y": 120
+            },
+            "size": {
+              "width": 60,
+              "height": 60
+            },
+            "attrs": {
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 2,
+            "id": "f390ac46-1720-45ee-a7ee-ea6406960f65",
+            "data": {
+              "type": "tm.Process",
+              "name": "Process",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "privilegeLevel": "",
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 800,
+              "y": 120
+            },
+            "size": {
+              "width": 120,
+              "height": 60
+            },
+            "attrs": {
+              "topLine": {
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "id": "81e71478-af02-45c4-be58-f39ed1541fc0",
+            "zIndex": 3,
+            "data": {
+              "type": "tm.Store",
+              "name": "Store",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "isALog": false,
+              "storesCredentials": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Data Flow",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "63092af0-537e-4a62-972e-1607d1055a22",
+            "source": {
+              "x": 259,
+              "y": 120
+            },
+            "target": {
+              "x": 359,
+              "y": 220
+            }
+          },
+          {
+            "shape": "trust-broundary-curve",
+            "attrs": {
+              "line": {
+                "targetMarker": "",
+                "sourceMarker": ""
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "labels": [
+              {
+                "attrs": {
+                  "text": {
+                    "text": ""
+                  }
+                }
+              }
+            ],
+            "data": {
+              "type": "tm.Boundary",
+              "name": "",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            },
+            "id": "17a5ae3c-6ba4-4f90-adf2-f34dfb02ea2d",
+            "source": {
+              "x": 1212,
+              "y": 120
+            },
+            "target": {
+              "x": 1312,
+              "y": 220
+            }
+          },
+          {
+            "position": {
+              "x": 1980,
+              "y": 120
+            },
+            "size": {
+              "width": 112.5,
+              "height": 60
+            },
+            "visible": true,
+            "shape": "td-text-block",
+            "id": "7e646636-e4ac-42b2-ad0c-0b942230093a",
+            "zIndex": 11,
+            "data": {
+              "type": "tm.Text",
+              "name": "Arbitrary Text",
+              "hasOpenThreats": false
+            }
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "02 - narrow LINDDUN diagram",
+        "diagramType": "LINDDUN",
+        "placeholder": "New LINDDUN diagram description",
+        "thumbnail": "./public/content/images/thumbnail.linddun.jpg",
+        "version": "2.0.3",
+        "description": "a narrow LINDDUN diagram for portrait",
+        "cells": [
+          {
+            "position": {
+              "x": 92,
+              "y": 700
+            },
+            "size": {
+              "width": 128,
+              "height": 60
+            },
+            "shape": "trust-boundary-box",
+            "id": "d1f97882-3ecb-42a9-826c-1bd7fb5279f4",
+            "zIndex": -1,
+            "data": {
+              "type": "tm.BoundaryBox",
+              "name": "Trust Boundary",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            }
+          },
+          {
+            "position": {
+              "x": 100,
+              "y": 50
+            },
+            "size": {
+              "width": 112.5,
+              "height": 60
+            },
+            "attrs": {
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "actor",
+            "zIndex": 1,
+            "id": "dfd95719-9e67-4997-97ad-ed7dc82aa004",
+            "data": {
+              "type": "tm.Actor",
+              "name": "Actor",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "providesAuthentication": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 126,
+              "y": 205
+            },
+            "size": {
+              "width": 60,
+              "height": 60
+            },
+            "attrs": {
+              "body": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "id": "6da30bce-0e2c-4899-be97-ee53e04f7236",
+            "zIndex": 3,
+            "data": {
+              "type": "tm.Process",
+              "name": "Process",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "privilegeLevel": "",
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "position": {
+              "x": 96,
+              "y": 346
+            },
+            "size": {
+              "width": 120,
+              "height": 60
+            },
+            "attrs": {
+              "topLine": {
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              },
+              "bottomLine": {
+                "strokeWidth": 1,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "store",
+            "id": "94a2604b-aaf3-46ee-8948-f0b27fb95dd3",
+            "zIndex": 4,
+            "data": {
+              "type": "tm.Store",
+              "name": "Store",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "isALog": false,
+              "storesCredentials": false,
+              "isEncrypted": false,
+              "isSigned": false,
+              "hasOpenThreats": false,
+              "threats": []
+            }
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "strokeWidth": 1,
+                "targetMarker": {
+                  "name": "classic"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Data Flow",
+              "description": "",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "fe9c2307-0d71-4e51-8fa6-1d73d806cc2d",
+            "source": {
+              "x": 96,
+              "y": 489
+            },
+            "target": {
+              "x": 196,
+              "y": 589
+            }
+          },
+          {
+            "shape": "trust-boundary-curve",
+            "attrs": {
+              "line": {
+                "targetMarker": "",
+                "sourceMarker": ""
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "labels": [
+              {
+                "attrs": {
+                  "text": {
+                    "text": ""
+                  }
+                }
+              }
+            ],
+            "data": {
+              "type": "tm.Boundary",
+              "name": "",
+              "description": "",
+              "isTrustBoundary": true,
+              "hasOpenThreats": false
+            },
+            "id": "21bc206c-b605-4f8a-bb96-37ec32c04f05",
+            "source": {
+              "x": 96,
+              "y": 885
+            },
+            "target": {
+              "x": 196,
+              "y": 985
+            }
+          },
+          {
+            "position": {
+              "x": 103.5,
+              "y": 1078
+            },
+            "size": {
+              "width": 112.5,
+              "height": 60
+            },
+            "visible": true,
+            "shape": "td-text-block",
+            "id": "345f613b-bfef-44e2-bf9a-65095b99cde9",
+            "zIndex": 11,
+            "data": {
+              "type": "tm.Text",
+              "name": "Arbitrary Text",
+              "hasOpenThreats": false
+            }
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "New DIE diagram",
+        "diagramType": "DIE",
+        "placeholder": "New DIE diagram description",
+        "thumbnail": "./public/content/images/thumbnail.die.jpg",
+        "version": "2.0.3",
+        "description": "test DIE diagram description",
+        "cells": [
+          {
+            "position": {
+              "x": 90,
+              "y": 40.00000000000017
+            },
+            "size": {
+              "width": 100,
+              "height": 100
+            },
+            "attrs": {
+              "text": {
+                "text": "Threatened\nprocess"
+              },
+              "body": {
+                "stroke": "red",
+                "strokeWidth": 3,
+                "strokeDasharray": null
+              }
+            },
+            "visible": true,
+            "shape": "process",
+            "zIndex": 1,
+            "id": "87978702-9f46-40e4-8728-5cca5325773b",
+            "data": {
+              "type": "tm.Process",
+              "name": "Threatened\nprocess",
+              "description": "Process in a DIE diagram with a threat",
+              "outOfScope": false,
+              "reasonOutOfScope": "",
+              "privilegeLevel": "",
+              "hasOpenThreats": true,
+              "threats": [
+                {
+                  "id": "e824e98b-8116-47ac-824d-1408b33e3f41",
+                  "title": "New DIE threat",
+                  "status": "Open",
+                  "severity": "Medium",
+                  "type": "Distributed",
+                  "description": "Provide a description for this threat",
+                  "mitigation": "Provide remediation for this threat or a reason if status is N/A",
+                  "modelType": "DIE",
+                  "new": false,
+                  "number": 7,
+                  "score": ""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "diagramTop": 5,
+    "reviewer": "+test reviewer+",
+    "threatTop": 7
+  }
+}

--- a/ThreatDragonModels/test-reports.json
+++ b/ThreatDragonModels/test-reports.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3",
+  "version": "2.0.5",
   "summary": {
     "title": "+test model+",
     "owner": "+test owner+",
@@ -284,7 +284,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": null
               }
@@ -323,7 +323,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": "5 2"
               }
@@ -362,7 +362,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": null
               }
@@ -401,7 +401,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": "5 2"
               }
@@ -454,8 +454,8 @@
               "height": 60
             },
             "shape": "trust-boundary-box",
-            "id": "07d6b9e7-9ae9-486a-b891-c624a0789a1a",
             "zIndex": -1,
+            "id": "07d6b9e7-9ae9-486a-b891-c624a0789a1a",
             "data": {
               "type": "tm.BoundaryBox",
               "name": "Trust Boundary",
@@ -547,8 +547,8 @@
             },
             "visible": true,
             "shape": "store",
-            "id": "81e71478-af02-45c4-be58-f39ed1541fc0",
             "zIndex": 3,
+            "id": "81e71478-af02-45c4-be58-f39ed1541fc0",
             "data": {
               "type": "tm.Store",
               "name": "Store",
@@ -570,7 +570,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": null
               }
@@ -584,6 +584,7 @@
               "name": "Data Flow",
               "description": "",
               "outOfScope": false,
+              "isBidirectional": false,
               "reasonOutOfScope": "",
               "protocol": "",
               "isEncrypted": false,
@@ -640,6 +641,94 @@
             }
           },
           {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": "block"
+                },
+                "strokeDasharray": null
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Data Flow",
+              "description": "",
+              "outOfScope": false,
+              "isBidirectional": true,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "8001a4ef-c6ee-4a03-beda-99f911386df4",
+            "source": {
+              "x": 348,
+              "y": 120
+            },
+            "target": {
+              "x": 450,
+              "y": 220
+            },
+            "labels": [
+              "Data Flow"
+            ]
+          },
+          {
+            "shape": "flow",
+            "attrs": {
+              "line": {
+                "stroke": "#333333",
+                "targetMarker": {
+                  "name": "block"
+                },
+                "sourceMarker": {
+                  "name": ""
+                },
+                "strokeDasharray": "4 3"
+              }
+            },
+            "width": 200,
+            "height": 100,
+            "zIndex": 10,
+            "connector": "smooth",
+            "data": {
+              "type": "tm.Flow",
+              "name": "Data Flow",
+              "description": "",
+              "outOfScope": true,
+              "isBidirectional": false,
+              "reasonOutOfScope": "",
+              "protocol": "",
+              "isEncrypted": false,
+              "isPublicNetwork": false,
+              "hasOpenThreats": false,
+              "threats": []
+            },
+            "id": "eaaed457-b833-40a4-bcd2-afc8c390e828",
+            "source": {
+              "x": 180,
+              "y": 130
+            },
+            "target": {
+              "x": 260,
+              "y": 220
+            },
+            "labels": [
+              "Data Flow"
+            ]
+          },
+          {
             "position": {
               "x": 1980,
               "y": 120
@@ -650,8 +739,8 @@
             },
             "visible": true,
             "shape": "td-text-block",
-            "id": "7e646636-e4ac-42b2-ad0c-0b942230093a",
             "zIndex": 11,
+            "id": "7e646636-e4ac-42b2-ad0c-0b942230093a",
             "data": {
               "type": "tm.Text",
               "name": "Arbitrary Text",
@@ -795,7 +884,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "block"
+                  "name": "classic"
                 },
                 "strokeDasharray": null
               }

--- a/ThreatDragonModels/v2-threat-model.json
+++ b/ThreatDragonModels/v2-threat-model.json
@@ -479,7 +479,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -542,7 +542,7 @@
               "line": {
                 "stroke": "red",
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -605,7 +605,7 @@
               "line": {
                 "stroke": "red",
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -668,7 +668,7 @@
               "line": {
                 "stroke": "red",
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -784,7 +784,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -848,7 +848,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": "2 2"
               }
@@ -901,7 +901,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": "2 2"
               }
@@ -954,7 +954,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -1007,7 +1007,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -1060,7 +1060,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }

--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -25,6 +25,7 @@
                 - providesAuthentication
 
             Flow:
+                - isBidirectional
                 - protocol
                 - isEncrypted
                 - isPublicNetwork
@@ -75,6 +76,11 @@
                             v-model="cellRef.data.outOfScope"
                             @change="onChangeScope()"
                         >{{ $t('threatmodel.properties.outOfScope') }}</b-form-checkbox>
+                        <b-form-checkbox
+                            id="bidirection"
+                            v-model="cellRef.data.isBidirectional"
+                            @change="onChangeBidirection()"
+                        >{{ $t('threatmodel.properties.bidirection') }}</b-form-checkbox>
                     </b-form-group>
                 </b-col>
 
@@ -219,6 +225,9 @@ export default {
     methods: {
         onChangeName() {
             dataChanged.updateName(this.cellRef);
+        },
+        onChangeBidirection() {
+            dataChanged.updateStyleAttrs(this.cellRef);
         },
         onChangeScope() {
             document.getElementById('reasonoutofscope').disabled = !this.cellRef.data.outOfScope;

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -133,6 +133,7 @@ const deu = {
             text: 'Text',
             description: 'Beschreibung',
             outOfScope: 'Nicht im Geltungsbereich',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Begründung für nicht im Geltungsbereich',
             privilegeLevel: 'Privilegstufe',
             isALog: 'Ist ein Log',

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -133,6 +133,7 @@ const ell = {
             text: 'Κείμενο',
             description: 'Περιγραφή',
             outOfScope: 'Εκτός πεδίου εφαρμογής',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Λόγος εκτός πεδίου εφαρμογής',
             privilegeLevel: 'Επίπεδο δικαιώματος',
             isALog: 'Είναι αρχείο καταγραφής',

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -133,6 +133,7 @@ const eng = {
             text: 'Text',
             description: 'Description',
             outOfScope: 'Out of Scope',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Reason for out of scope',
             privilegeLevel: 'Privilege Level',
             isALog: 'Is a Log',

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -133,6 +133,7 @@ const spa = {
             text: 'Texto',
             description: 'Descripción',
             outOfScope: 'Fuera de contexto',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Razón para estar fuera de contexto',
             privilegeLevel: 'Nivel de Privilegio',
             isALog: 'Es un Log',

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -133,6 +133,7 @@ const fin = {
             text: 'Teksti',
             description: 'Kuvaus',
             outOfScope: 'Rajattu ulos',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Ulos rajaamisen peruste',
             privilegeLevel: 'Käyttöoikeustaso',
             isALog: 'On loki',

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -133,6 +133,7 @@ const fra = {
             text: 'Texte',
             description: 'Description',
             outOfScope: 'Hors du domaine visé',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Raison de l\'exclusion du domaine visé',
             privilegeLevel: 'Niveau de privilège',
             isALog: 'Est un journal',

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -133,6 +133,7 @@ const hin = {
             text: 'टेक्स्ट',
             description: 'विवरण',
             outOfScope: 'आउट ऑफ स्कोप',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'दायरे से बाहर होने का कारण',
             privilegeLevel: 'विशेषाधिकार स्तर',
             isALog: 'एक लॉग है',

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -133,6 +133,7 @@ const por = {
             text: 'Texto',
             description: 'Descrição',
             outOfScope: 'Fora do Escopo',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Razão por estar fora de escopo',
             privilegeLevel: 'Nível de Privilégio',
             isALog: 'É um Log',

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -133,6 +133,7 @@ const rus = {
             text: 'Text',
             description: 'Description',
             outOfScope: 'Out of Scope',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Reason for out of scope',
             privilegeLevel: 'Privilege Level',
             isALog: 'Is a Log',

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -133,6 +133,7 @@ const ukr = {
             text: 'Text',
             description: 'Description',
             outOfScope: 'Out of Scope',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: 'Reason for out of scope',
             privilegeLevel: 'Privilege Level',
             isALog: 'Is a Log',

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -133,6 +133,7 @@ const zho = {
             text: '文本',
             description: '说明',
             outOfScope: '超出范围',
+            bidirection: 'Bidirectional',
             reasonOutOfScope: '超出范围的原因',
             privilegeLevel: '权限级别',
             isALog: '是日志',

--- a/td.vue/src/service/demo/v2-threat-model.js
+++ b/td.vue/src/service/demo/v2-threat-model.js
@@ -479,7 +479,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -542,7 +542,7 @@ export default {
                             'line': {
                                 'stroke': 'red',
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -605,7 +605,7 @@ export default {
                             'line': {
                                 'stroke': 'red',
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -668,7 +668,7 @@ export default {
                             'line': {
                                 'stroke': 'red',
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -784,7 +784,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -848,7 +848,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': '2 2'
                             }
@@ -901,7 +901,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': '2 2'
                             }
@@ -954,7 +954,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -1007,7 +1007,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }
@@ -1060,7 +1060,7 @@ export default {
                                 'stroke': '#333333',
                                 'strokeWidth': 1,
                                 'targetMarker': {
-                                    'name': 'classic'
+                                    'name': 'block'
                                 },
                                 'strokeDasharray': null
                             }

--- a/td.vue/src/service/entity/default-properties.js
+++ b/td.vue/src/service/entity/default-properties.js
@@ -28,6 +28,7 @@ const flow = {
     name: 'Data Flow',
     description: '',
     outOfScope: false,
+    isBidirectional: false,
     reasonOutOfScope: '',
     protocol: '',
     isEncrypted: false,

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -5,11 +5,11 @@
  */
 
 import cells from './cells.js';
-import dataChanged from '../x6/graph/data-changed.js';
-import graphFactory from '../x6/graph/graph.js';
-import store from '../../store/index.js';
-import tmActions from '../../store/actions/threatmodel.js';
-import events from '../x6/graph/events.js';
+import dataChanged from '@/service/x6/graph/data-changed.js';
+import graphFactory from '@/service/x6/graph/graph.js';
+import events from '@/service/x6/graph/events.js';
+import store from '@/store/index.js';
+import tmActions from '@/store/actions/threatmodel.js';
 
 const buildVersion = require('../../../package.json').version;
 
@@ -24,13 +24,8 @@ const drawV1 = (diagram, graph) => {
 
 // update a version 1.x threat model (and diagrams) to version 2.x
 const upgradeAndDraw = (diagram, graph) => {
-    // check if diagram is already at version 2.x
-    if (diagram.version != null && diagram.version.startsWith('2.')) {
-        graph.fromJSON(diagram);
-        return;
-    }
-
     drawV1(diagram, graph);
+
     const updated = graph.toJSON();
     updated.version = buildVersion;
     updated.title = diagram.title;
@@ -44,7 +39,13 @@ const upgradeAndDraw = (diagram, graph) => {
 };
 
 const drawGraph = (diagram, graph) => {
-    upgradeAndDraw(diagram, graph);
+    if (diagram.version && diagram.version.startsWith('2.')) {
+	    console.debug('open version 2.x diagram');
+        graph.fromJSON(diagram);
+    } else {
+	    console.debug('upgrade version 1.x diagram');
+        upgradeAndDraw(diagram, graph);
+    }
     return graph;
 };
 

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -42,7 +42,8 @@ const edgeUpdater = (edge, color, dash, strokeWidth) => {
     edge.setAttrByPath('line/stroke', color);
     edge.setAttrByPath('line/strokeWidth', strokeWidth);
     edge.setAttrByPath('line/strokeDasharray', dash);
-    edge.setAttrByPath('line/targetMarker/name', 'classic');
+    edge.setAttrByPath('line/targetMarker/name', 'block');
+    edge.setAttrByPath('line/sourceMarker/name', '');
 };
 
 const updateStyleAttrs = (cell) => {

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -9,17 +9,18 @@ const styles = {
     default: {
         color: '#333333',
         strokeDasharray: null,
-        strokeWidth: 1.0
+        strokeWidth: 1.5
     },
     hasOpenThreats: {
-        color: 'red'
+        color: 'red',
+        strokeWidth: 2.5
     },
     outOfScope: {
-        strokeDasharray: '5 2'
+        strokeDasharray: '4 3'
     },
     trustBoundary: {
-        strokeDasharray: '5 5',
-        strokeWidth: 3
+        strokeDasharray: '7 5',
+        strokeWidth: 3.0
     },
     unencrypted: {
         color: 'red',
@@ -58,7 +59,7 @@ const updateStyleAttrs = (cell) => {
 
     if (cellData.hasOpenThreats) {
         color = styles.hasOpenThreats.color;
-        strokeWidth = 3.0;
+        strokeWidth = styles.hasOpenThreats.strokeWidth;
     }
 
     if (cellData.outOfScope) {

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -8,8 +8,10 @@ import threats from '../../threats/index.js';
 const styles = {
     default: {
         color: '#333333',
+        sourceMarker: 'block',
         strokeDasharray: null,
-        strokeWidth: 1.5
+        strokeWidth: 1.5,
+        targetMarker: 'block'
     },
     hasOpenThreats: {
         color: 'red',
@@ -28,7 +30,7 @@ const styles = {
     }
 };
 
-const edgeUpdater = (edge, color, dash, strokeWidth) => {
+const edgeUpdater = (edge, color, dash, strokeWidth, sourceMarker) => {
     const data = edge.getData();
     if (data.isTrustBoundary) {
         edge.setAttrByPath('line/stroke', styles.trustBoundary.color);
@@ -36,14 +38,13 @@ const edgeUpdater = (edge, color, dash, strokeWidth) => {
         edge.setAttrByPath('line/strokeWidth', styles.trustBoundary.strokeWidth);
         edge.setAttrByPath('line/sourceMarker', '');
         edge.setAttrByPath('line/targetMarker', '');
-        return;
+    } else {
+        edge.setAttrByPath('line/stroke', color);
+        edge.setAttrByPath('line/strokeWidth', strokeWidth);
+        edge.setAttrByPath('line/strokeDasharray', dash);
+        edge.setAttrByPath('line/sourceMarker/name', sourceMarker);
+        edge.setAttrByPath('line/targetMarker/name', styles.default.targetMarker);
     }
-
-    edge.setAttrByPath('line/stroke', color);
-    edge.setAttrByPath('line/strokeWidth', strokeWidth);
-    edge.setAttrByPath('line/strokeDasharray', dash);
-    edge.setAttrByPath('line/targetMarker/name', 'block');
-    edge.setAttrByPath('line/sourceMarker/name', '');
 };
 
 const updateStyleAttrs = (cell) => {
@@ -56,7 +57,7 @@ const updateStyleAttrs = (cell) => {
 
     cell.data.hasOpenThreats = threats.hasOpenThreats(cell.data);
 
-    let { color, strokeDasharray, strokeWidth } = styles.default;
+    let { color, strokeDasharray, strokeWidth, sourceMarker } = styles.default;
 
     if (cellData.hasOpenThreats) {
         color = styles.hasOpenThreats.color;
@@ -67,8 +68,12 @@ const updateStyleAttrs = (cell) => {
         strokeDasharray = styles.outOfScope.strokeDasharray;
     }
 
+    if (!cellData.isBidirectional) {
+        sourceMarker = '';
+    }
+
     if (cell.isEdge()) {
-        edgeUpdater(cell, color, strokeDasharray, strokeWidth);
+        edgeUpdater(cell, color, strokeDasharray, strokeWidth, sourceMarker);
         return;
     }
 

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -7,8 +7,6 @@ import defaultProperties from '@/service/entity/default-properties.js';
 import store from '@/store/index.js';
 import { CELL_SELECTED, CELL_UNSELECTED } from '@/store/actions/cell.js';
 import shapes from '@/service/x6/shapes/index.js';
-//import { FlowStencil } from '@/service/x6/shapes/flow-stencil.js';
-import { TrustBoundaryCurveStencil } from '@/service/x6/shapes/trust-boundary-curve-stencil.js';
 
 const edgeConnected = ({ isNew, edge }) => {
     if (isNew) {
@@ -47,7 +45,7 @@ const cellAdded = (graph) => ({ cell }) => {
         if (cell.type === shapes.FlowStencil.prototype.type) {
             graph.addEdge(new shapes.Flow(config));
         }
-        if (cell.type === TrustBoundaryCurveStencil.prototype.type) {
+        if (cell.type === shapes.TrustBoundaryCurveStencil.prototype.type) {
             graph.addEdge(new shapes.TrustBoundaryCurve(config));
         }
 
@@ -112,10 +110,9 @@ const cellDataChanged = ({ cell }) => {
     dataChanged.updateStyleAttrs(cell);
 };
 
-const cellAddFlow = ({ cell }) => {
-    // if this is a node then add data flow
-    if (cell.isNode() && !cell.data.isTrustBoundary) {
-        console.debug('add flow to selected node: ' + cell.data.name);
+const nodeAddFlow = ({ node }) => {
+    if (!node.data.isTrustBoundary) {
+        console.debug('in future add flow from selected node: ' + node.data.name);
     }
 };
 
@@ -128,7 +125,7 @@ const listen = (graph) => {
     graph.on('cell:unselected', cellUnselected);
     graph.on('cell:change:data', cellDataChanged);
     graph.on('cell:selected', cellSelected);
-    graph.on('cell:dblclick', cellAddFlow);
+    graph.on('node:dblclick', nodeAddFlow);
 };
 
 const removeListeners = (graph) => {
@@ -140,7 +137,7 @@ const removeListeners = (graph) => {
     graph.off('cell:unselected', cellUnselected);
     graph.off('cell:change:data', cellDataChanged);
     graph.off('cell:selected', cellSelected);
-    graph.off('cell:dblclick', cellAddFlow);
+    graph.off('node:dblclick', nodeAddFlow);
 };
 
 export default {

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -74,14 +74,18 @@ const cellAdded = (graph) => ({ cell }) => {
 };
 
 const cellSelected = ({ cell }) => {
-    // TODO: We should be updating this somewhere else, not here.
-    if (cell.isNode()) {
-        cell.data.name = cell.getLabel();
-    } else {
-        if (!cell.data.name && cell.getLabels) {
-            const labels = cell.getLabels();
-            if (labels.length) {
-                cell.data.name = cell.data.isTrustBoundary ? labels[0].attrs.text.text : labels[0].attrs.label.text;
+    // try and get the cell name
+    if (cell.data) {
+        if (cell.isNode()) {
+            cell.data.name = cell.getLabel();
+            console.debug('cell selected: ' + cell.data.name);
+        } else {
+            if (!cell.data.name && cell.getLabels) {
+                const labels = cell.getLabels();
+                if (labels.length) {
+                    cell.data.name = cell.data.isTrustBoundary ? labels[0].attrs.text.text : labels[0].attrs.label.text;
+                    console.debug('cell selected: ' + cell.data.name);
+                }
             }
         }
     }
@@ -108,6 +112,7 @@ const cellDataChanged = ({ cell }) => {
 
 const listen = (graph) => {
     graph.on('edge:connected', edgeConnected);
+    graph.on('edge:dblclick', cellSelected);
     graph.on('cell:mouseleave', removeCellTools);
     graph.on('cell:mouseenter', mouseEnter);
     graph.on('cell:added', cellAdded(graph));
@@ -118,6 +123,7 @@ const listen = (graph) => {
 
 const removeListeners = (graph) => {
     graph.off('edge:connected', edgeConnected);
+    graph.off('edge:dblclick', cellSelected);
     graph.off('cell:mouseleave', removeCellTools);
     graph.off('cell:mouseenter', mouseEnter);
     graph.off('cell:added', cellAdded(graph));

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -110,9 +110,22 @@ const cellDataChanged = ({ cell }) => {
     dataChanged.updateStyleAttrs(cell);
 };
 
-const nodeAddFlow = ({ node }) => {
+const nodeAddFlow = (graph) => ({ node }) => {
     if (!node.data.isTrustBoundary) {
         console.debug('in future add flow from selected node: ' + node.data.name);
+
+        const position = node.position();
+        const config = {
+            source: {
+                cell: node.id
+            },
+            target: {
+                x: position.x + 50,
+                y: position.y - 50
+            }
+        };
+        console.debug('add data flow to node id:' + node.id);
+        graph.addEdge(new shapes.Flow(config));
     }
 };
 
@@ -125,7 +138,7 @@ const listen = (graph) => {
     graph.on('cell:unselected', cellUnselected);
     graph.on('cell:change:data', cellDataChanged);
     graph.on('cell:selected', cellSelected);
-    graph.on('node:dblclick', nodeAddFlow);
+    graph.on('node:dblclick', nodeAddFlow(graph));
 };
 
 const removeListeners = (graph) => {
@@ -137,7 +150,7 @@ const removeListeners = (graph) => {
     graph.off('cell:unselected', cellUnselected);
     graph.off('cell:change:data', cellDataChanged);
     graph.off('cell:selected', cellSelected);
-    graph.off('node:dblclick', nodeAddFlow);
+    graph.off('node:dblclick', nodeAddFlow(graph));
 };
 
 export default {

--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -70,7 +70,7 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
         orthogonal: true,
         restricted: false,
         autoScroll: true,
-        preserveAspectRatio: true,
+        preserveAspectRatio: false,
         allowReverse: true
     },
     mousewheel: {

--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -19,9 +19,8 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
     history: {
         enabled: true,
         beforeAddCommand: (event, args) => {
-            // Showing and hiding the tools on mouseover events
-            // gets added to the history stack.  Since that is not
-            // a "user" action, we can ignore those events
+            // Showing and hiding the tools on mouseover events gets added to the history stack
+            // Since that is not a "user" action we can ignore those events
             return args.key !== 'tools';
         }
     },

--- a/td.vue/src/service/x6/shapes/actor.js
+++ b/td.vue/src/service/x6/shapes/actor.js
@@ -13,6 +13,7 @@ export const ActorShape = Shape.Rect.define({
     label: tc('threatmodel.shapes.actor'),
     attrs: {
         body: {
+            fill: 'transparent',
             magnet: false // needs to be disabled to grab whole shape
         }
     }

--- a/td.vue/src/service/x6/shapes/flow-stencil.js
+++ b/td.vue/src/service/x6/shapes/flow-stencil.js
@@ -26,7 +26,7 @@ export const FlowStencil = Shape.Empty.define({
         boundary: {
             strokeWidth: 1,
             stroke: '#333333',
-            fill: '#ffffff',
+            fill: 'transparent',
             refD: 'M 30 20 C 70 20 70 100 110 100'
         },
         label: {

--- a/td.vue/src/service/x6/shapes/flow-stencil.js
+++ b/td.vue/src/service/x6/shapes/flow-stencil.js
@@ -2,7 +2,7 @@ import { Shape } from '@antv/x6';
 
 import { tc } from '@/i18n/index.js';
 
-import defaultProperties from '../../entity/default-properties.js';
+import defaultProperties from '@/service/entity/default-properties.js';
 
 const name = 'flow-stencil';
 

--- a/td.vue/src/service/x6/shapes/flow-stencil.js
+++ b/td.vue/src/service/x6/shapes/flow-stencil.js
@@ -24,7 +24,7 @@ export const FlowStencil = Shape.Empty.define({
     ],
     attrs: {
         boundary: {
-            strokeWidth: 1,
+            strokeWidth: 1.5,
             stroke: '#333333',
             fill: 'transparent',
             refD: 'M 30 20 C 70 20 70 100 110 100'
@@ -33,6 +33,10 @@ export const FlowStencil = Shape.Empty.define({
             text: tc('threatmodel.shapes.flowStencil'),
             fill: '#333',
             textVerticalAnchor: 'middle'
+        },
+        line: {
+            targetMarker: 'block',
+            sourceMarker: ''
         }
     },
     data: defaultProperties.flow

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -1,6 +1,6 @@
 import { Shape } from '@antv/x6';
 
-import defaultProperties from '../../entity/default-properties';
+import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'flow';
 

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -12,7 +12,7 @@ export const Flow = Shape.Edge.define({
     zIndex: 10,
     attrs: {
         line: {
-            strokeWidth: 3,
+            strokeWidth: 1.5,
             sourceMarker: null,
             targetMarker: null
         }

--- a/td.vue/src/service/x6/shapes/process.js
+++ b/td.vue/src/service/x6/shapes/process.js
@@ -28,6 +28,7 @@ export const ProcessShape = Shape.Circle.define({
             refHeight: '110%'
         },
         body: {
+            fill: 'transparent',
             magnet: false // needs to be disabled to grab whole shape
         }
     }

--- a/td.vue/src/service/x6/shapes/store.js
+++ b/td.vue/src/service/x6/shapes/store.js
@@ -35,6 +35,7 @@ export const StoreShape = Shape.Rect.define({
             refD: 'M 0 0 l 100 0'
         },
         body: {
+            fill: 'transparent',
             opacity: 0,
             magnet: false // needs to be disabled to grab whole shape
         }

--- a/td.vue/src/service/x6/shapes/text.js
+++ b/td.vue/src/service/x6/shapes/text.js
@@ -13,6 +13,7 @@ export const TextBlock = Shape.Rect.define({
     label: tc('threatmodel.shapes.text'),
     attrs: {
         body: {
+            fill: 'transparent',
             magnet: false, // disabled because data flows not allowed to text box
             fillOpacity: 0,
             strokeOpacity: 0

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -16,6 +16,7 @@ export const TrustBoundaryBox = Shape.HeaderedRect.define({
             ry: 10,
             strokeDasharray: '5 5',
             strokeWidth: 3,
+            fill: 'transparent',
             fillOpacity: 0
         },
         headerText: {

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
@@ -2,7 +2,7 @@ import { Shape } from '@antv/x6';
 
 import { tc } from '@/i18n/index.js';
 
-import defaultProperties from '../../entity/default-properties.js';
+import defaultProperties from '@/service/entity/default-properties.js';
 
 const name = 'trust-boundary-curve-stencil';
 

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
@@ -26,7 +26,7 @@ export const TrustBoundaryCurveStencil = Shape.Empty.define({
         boundary: {
             strokeWidth: 3,
             stroke: '#333333',
-            fill: '#ffffff',
+            fill: 'transparent',
             strokeDasharray: '5 5',
             refD: 'M 30 20 C 70 20 70 100 110 100'
         },

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -1,6 +1,6 @@
 import { Shape } from '@antv/x6';
 
-import defaultProperties from '../../entity/default-properties';
+import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'trust-boundary-curve';
 

--- a/td.vue/tests/e2e/fixtures/v2-model.json
+++ b/td.vue/tests/e2e/fixtures/v2-model.json
@@ -134,7 +134,7 @@
                 "stroke": "#333333",
                 "strokeWidth": 1,
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }
@@ -175,7 +175,7 @@
               "line": {
                 "stroke": "red",
                 "targetMarker": {
-                  "name": "classic"
+                  "name": "block"
                 },
                 "strokeDasharray": null
               }

--- a/td.vue/tests/unit/components/graphProperties.spec.js
+++ b/td.vue/tests/unit/components/graphProperties.spec.js
@@ -43,6 +43,7 @@ describe('components/GraphProperties.vue', () => {
                 name: 'some actor',
                 description: 'describing the thing',
                 outOfScope: true,
+                isBidirectional: true,
                 reasonOutOfScope: 'someone thought so'
             };
             const localVue = createLocalVue();
@@ -100,6 +101,13 @@ describe('components/GraphProperties.vue', () => {
                 .filter(x => x.attributes('id') === 'reasonoutofscope')
                 .at(0);
             expect(input.attributes('value')).toEqual(entityData.reasonOutOfScope);
+        });
+
+        it('has a bidirectional checkbox', () => {
+            const input = wrapper.findAllComponents(BFormCheckbox)
+                .filter(x => x.attributes('id') === 'bidirection')
+                .at(0);
+            expect(input.attributes('value')).toEqual(entityData.isBidirectional.toString());
         });
     });
 

--- a/td.vue/tests/unit/entity/default-properties.spec.js
+++ b/td.vue/tests/unit/entity/default-properties.spec.js
@@ -88,6 +88,10 @@ describe('service/entity/default-properties.js', () => {
             expect(defaultProperties.flow.outOfScope).toEqual(false);
         });
 
+        it('defines bidirection', () => {
+            expect(defaultProperties.flow.isBidirectional).toEqual(false);
+        });
+
         it('defines reasonOutOfScope', () => {
             expect(defaultProperties.flow.reasonOutOfScope).toEqual('');
         });

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -39,7 +39,7 @@ describe('service/x6/graph/data-changed.js', () => {
         });
 
         it('calls updateStyle', () => {
-            expect(cell.updateStyle).toHaveBeenCalledWith('red', '5 2', 3.0);
+            expect(cell.updateStyle).toHaveBeenCalledWith('red', '4 3', 2.5);
         });
     });
 
@@ -57,7 +57,7 @@ describe('service/x6/graph/data-changed.js', () => {
         });
 
         it('calls updateStyle', () => {
-            expect(cell.updateStyle).toHaveBeenCalledWith('#333333', null, 1.0);
+            expect(cell.updateStyle).toHaveBeenCalledWith('#333333', null, 1.5);
         });
     });
 
@@ -72,7 +72,7 @@ describe('service/x6/graph/data-changed.js', () => {
         });
 
         it('calls updateStyle', () => {
-            expect(cell.updateStyle).toHaveBeenCalledWith('#333333', null, 1.0);
+            expect(cell.updateStyle).toHaveBeenCalledWith('#333333', null, 1.5);
         });
     });
 
@@ -139,9 +139,9 @@ describe('service/x6/graph/data-changed.js', () => {
                 .toHaveBeenCalledWith('line/strokeDasharray', null);
         });
 
-        it('sets the target marker to classic', () => {
+        it('sets the target marker to block', () => {
             expect(cell.setAttrByPath)
-                .toHaveBeenCalledWith('line/targetMarker/name', 'classic');
+                .toHaveBeenCalledWith('line/targetMarker/name', 'block');
         });
     });
 });

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -124,7 +124,8 @@ describe('service/x6/graph/data-changed.js', () => {
             cell.constructor = { name: 'Edge' };
             cell.getData.mockImplementation(() => ({
                 isTrustBoundary: false,
-                isEncrypted: true
+                isEncrypted: true,
+                isBidirectional: true
             }));
             dataChanged.updateStyleAttrs(cell);
         });
@@ -137,6 +138,11 @@ describe('service/x6/graph/data-changed.js', () => {
         it('sets the strokeDasharray', () => {
             expect(cell.setAttrByPath)
                 .toHaveBeenCalledWith('line/strokeDasharray', null);
+        });
+
+        it('sets the source marker to block', () => {
+            expect(cell.setAttrByPath)
+                .toHaveBeenCalledWith('line/sourceMarker/name', 'block');
         });
 
         it('sets the target marker to block', () => {

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -4,7 +4,7 @@ import store from '@/store/index.js';
 import dataChanged from '../../../../../src/service/x6/graph/data-changed';
 
 describe('service/x6/graph/events.js', () => {
-    let cell, edge, graph, mockStore;
+    let cell, node, edge, graph, mockStore;
 
     beforeEach(() => {
         console.log = jest.fn();
@@ -31,13 +31,16 @@ describe('service/x6/graph/events.js', () => {
             id: 'foobar',
             position: jest.fn().mockReturnValue({ x: 1, y: 2 })
         };
+        node = {
+            data: { isTrustBoundary: true }
+        };
         edge = {};
     });
 
     describe('edge:connected', () => {
         describe('new edge', () => {
             beforeEach(() => {
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: true, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: true, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -52,7 +55,7 @@ describe('service/x6/graph/events.js', () => {
 
         describe('old edge', () => {
             beforeEach(() => {
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -65,7 +68,7 @@ describe('service/x6/graph/events.js', () => {
     describe('edge:dblclick', () => {
         describe('select edge', () => {
             beforeEach(() => {
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -79,7 +82,7 @@ describe('service/x6/graph/events.js', () => {
         describe('hasTools is true', () => {
             beforeEach(() => {
                 cell.hasTools.mockImplementation(() => true);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -103,7 +106,7 @@ describe('service/x6/graph/events.js', () => {
         describe('hasTools is false', () => {
             beforeEach(() => {
                 cell.hasTools.mockImplementation(() => false);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -118,7 +121,7 @@ describe('service/x6/graph/events.js', () => {
         describe('isNode is true', () => {
             beforeEach(() => {
                 cell.isNode.mockImplementation(() => true);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -134,7 +137,7 @@ describe('service/x6/graph/events.js', () => {
         describe('isNode is false', () => {
             beforeEach(() => {
                 cell.isNode.mockImplementation(() => false);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -153,7 +156,7 @@ describe('service/x6/graph/events.js', () => {
             beforeEach(() => {
                 cell.isNode.mockImplementation(() => true);
                 cell.constructor = { name: 'other' };
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -174,7 +177,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.type = shapes.StoreShape.prototype.type;
                 if (cell.data) { delete cell.data; }
                 cell.setData.mockImplementation((data) => cell.data = data);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -189,7 +192,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.isNode.mockImplementation(() => true);
                 cell.constructor = { name: 'TrustBoundaryCurveStencil' };
                 cell.type = shapes.TrustBoundaryCurveStencil.prototype.type;
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -212,7 +215,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.isNode.mockImplementation(() => true);
                 cell.constructor = { name: 'FlowStencil' };
                 cell.type = shapes.FlowStencil.prototype.type;
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -238,7 +241,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.type = shapes.FlowStencil.prototype.type;
                 if (cell.data) { delete cell.data; }
                 cell.setData.mockImplementation((data) => cell.data = data);
-                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);
             });
 
@@ -328,25 +331,17 @@ describe('service/x6/graph/events.js', () => {
             });
         });
 
-        describe('cell:dblclick', () => {
+        describe('node:dblclick', () => {
             beforeEach(() => {
-                cell.hasTools.mockImplementation(() => true);
-                cell.isNode.mockImplementation(() => false);
+                node.data.isTrustBoundary = true;
+                graph.on.mockImplementation((evt, fn) => fn({ node, edge, cell }));
                 events.listen(graph);
             });
 
             it('listens to the cell double click event', () => {
-                expect(graph.on).toHaveBeenCalledWith('cell:dblclick', expect.any(Function));
+                expect(graph.on).toHaveBeenCalledWith('node:dblclick', expect.any(Function));
             });
 
-            describe('without getLabels', () => {
-                it('does not set the name', () => {
-                    delete cell.getLabels;
-                    events.listen(graph);
-                    graph.evts['cell:dblclick']({ cell });
-                    expect(cell.data.name).toBeUndefined();
-                });
-            });
         });
     });
 
@@ -391,8 +386,8 @@ describe('service/x6/graph/events.js', () => {
             expect(graph.off).toHaveBeenCalledWith('cell:selected', expect.anything());
         });
 
-        it('removes the cell:dblclick listener', () => {
-            expect(graph.off).toHaveBeenCalledWith('cell:dblclick', expect.anything());
+        it('removes the node:dblclick listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('node:dblclick', expect.anything());
         });
 
         it('removes the cell:added listener again', () => {

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -62,6 +62,19 @@ describe('service/x6/graph/events.js', () => {
         });
     });
 
+    describe('edge:dblclick', () => {
+        describe('select edge', () => {
+            beforeEach(() => {
+                graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
+                events.listen(graph);
+            });
+
+            it('listens to the event', () => {
+                expect(graph.on).toHaveBeenCalledWith('edge:dblclick', expect.any(Function));
+            });
+        });
+    });
+
     describe('removeCellTools', () => {
         describe('hasTools is true', () => {
             beforeEach(() => {
@@ -310,6 +323,10 @@ describe('service/x6/graph/events.js', () => {
 
         it('removes the edge:connected listener', () => {
             expect(graph.off).toHaveBeenCalledWith('edge:connected', expect.anything());
+        });
+
+        it('removes the edge:dblclick listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('edge:dblclick', expect.anything());
         });
 
         it('removes the cell:mouseleave listener', () => {

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -69,7 +69,7 @@ describe('service/x6/graph/events.js', () => {
                 events.listen(graph);
             });
 
-            it('listens to the event', () => {
+            it('listens to the edge double click event', () => {
                 expect(graph.on).toHaveBeenCalledWith('edge:dblclick', expect.any(Function));
             });
         });
@@ -114,6 +114,7 @@ describe('service/x6/graph/events.js', () => {
     });
 
     describe('cell:mouseenter', () => {
+
         describe('isNode is true', () => {
             beforeEach(() => {
                 cell.isNode.mockImplementation(() => true);
@@ -154,6 +155,10 @@ describe('service/x6/graph/events.js', () => {
                 cell.constructor = { name: 'other' };
                 graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, cell }));
                 events.listen(graph);
+            });
+
+            it('listens to the cell added event', () => {
+                expect(graph.on).toHaveBeenCalledWith('cell:added', expect.any(Function));
             });
 
             it('does not add an edge', () => {
@@ -260,6 +265,10 @@ describe('service/x6/graph/events.js', () => {
                 graph.evts['cell:unselected']({ cell });
             });
 
+            it('listens to the cell unselected event', () => {
+                expect(graph.on).toHaveBeenCalledWith('cell:unselected', expect.any(Function));
+            });
+
             it('sets the name', () => {
                 expect(cell.setName).toHaveBeenCalledWith('test');
             });
@@ -274,6 +283,10 @@ describe('service/x6/graph/events.js', () => {
                 cell.hasTools.mockImplementation(() => true);
                 cell.isNode.mockImplementation(() => false);
                 events.listen(graph);
+            });
+
+            it('listens to the cell selected event', () => {
+                expect(graph.on).toHaveBeenCalledWith('cell:selected', expect.any(Function));
             });
 
             describe('trust boundary', () => {
@@ -314,6 +327,27 @@ describe('service/x6/graph/events.js', () => {
                 });
             });
         });
+
+        describe('cell:dblclick', () => {
+            beforeEach(() => {
+                cell.hasTools.mockImplementation(() => true);
+                cell.isNode.mockImplementation(() => false);
+                events.listen(graph);
+            });
+
+            it('listens to the cell double click event', () => {
+                expect(graph.on).toHaveBeenCalledWith('cell:dblclick', expect.any(Function));
+            });
+
+            describe('without getLabels', () => {
+                it('does not set the name', () => {
+                    delete cell.getLabels;
+                    events.listen(graph);
+                    graph.evts['cell:dblclick']({ cell });
+                    expect(cell.data.name).toBeUndefined();
+                });
+            });
+        });
     });
 
     describe('removeListeners', () => {
@@ -350,7 +384,15 @@ describe('service/x6/graph/events.js', () => {
         });
 
         it('removes the cell:change:data listener', () => {
-            expect(graph.off).toHaveBeenCalledWith('edge:connected', expect.anything());
+            expect(graph.off).toHaveBeenCalledWith('cell:change:data', expect.anything());
+        });
+
+        it('removes the cell:selected listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('cell:selected', expect.anything());
+        });
+
+        it('removes the cell:dblclick listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('cell:dblclick', expect.anything());
         });
 
         it('removes the cell:added listener again', () => {

--- a/td.vue/tests/unit/service/x6/graph/graph.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/graph.spec.js
@@ -149,7 +149,7 @@ describe('service/x6/graph/graph.js', () => {
                 orthogonal: true,
                 restricted: false,
                 autoScroll: true,
-                preserveAspectRatio: true,
+                preserveAspectRatio: false,
                 allowReverse: true
             });
         });


### PR DESCRIPTION
**Summary**:
There are various niggles with the drawing styles and abilities, some of which are fixed here:
* allow change in aspect ratio for diagram components
* selecting a data flow or a trust boundary by double clicking
* provide bidirectional option for data flows
* line widths and dashed ratios modified
* provide new data flow when a double click is received on a node (excluding trust boundary box)

These new features need to be documented in the Threat Dragon project pages, and a [new issue has been raised](https://github.com/OWASP/www-project-threat-dragon/issues/59) to do this

**Description for the changelog**:
updates for diagram features and styles

**Other info**:
closes #452 'Allow change in ratio for Actors and Stores'
closes #487 'Modify Enclosed Trust Boundary to allow change in aspect ratio'
closes #154 'Provide bi-directional dataflow'
closes #687 'Make it easier to select a data flow'
closes #666 'New Data Flow does not show property editor'
closes #429 'Quick arrow connection between elements'
closes #462 'Movement of dataflows does not detach from component'
