### PR TITLE
fix bug where selecting a threat boundary curve throws an error

### DIFF
--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -67,7 +67,19 @@
                     </b-form-group>
                 </b-col>
                 
-                <b-col v-if="!cellRef.data.isTrustBoundary && cellRef.data.type !== 'tm.Text'" md="6">
+                <b-col v-if="!cellRef.data.isTrustBoundary && cellRef.data.type !== 'tm.Text' && cellRef.data.type !== 'tm.Flow'" md="6">
+                    <b-form-group
+                        label-cols="auto"
+                        id="outofscope-group">
+                        <b-form-checkbox
+                            id="outofscope"
+                            v-model="cellRef.data.outOfScope"
+                            @change="onChangeScope()"
+                        >{{ $t('threatmodel.properties.outOfScope') }}</b-form-checkbox>
+                    </b-form-group>
+                </b-col>
+
+                <b-col v-if="cellRef.data.type === 'tm.Flow'" md="6">
                     <b-form-group
                         label-cols="auto"
                         id="outofscope-group">

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -40,8 +40,8 @@ const edgeUpdater = (edge, color, dash, strokeWidth, sourceMarker) => {
         edge.setAttrByPath('line/targetMarker', '');
     } else {
         edge.setAttrByPath('line/stroke', color);
-        edge.setAttrByPath('line/strokeWidth', strokeWidth);
         edge.setAttrByPath('line/strokeDasharray', dash);
+        edge.setAttrByPath('line/strokeWidth', strokeWidth);
         edge.setAttrByPath('line/sourceMarker/name', sourceMarker);
         edge.setAttrByPath('line/targetMarker/name', styles.default.targetMarker);
     }

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -72,15 +72,15 @@ const cellSelected = ({ cell }) => {
     if (cell.data) {
         if (cell.isNode()) {
             cell.data.name = cell.getLabel();
-            console.debug('cell selected: ' + cell.data.name);
+            console.debug('node selected: ' + cell.data.name);
         } else {
             if (cell.data.name) {
                 console.debug('edge selected: ' + cell.data.name);
             } else if (cell.getLabels) {
                 const labels = cell.getLabels();
-                if (labels.length) {
-                    cell.data.name = cell.data.isTrustBoundary ? labels[0].attrs.text.text : labels[0].attrs.label.text;
-                    console.debug('edge selected: ' + cell.data.name);
+                if (labels.length && labels[0].attrs.label) {
+                    cell.data.name = labels[0].attrs.label.text;
+                    console.debug('edge selected with label: ' + cell.data.name);
                 } else {
                     console.debug('edge selected with no label');
                 }
@@ -88,9 +88,12 @@ const cellSelected = ({ cell }) => {
                 console.debug('edge selected with no name');
             }
         }
+    } else {
+        console.debug('cell selected with no name');
     }
 
     store.get().dispatch(CELL_SELECTED, cell);
+    dataChanged.updateStyleAttrs(cell);
 };
 
 const cellUnselected = ({ cell }) => {
@@ -130,25 +133,29 @@ const nodeAddFlow = (graph) => ({ node }) => {
 const listen = (graph) => {
     graph.on('edge:connected', edgeConnected);
     graph.on('edge:dblclick', cellSelected);
+    graph.on('edge:move', cellSelected);
     graph.on('cell:mouseleave', removeCellTools);
     graph.on('cell:mouseenter', mouseEnter);
     graph.on('cell:added', cellAdded(graph));
-    graph.on('cell:unselected', cellUnselected);
     graph.on('cell:change:data', cellDataChanged);
     graph.on('cell:selected', cellSelected);
+    graph.on('cell:unselected', cellUnselected);
     graph.on('node:dblclick', nodeAddFlow(graph));
+    graph.on('node:move', cellSelected);
 };
 
 const removeListeners = (graph) => {
     graph.off('edge:connected', edgeConnected);
     graph.off('edge:dblclick', cellSelected);
+    graph.off('edge:move', cellSelected);
     graph.off('cell:mouseleave', removeCellTools);
     graph.off('cell:mouseenter', mouseEnter);
     graph.off('cell:added', cellAdded(graph));
-    graph.off('cell:unselected', cellUnselected);
     graph.off('cell:change:data', cellDataChanged);
     graph.off('cell:selected', cellSelected);
+    graph.off('cell:unselected', cellUnselected);
     graph.off('node:dblclick', nodeAddFlow(graph));
+    graph.off('node:move', cellSelected);
 };
 
 export default {

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -19,13 +19,6 @@ export const TrustBoundaryCurve = Shape.Edge.define({
         }
     },
     connector: 'smooth',
-    labels: [{
-        attrs: {
-            text: {
-                text: ''
-            }
-        }
-    }],
     data: defaultProperties.boundary
 });
 

--- a/td.vue/tests/unit/components/graphProperties.spec.js
+++ b/td.vue/tests/unit/components/graphProperties.spec.js
@@ -39,8 +39,8 @@ describe('components/GraphProperties.vue', () => {
 
         beforeEach(() => {
             entityData = {
-                type: 'tm.Actor',
-                name: 'some actor',
+                type: 'tm.Flow',
+                name: 'some flow',
                 description: 'describing the thing',
                 outOfScope: true,
                 isBidirectional: true,

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -75,6 +75,10 @@ describe('service/x6/graph/events.js', () => {
             it('listens to the edge double click event', () => {
                 expect(graph.on).toHaveBeenCalledWith('edge:dblclick', expect.any(Function));
             });
+
+            it('listens to the edge move event', () => {
+                expect(graph.on).toHaveBeenCalledWith('edge:move', expect.any(Function));
+            });
         });
     });
 
@@ -296,7 +300,7 @@ describe('service/x6/graph/events.js', () => {
                 beforeEach(() => {
                     cell.data.isTrustBoundary = true;
                     cell.getLabels.mockImplementation(() => ([
-                        { attrs: { text: { text: 'test' }}}
+                        { attrs: { label: { text: 'test' }}}
                     ]));
                     events.listen(graph);
                     graph.evts['cell:selected']({ cell });
@@ -331,18 +335,23 @@ describe('service/x6/graph/events.js', () => {
             });
         });
 
-        describe('node:dblclick', () => {
+        describe('node events', () => {
             beforeEach(() => {
                 node.data.isTrustBoundary = true;
                 graph.on.mockImplementation((evt, fn) => fn({ node, edge, cell }));
                 events.listen(graph);
             });
 
-            it('listens to the cell double click event', () => {
+            it('listens to the node double click event', () => {
                 expect(graph.on).toHaveBeenCalledWith('node:dblclick', expect.any(Function));
             });
 
+            it('listens to the node move event', () => {
+                expect(graph.on).toHaveBeenCalledWith('node:move', expect.any(Function));
+            });
+
         });
+
     });
 
     describe('removeListeners', () => {
@@ -358,6 +367,10 @@ describe('service/x6/graph/events.js', () => {
             expect(graph.off).toHaveBeenCalledWith('edge:dblclick', expect.anything());
         });
 
+        it('removes the edge:move listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('edge:move', expect.anything());
+        });
+
         it('removes the cell:mouseleave listener', () => {
             expect(graph.off).toHaveBeenCalledWith('cell:mouseleave', expect.anything());
         });
@@ -370,14 +383,6 @@ describe('service/x6/graph/events.js', () => {
             expect(graph.off).toHaveBeenCalledWith('cell:added', expect.anything());
         });
 
-        it('removes the cell:unselected listener', () => {
-            expect(graph.off).toHaveBeenCalledWith('cell:unselected', expect.anything());
-        });
-
-        it('removes the cell:unselected listener again', () => {
-            expect(graph.off).toHaveBeenCalledWith('cell:unselected', expect.anything());
-        });
-
         it('removes the cell:change:data listener', () => {
             expect(graph.off).toHaveBeenCalledWith('cell:change:data', expect.anything());
         });
@@ -386,8 +391,20 @@ describe('service/x6/graph/events.js', () => {
             expect(graph.off).toHaveBeenCalledWith('cell:selected', expect.anything());
         });
 
+        it('removes the cell:unselected listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('cell:unselected', expect.anything());
+        });
+
+        it('removes the cell:unselected listener again', () => {
+            expect(graph.off).toHaveBeenCalledWith('cell:unselected', expect.anything());
+        });
+
         it('removes the node:dblclick listener', () => {
             expect(graph.off).toHaveBeenCalledWith('node:dblclick', expect.anything());
+        });
+
+        it('removes the node:move listener', () => {
+            expect(graph.off).toHaveBeenCalledWith('node:move', expect.anything());
         });
 
         it('removes the cell:added listener again', () => {


### PR DESCRIPTION
**Summary**:
Various problems exist with selecting nodes and edges in the diagram:
* a bg where selecting a threat boundary curve throws an error
* clicking / selecting a node does not update the attributes
* moving a node does not update the attributes

**Description for the changelog**:
fix bug where selecting a threat boundary curve throws an error

**Other info**:

