### PR TITLE
Fix for errors thrown when selecting graph components

### DIFF
--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -82,9 +82,9 @@
                 <b-col v-if="cellRef.data.type === 'tm.Flow'" md="6">
                     <b-form-group
                         label-cols="auto"
-                        id="outofscope-group">
+                        id="flowoutofscope-group">
                         <b-form-checkbox
-                            id="outofscope"
+                            id="flowoutofscope"
                             v-model="cellRef.data.outOfScope"
                             @change="onChangeScope()"
                         >{{ $t('threatmodel.properties.outOfScope') }}</b-form-checkbox>
@@ -242,6 +242,7 @@ export default {
             dataChanged.updateStyleAttrs(this.cellRef);
         },
         onChangeScope() {
+            console.debug('scope changed');
             document.getElementById('reasonoutofscope').disabled = !this.cellRef.data.outOfScope;
             dataChanged.updateStyleAttrs(this.cellRef);
         }

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -83,7 +83,11 @@ const updateStyleAttrs = (cell) => {
 };
 
 const updateName = (cell) => {
-    if (cell.setName && cell.getData) {
+
+    if (!cell || !cell.setName || !cell.getData) {
+        console.debug('Name update ignored for empty cell');
+    } else {
+        console.debug('Updating name for cell ' + cell.getData().name);
         cell.setName(cell.getData().name);
     }
 };

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -51,7 +51,7 @@ const updateStyleAttrs = (cell) => {
     const cellData = cell.getData();
 
     // New UI elements will not have any cell data
-    if (!cellData) {
+    if (!cellData || !cell.data) {
         return;
     }
 

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -97,14 +97,9 @@ const cellSelected = ({ cell }) => {
 };
 
 const cellUnselected = ({ cell }) => {
+    console.debug('cell unselected');
     removeCellTools({ cell });
-
-    if (cell.setName && cell.getData) {
-        cell.setName(cell.getData().name);
-    } else {
-        console.log('Cannot set name');
-    }
-
+    dataChanged.updateName(cell);
     store.get().dispatch(CELL_UNSELECTED);
     dataChanged.updateStyleAttrs(cell);
 };

--- a/td.vue/tests/unit/components/graphProperties.spec.js
+++ b/td.vue/tests/unit/components/graphProperties.spec.js
@@ -91,7 +91,7 @@ describe('components/GraphProperties.vue', () => {
 
         it('has an out of scope checkbox', () => {
             const input = wrapper.findAllComponents(BFormCheckbox)
-                .filter(x => x.attributes('id') === 'outofscope')
+                .filter(x => x.attributes('id') === 'flowoutofscope')
                 .at(0);
             expect(input.attributes('value')).toEqual(entityData.outOfScope.toString());
         });

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -31,6 +31,7 @@ describe('service/x6/graph/events.js', () => {
             id: 'foobar',
             position: jest.fn().mockReturnValue({ x: 1, y: 2 })
         };
+        cell.getData.mockImplementation(() => ({ name: 'test' }));
         node = {
             data: { isTrustBoundary: true }
         };
@@ -244,6 +245,7 @@ describe('service/x6/graph/events.js', () => {
                 cell.constructor = { name: 'FlowStencil' };
                 cell.type = shapes.FlowStencil.prototype.type;
                 if (cell.data) { delete cell.data; }
+                dataChanged.updateStyleAttrs = jest.fn();
                 cell.setData.mockImplementation((data) => cell.data = data);
                 graph.on.mockImplementation((evt, fn) => fn({ isNew: false, edge, node, cell }));
                 events.listen(graph);


### PR DESCRIPTION
**Summary**:
This fixes the broken unit tests by checking for null cell data
Also fixes an error thrown when an empty cell is selected after updating a previous cell

**Description for the changelog**:
fix for errors thrown when selecting graph components

**Other info**:

