### PR TITLE
Fix searchAsync to *actually* use the access_token (and pagination) correctly

### DIFF
--- a/td.server/src/repositories/threatmodelrepository.js
+++ b/td.server/src/repositories/threatmodelrepository.js
@@ -19,8 +19,8 @@ const getClient = (accessToken) => {
 const reposAsync = (page, accessToken) => getClient(accessToken).me().
 reposAsync(page);
 
-const searchAsync = (accessToken, searchQuery) => getClient(accessToken).search().
-    reposAsync({ q: searchQuery });
+const searchAsync = (page, accessToken, searchQuery) => getClient(accessToken).search().
+    reposAsync({ page: page, q: searchQuery });
 
 const userAsync = async (accessToken) => {
     const resp = await getClient(accessToken).me().


### PR DESCRIPTION
**Summary**:
With `GITHUB_USE_SEARCH` was enabled, calling `searchAsync` threw an error, as the `page` parameter was being passed in first (but wasn't used in the function).

**Description for the changelog**:
- Fix `searchAsync` to enable repo search to work (and use pagination) correctly