### PR TITLE
fix bug that overwrites node properties when adding dataflows

### DIFF
--- a/td.vue/jest.config.js
+++ b/td.vue/jest.config.js
@@ -1,29 +1,29 @@
 module.exports = async () => {
-  return {
-    preset: '@vue/cli-plugin-unit-jest',
-    verbose: true,
-    transform: {
-      // process `*.js` files with `babel-jest`
-      '.*\\.(js)$': 'babel-jest'
-    },
-    moduleNameMapper: {
-      '^@/(.*)$': '<rootDir>/src/$1',
-      '^lodash-es$': 'lodash'
-    },
-    collectCoverage: true,
-    collectCoverageFrom: [
-      'src/**/*.{js,vue}',
-      '!src/service/demo/**',
-      '!**/node_modules/**',
-      '!**/coverage/**',
-      '!src/main*.js', // Bootstrap code for web app and desktop app
-      '!src/plugins/*.js' // Bootstrap code
-    ],
-    resetMocks: true,
-    restoreMocks: true,
-    transformIgnorePatterns: [
-      '<rootDir>/node_modules/(?!lodash-es|axios)'
-    ]
-  };
+    return {
+        preset: '@vue/cli-plugin-unit-jest',
+        verbose: true,
+        transform: {
+            // process `*.js` files with `babel-jest`
+            '.*\\.(js)$': 'babel-jest'
+        },
+        moduleNameMapper: {
+            '^@/(.*)$': '<rootDir>/src/$1',
+            '^lodash-es$': 'lodash'
+        },
+        collectCoverage: true,
+        collectCoverageFrom: [
+            'src/**/*.{js,vue}',
+            '!src/service/demo/**',
+            '!**/node_modules/**',
+            '!**/coverage/**',
+            '!src/main*.js', // Bootstrap code for web app and desktop app
+            '!src/plugins/*.js' // Bootstrap code
+        ],
+        resetMocks: true,
+        restoreMocks: true,
+        transformIgnorePatterns: [
+            '<rootDir>/node_modules/(?!lodash-es|axios)'
+        ]
+    };
 };
 

--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -265,6 +265,7 @@ export default {
         },
         onChangeScope() {
             document.getElementById('reasonoutofscope').disabled = !this.cellRef.data.outOfScope;
+            dataChanged.updateProperties(this.cellRef);
             dataChanged.updateStyleAttrs(this.cellRef);
             this.updateComponent();
         }

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -94,8 +94,40 @@ const updateProperties = (cell) => {
     }
 };
 
+// future modifications to the list of properties applied to cells that may not have them
+const upgradeProperties = (cell) => {
+    // fundamentally the shape is the only constant identifier
+    switch (cell.shape) {
+	    case 'actor':
+        cell.data.type = 'tm.Actor';
+        break;
+	    case 'store':
+        cell.data.type = 'tm.Store';
+        break;
+	    case 'process':
+        cell.data.type = 'tm.Process';
+        break;
+	    case 'flow':
+        cell.data.type = 'tm.Flow';
+        break;
+	    case 'trust-boundary-box':
+        cell.data.type = 'tm.BoundaryBox';
+        break;
+	    case 'trust-boundary-curve':
+	    case 'trust-broundary-curve':
+        cell.data.type = 'tm.Boundary';
+        break;
+	    case 'td-text-block':
+        cell.data.type = 'tm.Text';
+        break;
+    default:
+        console.debug('Unrecognized shape');
+    }
+};
+
 export default {
     updateName,
     updateStyleAttrs,
-    updateProperties
+    updateProperties,
+    upgradeProperties
 };

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -5,6 +5,7 @@
 
 import store from '@/store/index.js';
 import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
+import { THREATMODEL_MODIFIED } from '@/store/actions/threatmodel.js';
 import threats from '@/service/threats/index.js';
 import defaultProperties from '@/service/entity/default-properties.js';
 
@@ -41,6 +42,7 @@ const updateStyleAttrs = (cell) => {
     if (cell.data) {
         cell.data.hasOpenThreats = threats.hasOpenThreats(cell.data);
         store.get().dispatch(CELL_DATA_UPDATED, cell.data);
+        store.get().dispatch(THREATMODEL_MODIFIED);
     }
 
     let { color, strokeDasharray, strokeWidth, sourceMarker } = styles.default;
@@ -86,6 +88,7 @@ const updateProperties = (cell) => {
             console.debug('Setting properties for cell: ' + cell.getData().name);
         }
         store.get().dispatch(CELL_DATA_UPDATED, cell.data);
+        store.get().dispatch(THREATMODEL_MODIFIED);
     } else {
         console.debug('No cell data to update');
     }

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -6,6 +6,7 @@
 import store from '@/store/index.js';
 import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
 import threats from '@/service/threats/index.js';
+import defaultProperties from '@/service/entity/default-properties.js';
 
 const styles = {
     default: {
@@ -73,8 +74,17 @@ const updateName = (cell) => {
 };
 
 const updateProperties = (cell) => {
-    if (!!cell && !!cell.data) {
-        console.debug('Update property for cell: ' + cell.getData().name);
+    if (cell) {
+        if (cell.data) {
+            console.debug('Update properties for cell: ' + cell.getData().name);
+        } else {
+            if (cell.isEdge()) {
+                cell.type = defaultProperties.flow.type;
+                console.debug('Edge cell given type: ' + cell.type);
+            }
+            cell.setData(defaultProperties.getByType(cell.type));
+            console.debug('Setting properties for cell: ' + cell.getData().name);
+        }
         store.get().dispatch(CELL_DATA_UPDATED, cell.data);
     } else {
         console.debug('No cell data to update');

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -68,7 +68,6 @@ const cellAdded = (graph) => ({ cell }) => {
     store.get().dispatch(CELL_SELECTED, cell);
     dataChanged.updateProperties(cell);
     dataChanged.updateStyleAttrs(cell);
-    store.get().dispatch(THREATMODEL_MODIFIED);
 };
 
 const cellDeleted = () => {
@@ -105,7 +104,6 @@ const cellSelected = (graph) => ({ cell }) => {
     store.get().dispatch(CELL_SELECTED, cell);
     dataChanged.updateProperties(cell);
     dataChanged.updateStyleAttrs(cell);
-    store.get().dispatch(THREATMODEL_MODIFIED);
 };
 
 const cellUnselected = ({ cell }) => {
@@ -122,6 +120,7 @@ const cellDataChanged = ({ cell }) => {
     }
     store.get().dispatch(CELL_SELECTED, cell);
     dataChanged.updateStyleAttrs(cell);
+    store.get().dispatch(THREATMODEL_MODIFIED);
 };
 
 const nodeAddFlow = (graph) => ({ node }) => {

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -3,7 +3,6 @@
  * @description Event listeners for the graph
  */
 import dataChanged from './data-changed.js';
-import defaultProperties from '@/service/entity/default-properties.js';
 import store from '@/store/index.js';
 import { CELL_SELECTED, CELL_UNSELECTED } from '@/store/actions/cell.js';
 import { THREATMODEL_MODIFIED } from '@/store/actions/threatmodel.js';
@@ -66,15 +65,9 @@ const cellAdded = (graph) => ({ cell }) => {
         cell.zIndex = -1;
     }
 
-    dataChanged.updateStyleAttrs(cell);
-    if (!cell.data) {
-        if (cell.isEdge()) {
-            cell.type = defaultProperties.flow.type;
-            console.debug('edge cell given type: ' + cell.type);
-        }
-        cell.setData(defaultProperties.getByType(cell.type));
-    }
     store.get().dispatch(CELL_SELECTED, cell);
+    dataChanged.updateProperties(cell);
+    dataChanged.updateStyleAttrs(cell);
     store.get().dispatch(THREATMODEL_MODIFIED);
 };
 
@@ -83,7 +76,8 @@ const cellDeleted = () => {
     store.get().dispatch(THREATMODEL_MODIFIED);
 };
 
-const cellSelected = ({ cell }) => {
+const cellSelected = (graph) => ({ cell }) => {
+    graph.resetSelection(cell);
     // try and get the cell name
     if (cell.data) {
         if (cell.isNode()) {
@@ -109,6 +103,7 @@ const cellSelected = ({ cell }) => {
     }
 
     store.get().dispatch(CELL_SELECTED, cell);
+    dataChanged.updateProperties(cell);
     dataChanged.updateStyleAttrs(cell);
     store.get().dispatch(THREATMODEL_MODIFIED);
 };
@@ -142,7 +137,8 @@ const nodeAddFlow = (graph) => ({ node }) => {
             }
         };
         console.debug('add data flow to node id:' + node.id);
-        graph.addEdge(new shapes.Flow(config));
+        let cell = graph.addEdge(new shapes.Flow(config));
+        graph.resetSelection(cell);
     }
 };
 
@@ -155,7 +151,7 @@ const listen = (graph) => {
     graph.on('cell:added', cellAdded(graph));
     graph.on('cell:removed', cellDeleted);
     graph.on('cell:change:data', cellDataChanged);
-    graph.on('cell:selected', cellSelected);
+    graph.on('cell:selected', cellSelected(graph));
     graph.on('cell:unselected', cellUnselected);
     graph.on('node:dblclick', nodeAddFlow(graph));
     graph.on('node:move', cellSelected);
@@ -170,7 +166,7 @@ const removeListeners = (graph) => {
     graph.off('cell:added', cellAdded(graph));
     graph.off('cell:removed', cellDeleted);
     graph.off('cell:change:data', cellDataChanged);
-    graph.off('cell:selected', cellSelected);
+    graph.off('cell:selected', cellSelected(graph));
     graph.off('cell:unselected', cellUnselected);
     graph.off('node:dblclick', nodeAddFlow(graph));
     graph.off('node:move', cellSelected);

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -104,6 +104,7 @@ const cellSelected = (graph) => ({ cell }) => {
     store.get().dispatch(CELL_SELECTED, cell);
     dataChanged.updateProperties(cell);
     dataChanged.updateStyleAttrs(cell);
+    dataChanged.upgradeProperties(cell);
 };
 
 const cellUnselected = ({ cell }) => {

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -32,6 +32,9 @@ const mouseEnter = ({ cell }) => {
 };
 
 const cellAdded = (graph) => ({ cell }) => {
+    graph.resetSelection(cell);
+    console.debug('cell added with shape: ', cell.shape);
+
     if (cell.convertToEdge) {
         let edge = cell;
         const position = cell.position();
@@ -76,7 +79,7 @@ const cellAdded = (graph) => ({ cell }) => {
 };
 
 const cellDeleted = () => {
-    console.debug('cell deleted: ');
+    console.debug('cell deleted');
     store.get().dispatch(THREATMODEL_MODIFIED);
 };
 

--- a/td.vue/src/service/x6/shapes/index.js
+++ b/td.vue/src/service/x6/shapes/index.js
@@ -10,6 +10,9 @@ import { TrustBoundaryBox } from './trust-boundary-box.js';
 import { TrustBoundaryCurve } from './trust-boundary-curve.js';
 import { TrustBoundaryCurveStencil } from './trust-boundary-curve-stencil.js';
 
+// this looks and is wrong, but a lot of existing models have this typo, so make compatible
+Graph.registerNode('trust-broundary-curve', TrustBoundaryCurve);
+
 Graph.registerNode('actor', ActorShape);
 Graph.registerNode('flow', Flow);
 Graph.registerNode('process', ProcessShape);
@@ -17,9 +20,6 @@ Graph.registerNode('store', StoreShape);
 Graph.registerNode('td-text-block', TextBlock);
 Graph.registerNode('trust-boundary-box', TrustBoundaryBox);
 Graph.registerNode('trust-boundary-curve', TrustBoundaryCurve);
-
-// this looks and is wrong, but a lot of existing models have this typo, so make compatible
-Graph.registerNode('trust-broundary-curve', TrustBoundaryCurve);
 
 export default {
     ActorShape,

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -260,6 +260,7 @@ export default {
             };
             this.$store.dispatch(tmActions.update, { diagramTop: this.diagramTop + 1 });
             this.model.detail.diagrams.push(newDiagram);
+            this.$store.dispatch(tmActions.modified);
         },
         onDiagramTypeClick(idx, type) {
             let defaultTitle;
@@ -316,9 +317,11 @@ export default {
             ) {
                 this.model.detail.diagrams[idx].title = defaultTitle;
             }
+            this.$store.dispatch(tmActions.modified);
         },
         onRemoveDiagramClick(idx) {
             this.model.detail.diagrams.splice(idx, 1);
+            this.$store.dispatch(tmActions.modified);
         },
         onModifyModel() {
             this.$store.dispatch(tmActions.modified);

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -12,8 +12,9 @@ describe('service/x6/graph/events.js', () => {
         store.get = jest.fn().mockReturnValue(mockStore);
         graph = {
             evts: {},
+            off: jest.fn(),
             on: function(evt, cb) { this.evts[evt] = cb; },
-            off: jest.fn()
+            resetSelection: jest.fn()
         };
         jest.spyOn(graph, 'on');
         cell = {


### PR DESCRIPTION
**Summary**:
This fixes the bug when a node is already selected, and then a new data flow added, the selected node's properties are overwritten as data-flow properties

**Description for the changelog**:
fix bug that overwrites node properties when adding dataflows

**Other info**:
Closes #786 
Closes #768 
