### PR TITLE
for now hide rus and ukr from i18n menu until translated

### DIFF
--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -19,13 +19,15 @@ import fin from '@/i18n/fi.js';
 import fra from '@/i18n/fr.js';
 import hin from '@/i18n/hi.js';
 import por from '@/i18n/pt.js';
-import rus from '@/i18n/ru.js';
+// hide RUS & UKR for now: import rus from '@/i18n/ru.js';
 import spa from '@/i18n/es.js';
-import ukr from '@/i18n/uk.js';
+// hide RUS & UKR for now: import ukr from '@/i18n/uk.js';
 import zho from '@/i18n/zh.js';
 
-const messages = { deu, ell, eng, fin, fra, hin, por, rus, spa, ukr, zho };
-const languages = [ 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'por', 'rus', 'spa', 'ukr', 'zho' ];
+const messages = { deu, ell, eng, fin, fra, hin, por, spa, zho };
+// hide RUS & UKR for now: const messages = { deu, ell, eng, fin, fra, hin, por, rus, spa, ukr, zho };
+const languages = [ 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'por', 'spa', 'zho' ];
+// hide RUS & UKR for now: const languages = [ 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'por', 'rus', 'spa', 'ukr', 'zho' ];
 const defaultLanguage = 'eng';
 var language = defaultLanguage;
 

--- a/td.vue/src/i18n/index.js
+++ b/td.vue/src/i18n/index.js
@@ -13,8 +13,8 @@ import fin from './fi.js';
 import fra from './fr.js';
 import hin from './hi.js';
 import por from './pt.js';
-import rus from './ru.js';
-import ukr from './uk.js';
+// hide RUS & UKR for now: import rus from './ru.js';
+// hide RUS & UKR for now: import ukr from './uk.js';
 import zho from './zh.js';
 
 Vue.use(VueI18n);
@@ -24,7 +24,8 @@ const get = () => {
     if (i18n === null) {
         i18n = new VueI18n({
             locale: 'eng',
-            messages: { deu, ell, eng, spa, fin, fra, hin, por, rus, ukr, zho }
+            messages: { deu, ell, eng, spa, fin, fra, hin, por, zho }
+            // hide RUS & UKR for now: messages: { deu, ell, eng, spa, fin, fra, hin, por, rus, ukr, zho }
         });
     }
     return i18n;


### PR DESCRIPTION
**Summary**:
hide rus and ukr from i18n menu for now, until translation becomes available

**Description for the changelog**:
hide untranslated languages

**Other info**:

