### PR TITLE
Create desktop Export sub-menu

### DIFF
--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -79,18 +79,31 @@ export function getMenuTemplate () {
                     }
                 },
                 {
-                    label: messages[language].forms.savePdf,
-                    click () {
-                        printModel();
-                        modelPrint('PDF');
-                    }
-                },
-                {
-                    label: messages[language].forms.saveHtml,
-                    click () {
-                        printModel();
-                        modelPrint('HTML');
-                    }
+                    label: messages[language].forms.exportAs,
+                    submenu: [
+                        {
+                            label: messages[language].forms.exportHtml,
+                            click () {
+                                printModel();
+                                modelPrint('HTML');
+                            }
+                        },
+                        {
+                            label: messages[language].forms.exportPdf,
+                            click () {
+                                printModel();
+                                modelPrint('PDF');
+                            }
+                        },
+                        {
+                            label: messages[language].forms.exportOtm,
+                            enabled: false
+                        },
+                        {
+                            label: messages[language].forms.exportTd,
+                            enabled: false
+                        }
+                    ]
                 },
                 {
                     label: messages[language].desktop.file.close,
@@ -247,7 +260,7 @@ function newModel () {
 
 // print the model report
 function printModel () {
-    logger.log.debug(messages[language].forms.savePdf+ ': ' + model.filePath);
+    logger.log.debug(messages[language].forms.exportPdf+ ': ' + model.filePath);
     // prompt the renderer to open the print/report window
     mainWindow.webContents.send('print-model');
 }
@@ -349,7 +362,7 @@ function saveHTMLReport (htmlPath) {
 function savePDFReport (pdfPath) {
     pdfPath += '.pdf';
     var dialogOptions = {
-        title: messages[language].forms.savePdf,
+        title: messages[language].forms.exportPdf,
         defaultPath: pdfPath,
         filters: [{ name: 'PDF report', extensions: ['.pdf'] }, { name: 'All Files', extensions: ['*'] }]
     };
@@ -373,9 +386,9 @@ function savePDFReport (pdfPath) {
                 logger.log.error(`Failed to write PDF to ${pdfPath}: `, error);
             });
 
-            logger.log.debug(messages[language].forms.savePdf + ' : ' + pdfPath);
+            logger.log.debug(messages[language].forms.exportPdf + ' : ' + pdfPath);
         } else {
-            logger.log.debug(messages[language].forms.savePdf + ' : canceled');
+            logger.log.debug(messages[language].forms.exportPdf + ' : canceled');
         }
     }).catch(err => {
         logger.log.error(err);

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -227,6 +227,9 @@ const deu = {
         discardTitle: 'Änderung verwerfen?',
         discardMessage: 'Sind Sie sicher, dass Sie Ihre Änderungen verwerfen wollen?',
         edit: 'Editieren',
+        exportAs: 'Export Model As',
+        exportHtml: 'Speichern als HTML',
+        exportPdf: 'Speichern als PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Importieren',
@@ -239,10 +242,8 @@ const deu = {
         report: 'Bericht',
         save: 'Speichern',
         saveAs: 'Speichern als',
-        saveHtml: 'Speichern als HTML',
         saveModel: 'Modell speichern',
         saveModelAs: 'Modell speichern als',
-        savePdf: 'Speichern als PDF',
         search: 'Suchen'
     },
     threats: {

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -227,6 +227,9 @@ const ell = {
         discardTitle: 'Απόρριψη αλλαγών;',
         discardMessage: 'Είστε σίγουροι ότι θέλετε να απορρίψετε τις αλλαγές;',
         edit: 'Επεξεργασία',
+        exportAs: 'Export Model As',
+        exportHtml: 'Αναφορά HTML',
+        exportPdf: 'Αναφορά PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Εισαγωγή',
@@ -239,10 +242,8 @@ const ell = {
         report: 'Αναφορά',
         save: 'Αποθήκευση',
         saveAs: 'Αποθήκευση ως',
-        saveHtml: 'Αποθήκευση HTML',
         saveModel: 'Αποθήκευση Μοντέλου',
         saveModelAs: 'Αποθήκευση Μοντέλου ως',
-        savePdf: 'Αποθήκευση PDF',
         search: 'Αναζήτηση'
     },
     threats: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -227,6 +227,9 @@ const eng = {
         discardTitle: 'Discard Changes?',
         discardMessage: 'Are you sure you want to discard your changes?',
         edit: 'Edit',
+        exportAs: 'Export Model As',
+        exportHtml: 'HTML Report',
+        exportPdf: 'PDF Report',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Import',
@@ -239,10 +242,8 @@ const eng = {
         report: 'Report',
         save: 'Save',
         saveAs: 'Save As',
-        saveHtml: 'Save HTML',
         saveModel: 'Save Model',
         saveModelAs: 'Save Model As',
-        savePdf: 'Save PDF',
         search: 'Search'
     },
     threats: {

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -227,6 +227,9 @@ const spa = {
         discardTitle: '¿Descartar los cambios?',
         discardMessage: '¿Está seguro de descartar sus cambios?',
         edit: 'Editar',
+        exportAs: 'Export Model As',
+        exportHtml: 'Reporte HTML',
+        exportPdf: 'Reporte PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Importar',
@@ -239,10 +242,8 @@ const spa = {
         report: 'Reporte',
         save: 'Guardar',
         saveAs: 'Guardar como',
-        saveHtml: 'Exportar HTML',
         saveModel: 'Guardar modelo',
         saveModelAs: 'Guardar modelo como',
-        savePdf: 'Exportar PDF',
         search: 'Buscar'
     },
     threats: {

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -227,6 +227,9 @@ const fin = {
         discardTitle: 'Menetä muutokset?',
         discardMessage: 'Oletko varma, että haluat menettää muutokset?',
         edit: 'Muokkaa',
+        exportAs: 'Export Model As',
+        exportHtml: 'Raportti HTML',
+        exportPdf: 'Raportti PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Tuo',
@@ -239,10 +242,8 @@ const fin = {
         report: 'Raportti',
         save: 'Tallenna',
         saveAs: 'Tallenna Nimellä',
-        saveHtml: 'Tallenna HTML',
         saveModel: 'Tallenna Uhkamalli',
         saveModelAs: 'Tallenna Uhkamalli Nimellä',
-        savePdf: 'Tallenna PDF',
         search: 'Etsi'
     },
     threats: {

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -227,6 +227,9 @@ const fra = {
         discardTitle: 'Annuler les modifications?',
         discardMessage: 'Êtes-vous sûr de vouloir abandonner vos modifications?',
         edit: 'Modifier',
+        exportAs: 'Export Model As',
+        exportHtml: 'Rapport HTML',
+        exportPdf: 'Rapport PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Importer',
@@ -239,10 +242,8 @@ const fra = {
         report: 'Rapport',
         save: 'Sauvegarder',
         saveAs: 'Sauvergarder en tant que',
-        saveHtml: 'Sauvergarder le HTML',
         saveModel: 'Sauvergarder le modèle',
         saveModelAs: 'Sauvergarder le modèle en tant que',
-        savePdf: 'Sauvergarder le PDF',
         search: 'Rechercher'
     },
     threats: {

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -227,6 +227,9 @@ const hin = {
         discardTitle: 'परिवर्तनों को त्यागें?',
         discardMessage: 'क्या आप सुनिश्चित हैं कि आप अपने परिवर्तनों को खारिज करना चाहते हैं?',
         edit: 'संपादित करें',
+        exportAs: 'Export Model As',
+        exportHtml: 'HTML रिपोर्टें',
+        exportPdf: 'पीडीएफ रिपोर्टें',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'आयात',
@@ -239,10 +242,8 @@ const hin = {
         report: 'रिपोर्ट',
         save: 'सहेजें',
         saveAs: 'इस रूप में सहेजें',
-        saveHtml: 'HTML सेव करें',
         saveModel: 'मॉडल सेव करें',
         saveModelAs: 'मॉडल को इस रूप में सहेजें',
-        savePdf: 'पीडीएफ सेव करें',
         search: 'खोज'
     },
     threats: {

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -227,6 +227,9 @@ const por = {
         discardTitle: 'Discard Changes?',
         discardMessage: 'Are you sure you want to discard your changes?',
         edit: 'Editar',
+        exportAs: 'Export Model As',
+        exportHtml: 'HTML Reporte',
+        exportPdf: 'PDF Reporte',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Import',
@@ -239,10 +242,8 @@ const por = {
         report: 'Reporte',
         save: 'Salvar',
         saveAs: 'Save As',
-        saveHtml: 'Save HTML',
         saveModel: 'Save Model',
         saveModelAs: 'Save Model As',
-        savePdf: 'Save PDF',
         search: 'Search'
     },
     threats: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -227,6 +227,9 @@ const rus = {
         discardTitle: 'Discard Changes?',
         discardMessage: 'Are you sure you want to discard your changes?',
         edit: 'Edit',
+        exportAs: 'Export Model As',
+        exportHtml: 'HTML Report',
+        exportPdf: 'PDF Report',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Import',
@@ -239,10 +242,8 @@ const rus = {
         report: 'Report',
         save: 'Save',
         saveAs: 'Save As',
-        saveHtml: 'Save HTML',
         saveModel: 'Save Model',
         saveModelAs: 'Save Model As',
-        savePdf: 'Save PDF',
         search: 'Search'
     },
     threats: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -227,6 +227,9 @@ const ukr = {
         discardTitle: 'Discard Changes?',
         discardMessage: 'Are you sure you want to discard your changes?',
         edit: 'Edit',
+        exportAs: 'Export Model As',
+        exportHtml: 'HTML Report',
+        exportPdf: 'PDF Report',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Import',
@@ -239,10 +242,8 @@ const ukr = {
         report: 'Report',
         save: 'Save',
         saveAs: 'Save As',
-        saveHtml: 'Save HTML',
         saveModel: 'Save Model',
         saveModelAs: 'Save Model As',
-        savePdf: 'Save PDF',
         search: 'Search'
     },
     threats: {

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -227,6 +227,9 @@ const zho = {
         discardTitle: '放弃更改？',
         discardMessage: '您确定要放弃您的更改吗？',
         edit: '编辑',
+        exportAs: 'Export Model As',
+        exportHtml: '报告HTML',
+        exportPdf: '报告PDF',
         exportTd: 'Original (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: '导入',
@@ -239,10 +242,8 @@ const zho = {
         report: '报告',
         save: '保存',
         saveAs: '保存为',
-        saveHtml: '保存HTML',
         saveModel: '保存模型',
         saveModelAs: '模型保存为',
-        savePdf: '保存PDF',
         search: '搜索'
     },
     threats: {

--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -69,7 +69,7 @@
                         :onBtnClick="printPdf"
                         v-if="isElectron"
                         icon="file-pdf"
-                        :text="$t('forms.savePdf')" />
+                        :text="$t('forms.exportPdf')" />
                     <td-form-button
                         id="td-print-btn"
                         :onBtnClick="print"


### PR DESCRIPTION
**Summary**:
Creates a new desktop submenu for Export actions, and puts the HTML and PDF report functions under it

**Description for the changelog**:
create desktop sub-menu for export functions

**Other info**:
