### PR TITLE
made language selection understandable

### DIFF
--- a/td.vue/src/components/LocaleSelect.vue
+++ b/td.vue/src/components/LocaleSelect.vue
@@ -5,7 +5,7 @@
         v-for="locale in $i18n.availableLocales"
         :key="`locale-${locale}`"
         :value="locale"
-        @click.native="updateLocale(locale)">{{ locale }}</b-dropdown-item>
+        @click.native="updateLocale(locale)">{{getLanguageName(locale)}}</b-dropdown-item>
     </b-dropdown>
   </div>
 </template>
@@ -34,7 +34,34 @@ export default {
                 // tell the electron main process that the locale has changed
                 window.electronAPI.updateMenu(locale);
             }
-        }
-    }
+        },
+        getLanguageName(locale) {
+            switch (locale) {
+                case 'ara':
+                return 'العربية'; // Arabic
+                case 'deu':
+                return 'Deutsch'; // German
+                case 'ell':
+                return 'Ελληνικά'; // Greek
+                case 'eng':
+                return 'English';
+                case 'spa':
+                return 'Español'; // Spanish
+                case 'fin':
+                return 'Suomi'; // Finnish
+                case 'fra':
+                return 'Français'; // French
+                case 'hin':
+                return 'हिंदी'; // Hindi
+                case 'por':
+                return 'Português'; // Portuguese
+                case 'zho':
+                return '中文'; // Chinese
+                default:
+                return locale; // Default to the original locale code if not found
+            }
+            }
+    },
+    
 };
 </script>

--- a/td.vue/tests/unit/components/localeSelect.spec.js
+++ b/td.vue/tests/unit/components/localeSelect.spec.js
@@ -47,13 +47,13 @@ describe('components/LocaleSelect.vue', () => {
 
         it('has an option for eng', () => {
             expect(wrapper.findAllComponents(BDropdownItem)
-                .filter((c) => c.text() === 'eng').exists()
+                .filter((c) => c.text() === 'English').exists()
             ).toEqual(true);
         });
 
         it('has an option for deu', () => {
             expect(wrapper.findAllComponents(BDropdownItem)
-                .filter((c) => c.text() === 'deu').exists()
+                .filter((c) => c.text() === 'Deutsch').exists()
             ).toEqual(true);
         });
 
@@ -64,7 +64,7 @@ describe('components/LocaleSelect.vue', () => {
 
             it('updates the locale to deu', async () => {
                 await wrapper.findAllComponents(BDropdownItem)
-                    .filter(c => c.text() === 'deu')
+                    .filter(c => c.text() === 'Deutsch')
                     .at(0)
                     .trigger('click');
                 
@@ -73,7 +73,7 @@ describe('components/LocaleSelect.vue', () => {
 
             it('updates the locale to eng', async () => {
                 await wrapper.findAllComponents(BDropdownItem)
-                    .filter(c => c.text() === 'eng')
+                    .filter(c => c.text() === 'English')
                     .at(0)
                     .trigger('click');
                 


### PR DESCRIPTION
**Summary**:

This PR changes the way languages are getting rendered. Initially the languages in the locale select dialog box was getting rendered by 3 letter ISO codes but now they have been locally transliterated into the respective language.

The update fixes a part of all the issues mentioned in #806. This PR changes the way languages are getting rendered.

**Description for the changelog**:
language selection dropdown menu uses natural language

**Other info**:  
closes #806 

