### PR TITLE
Prompt user to save model before quitting the app

### DIFF
--- a/td.vue/public/preload.js
+++ b/td.vue/public/preload.js
@@ -6,6 +6,7 @@ if (process.env.IS_TEST === 'true') {
 
 contextBridge.exposeInMainWorld('electronAPI', {
     // renderer to electron main
+    appClose: () => ipcRenderer.send('close-app'),
     updateMenu: (locale) => ipcRenderer.send('update-menu', locale),
     modelClosed: (fileName) => ipcRenderer.send('model-closed', fileName),
     modelModified: (modified) => ipcRenderer.send('model-modified', modified),
@@ -15,6 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     modelSave: (modelData, fileName) => ipcRenderer.send('model-save', modelData, fileName),
 
     // electron main to renderer
+    onCloseAppRequest: (callback) => ipcRenderer.on('close-app-request', callback),
     onCloseModelRequest: (callback) => ipcRenderer.on('close-model-request', callback),
     onNewModelRequest: (callback) => ipcRenderer.on('new-model-request', callback),
     onOpenModel: (callback) => ipcRenderer.on('open-model', callback),

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -111,7 +111,8 @@ export default {
         }
     },
     destroyed() {
-        diagramService.dispose(this.graph);
+      diagramService.dispose(this.graph);
+      this.$store.dispatch(tmActions.notModified);
     }
 };
 </script>

--- a/td.vue/src/desktop/desktop.js
+++ b/td.vue/src/desktop/desktop.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { app, protocol, BrowserWindow, Menu, ipcMain } from 'electron';
+import { app, protocol, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib';
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
 import menu from './menu.js';
@@ -55,6 +55,35 @@ async function createWindow () {
         // menu system needs to access the main window
         menu.setMainWindow(mainWindow);
     });
+
+    mainWindow.on("close" , (event) => {
+        const modified = menu.model.isModified
+
+        if(modified){
+
+        const choice =  dialog.showMessageBoxSync(mainWindow, {
+            type: 'question',
+            buttons: ['Save', 'Don\'t Save, Quit', 'Cancel'],
+            defaultId: 0,
+            message: 'Do you want to save your changes before closing?'
+        });
+
+        if (choice === 0) {
+            // User clicked "Save"
+            mainWindow.webContents.send('save-model-request', path.basename(menu.model.filePath));
+            event.preventDefault();
+
+        } else if (choice === 2) {
+            // User clicked "Cancel" or closed the dialog
+            // Prevent the window from closing
+            event.preventDefault();
+        } else {
+            // User clicked "Don't Save"
+            // Close the window without saving changes
+        }
+
+    }
+})
 
     if (electronURL) {
         logger.log.info('Running in development mode with WEBPACK_DEV_SERVER_URL: ' + electronURL);

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -416,6 +416,8 @@ export const modelSave = (modelData, fileName) => {
     } else {
         saveModelData(modelData);
     }
+
+    model.isModified = false;
 };
 
 // the renderer has changed the language
@@ -427,6 +429,10 @@ export const setMainWindow = (window) => {
     mainWindow = window;
 };
 
+export const getMainWindow = () => {
+    return mainWindow;
+}
+
 export default {
     getMenuTemplate,
     modelClosed,
@@ -437,5 +443,7 @@ export default {
     openModel,
     openModelRequest,
     setLocale,
-    setMainWindow
+    setMainWindow,
+    getMainWindow,
+    model
 };

--- a/td.vue/src/main.desktop.js
+++ b/td.vue/src/main.desktop.js
@@ -29,6 +29,16 @@ const getConfirmModal = () => {
     });
 };
 
++// request from electron to renderer to close the application
+window.electronAPI.onCloseAppRequest(async (_event) =>  {
+        console.debug('Close application request');
+        if (!app.$store.getters.modelChanged || await getConfirmModal()) {
+            console.debug('Closing application');
+            // send request back to electron server to close the application
+            window.electronAPI.appClose();
+        };
+    });
+
 // request from electron to renderer to close the model
 window.electronAPI.onCloseModelRequest(async (_event, fileName) =>  {
     console.debug('Close model request for file name : ' + fileName);
@@ -36,14 +46,14 @@ window.electronAPI.onCloseModelRequest(async (_event, fileName) =>  {
         console.debug('Closing model and diagram');
         app.$store.dispatch(tmActions.diagramClosed);
         localAuth();
-        app.$router.push({ name: 'MainDashboard' }).catch(error => {
-            if (error.name != 'NavigationDuplicated') {
-                throw error;
+            app.$router.push({ name: 'MainDashboard' }).catch(error => {
+                if (error.name != 'NavigationDuplicated') {
+                    throw error;
+                }
+            });
+            // store clear action sends modelClosed notification back to electron server
+            app.$store.dispatch(tmActions.clear);
             }
-        });
-        // store clear action sends modelClosed notification back to electron server
-        app.$store.dispatch(tmActions.clear);
-    }
 });
 
 // request from electron to renderer to start a new model


### PR DESCRIPTION
**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Prompts the user to save the model before quitting. Solves #846 

**Description for the changelog**:
<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->
Controlled the way Electron was closing the app previously. However, the guard on the route to #/dashboard has not been implemented yet. We can address this in a separate issue to better organize the code.