### PR TITLE
Fixes:dashboard action

### DIFF
--- a/td.vue/src/components/DashboardAction.vue
+++ b/td.vue/src/components/DashboardAction.vue
@@ -1,16 +1,16 @@
 <template>    
     <b-col lg>
+    <router-link :to="to" class="action-pane-link">
         <b-jumbotron class="text-center action-pane">
-            <router-link :to="to">
                 <font-awesome-icon
                 :icon="[iconPreface, icon]"
-                size="3x"
+                size="4x"
                 class="action-icon"
                 ></font-awesome-icon>
-            </router-link>
             <br />
             {{ $t(`dashboard.actions.${description}`) }}
         </b-jumbotron>
+            </router-link>
     </b-col>
 </template>
 
@@ -23,6 +23,9 @@
 .action-pane {
     min-height: 100%;
     margin-bottom: 0px;
+}
+.action-pane-link:hover {
+    text-decoration: none;
 }
 </style>
 


### PR DESCRIPTION
**Summary**:
made changes in order to make whole dashboard-action block clickable and after making changes our dashboard-action panel will be looking like below

[screen-capture (1).webm](https://github.com/OWASP/threat-dragon/assets/107138786/750cc58c-573e-4407-859d-b295ddc21f23)

**Description for the changelog**:
fixes: dashboard action

**Other info**:
Fixes : #871 
