### PR TITLE
Fix: Adding Same type of Threats

### DIFF
--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -240,7 +240,12 @@ export default {
         },
         updateThreat() {
             const threatRef = this.threat;
-
+            const existingThreat = this.cellRef.data.threats.find(x => x.type === threatRef.type && x.id !== threatRef.id);
+            if (existingThreat) {
+                console.warn('A threat of the same type already exists:', existingThreat);
+                this.$toast.warning("A threat of the same type already exists for Current Model !!")
+                return; // Return without adding the threat
+            }
             if (threatRef) {
                 threatRef.status = this.threat.status;
                 threatRef.severity = this.threat.severity;


### PR DESCRIPTION
**Summary**:
Fixes:[#892 ]
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->

**Description for the changelog**:
Now We can't add same type of threat to same element of chosen threat model . Now our webpage will behave like below on adding same type of threat more than once.


[screen-capture (1).webm](https://github.com/OWASP/threat-dragon/assets/107138786/f2cd178e-bd10-443b-a207-8a8e2d5b21ff)

<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->

**Other info**:
<!--
Add here any other information that may be of help to the reviewer
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
