### PR TITLE
Fix:Buttons in Threat Edit Page

### DIFF
--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -146,7 +146,7 @@
                 <b-button
                     v-if="!newThreat"
                     variant="secondary"
-                    class="float-right"
+                    class="float-right mr-2"
                     @click="hideModal()"
                 >
                     {{ $t('forms.cancel') }}


### PR DESCRIPTION
**Summary**:
provides space for Buttons in Threat Edit Page

**Description for the changelog**:
provide space for Buttons in Threat Edit Page

**Other info**:
Fixes: #897
