### PR TITLE
Creation of threats made consistent

### DIFF
--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -83,8 +83,8 @@ export default {
                 this.$store.dispatch(tmActions.diagramModified, updated);
             });
         },
-        threatSelected(threatId) {
-            this.$refs.threatEditDialog.editThreat(threatId);
+        threatSelected(threatId,state) {
+            this.$refs.threatEditDialog.editThreat(threatId,state);
         },
         saved() {
             console.debug('Save diagram');

--- a/td.vue/src/components/GraphMeta.vue
+++ b/td.vue/src/components/GraphMeta.vue
@@ -80,6 +80,7 @@ import { mapState } from 'vuex';
 import { createNewTypedThreat } from '@/service/threats/index.js';
 import { CELL_DATA_UPDATED, CELL_UNSELECTED } from '@/store/actions/cell.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
+import tmActions from '@/store/actions/threatmodel.js';
 import TdGraphProperties from '@/components/GraphProperties.vue';
 import TdGraphThreats from '@/components/GraphThreats.vue';
 
@@ -89,6 +90,7 @@ export default {
         cellRef: (state) => state.cell.ref,
         threats: (state) => state.cell.threats,
         diagram: (state) => state.threatmodel.selectedDiagram,
+        threatTop: (state) => state.threatmodel.data.detail.threatTop,
         disableNewThreat: function (state) {
             return state.cell.ref.data.outOfScope || state.cell.ref.data.isTrustBoundary || state.cell.ref.data.type === 'tm.Text';
         }
@@ -109,10 +111,12 @@ export default {
             this.$emit('threatSelected', threatId);
         },
         newThreat() {
-            const threat = createNewTypedThreat(this.diagram.diagramType, this.cellRef.data.type);
+            const threat = createNewTypedThreat(this.diagram.diagramType, this.cellRef.data.type,this.threatTop+1);
             console.debug('new threat ID: ' + threat.id);
             this.cellRef.data.threats.push(threat);
             this.cellRef.data.hasOpenThreats = this.cellRef.data.threats.length > 0;
+            this.$store.dispatch(tmActions.update, { threatTop: this.threatTop+1 });
+            this.$store.dispatch(tmActions.modified);
             this.$store.dispatch(CELL_DATA_UPDATED, this.cellRef.data);
             dataChanged.updateStyleAttrs(this.cellRef);
             this.threatSelected(threat.id);

--- a/td.vue/src/components/GraphMeta.vue
+++ b/td.vue/src/components/GraphMeta.vue
@@ -106,9 +106,9 @@ export default {
         init() {
             this.$store.dispatch(CELL_UNSELECTED);
         },
-        threatSelected(threatId) {
+        threatSelected(threatId,state) {
             console.debug('selected threat ID: ' + threatId);
-            this.$emit('threatSelected', threatId);
+            this.$emit('threatSelected', threatId,state);
         },
         newThreat() {
             const threat = createNewTypedThreat(this.diagram.diagramType, this.cellRef.data.type,this.threatTop+1);
@@ -119,7 +119,7 @@ export default {
             this.$store.dispatch(tmActions.modified);
             this.$store.dispatch(CELL_DATA_UPDATED, this.cellRef.data);
             dataChanged.updateStyleAttrs(this.cellRef);
-            this.threatSelected(threat.id);
+            this.threatSelected(threat.id,'new');
         }
     },
 };

--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -90,7 +90,7 @@ export default {
     },
     methods: {
         threatSelected() {
-            this.$emit('threatSelected', this.id);
+            this.$emit('threatSelected', this.id,'old');
         }
     }
 };

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -214,7 +214,7 @@ export default {
         };
     },
     methods: {
-        editThreat(threatId) {
+        editThreat(threatId,state) {
             const crnthreat = this.cellRef.data.threats.find(x => x.id === threatId);
             this.threat = {...crnthreat};
             if (!this.threat) {
@@ -222,7 +222,7 @@ export default {
                 console.warn('Trying to access a non-existent threatId: ' + threatId);
             } else {
                 this.number = this.threat.number;
-                this.newThreat = this.threat.new;
+                this.newThreat = state==='new';
                 this.$refs.editModal.show();
             }
         },

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -144,13 +144,13 @@
                     {{ $t('forms.apply') }}
                 </b-button>
                 <b-button
-                    v-if="!newThreat"
-                    variant="secondary"
-                    class="float-right mr-2"
-                    @click="hideModal()"
-                >
-                    {{ $t('forms.cancel') }}
-                </b-button>
+                v-if="!newThreat"
+                variant="secondary"
+                class="float-right mr-2"
+                @click="hideModal()"
+            >
+                {{ $t('forms.cancel') }}
+            </b-button>
                 </div>
             </template>
         </b-modal>
@@ -210,36 +210,24 @@ export default {
                 'PLOT4ai',
                 'STRIDE'
             ],
-            newThreat: true,
             number: 0
         };
     },
     methods: {
         editThreat(threatId) {
-            this.threat = this.cellRef.data.threats.find(x => x.id === threatId);
+            const crnthreat = this.cellRef.data.threats.find(x => x.id === threatId);
+            this.threat = {...crnthreat};
             if (!this.threat) {
                 // this should never happen with a valid threatId
                 console.warn('Trying to access a non-existent threatId: ' + threatId);
             } else {
+                this.number = this.threat.number;
+                this.newThreat = this.threat.new;
                 this.$refs.editModal.show();
             }
-            this.newThreat = this.threat.new;
-
-            if (this.threat.new === true) {
-                // provide a new threat number that is unique project wide
-                if (this.threatTop) {
-                    this.number = this.threatTop + 1;
-                } else {
-                    this.number = 1;
-                }
-                this.$store.dispatch(tmActions.update, { threatTop: this.number });
-            } else {
-                this.number = this.threat.number;
-            }
-            this.$store.dispatch(tmActions.modified);
         },
         updateThreat() {
-            const threatRef = this.threat;
+            const threatRef = this.cellRef.data.threats.find(x => x.id === this.threat.id);
 
             if (threatRef) {
                 threatRef.status = this.threat.status;
@@ -252,7 +240,6 @@ export default {
                 threatRef.new = false;
                 threatRef.number = this.number;
                 threatRef.score = this.threat.score;
-
                 this.$store.dispatch(CELL_DATA_UPDATED, this.cellRef.data);
                 this.$store.dispatch(tmActions.modified);
                 dataChanged.updateStyleAttrs(this.cellRef);

--- a/td.vue/src/service/threats/index.js
+++ b/td.vue/src/service/threats/index.js
@@ -42,7 +42,7 @@ const valuesToTranslations = {
 
 const convertToTranslationString = (val) => valuesToTranslations[val];
 
-export const createNewTypedThreat = function (modelType, cellType) {
+export const createNewTypedThreat = function (modelType, cellType,number) {
     if (!modelType) {
         modelType = 'STRIDE';
     }
@@ -99,7 +99,7 @@ export const createNewTypedThreat = function (modelType, cellType) {
         mitigation: tc('threats.mitigation'),
         modelType,
         new: true,
-        number: 0,
+        number: number,
         score: ''
     };
 };

--- a/td.vue/tests/unit/components/graph.spec.js
+++ b/td.vue/tests/unit/components/graph.spec.js
@@ -114,8 +114,8 @@ describe('components/GraphButtons.vue', () => {
     });
 
     it('shows the threat edit modal dialog', () => {
-        wrapper.vm.threatSelected('asdf');
-        expect(threatEditStub.methods.editThreat).toHaveBeenCalledWith('asdf');
+        wrapper.vm.threatSelected('asdf','new');
+        expect(threatEditStub.methods.editThreat).toHaveBeenCalledWith('asdf','new');
     });
 
     it('saves the threat model diagram', () => {

--- a/td.vue/tests/unit/components/graphMeta.spec.js
+++ b/td.vue/tests/unit/components/graphMeta.spec.js
@@ -120,8 +120,8 @@ describe('components/GraphMeta.vue', () => {
         });
 
         it('emits the threatSelected event with the threat id', () => {
-            wrapper.vm.threatSelected('id1');
-            expect(emitter).toHaveBeenCalledWith('threatSelected', 'id1');
+            wrapper.vm.threatSelected('id1','new');
+            expect(emitter).toHaveBeenCalledWith('threatSelected', 'id1','new');
         });
     });
 
@@ -181,7 +181,7 @@ describe('components/GraphMeta.vue', () => {
         });
 
         it('adds a threat to the cell data', () => {
-            expect(wrapper.vm.threatSelected).toHaveBeenCalledWith(expect.anything());
+            expect(wrapper.vm.threatSelected).toHaveBeenCalledWith(expect.anything(),'new');
         });
     });
 

--- a/td.vue/tests/unit/components/graphMeta.spec.js
+++ b/td.vue/tests/unit/components/graphMeta.spec.js
@@ -158,9 +158,15 @@ describe('components/GraphMeta.vue', () => {
                     threatmodel: {
                         selectedDiagram: {
                             diagramType: 'LINDDUN'
+                        },
+                        data:{
+                            detail:{
+                                threatTop:0,
+                            },
                         }
                     }
-                }
+                },
+                actions:{ THREATMODEL_UPDATE: ()=> {}},
             });
             wrapper = shallowMount(TdGraphMeta, {
                 localVue,

--- a/td.vue/tests/unit/components/graphThreats.spec.js
+++ b/td.vue/tests/unit/components/graphThreats.spec.js
@@ -162,7 +162,7 @@ describe('components/GraphThreats.vue', () => {
         });
 
         it('emits the threatSelected event with the threat id', () => {
-            expect(emitter).toHaveBeenCalledWith('threatSelected', propsData.id);
+            expect(emitter).toHaveBeenCalledWith('threatSelected', propsData.id,'old');
         });
     });
 });


### PR DESCRIPTION
**Fixed the following issues**:

- (bug title is not updated with number after creation without saving) 
- (changes should not be preserved when retained threat next displayed)

**How does the addressed issues function now**:
now the number of the threat is added when it's created and the content of the threat in the cell is not changed unless saved so the unsaved changes are not retained when the threat is going to get edited again

Fixes some points addressed in #899 
Closes #899 
Closes #889 
