### PR TITLE
Also build for arm64

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -186,6 +186,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.1.0
@@ -217,6 +220,7 @@ jobs:
           tags:  ${{ env.IMAGE_NAME }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
 
   e2e_smokes:
     name: Site e2e smokes

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -182,6 +182,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [site_unit_tests, server_unit_tests]
     if: github.repository == 'OWASP/threat-dragon'
+    outputs:
+      image_is_pushed: ${{ steps.set-outputs.outputs.CREDS_PRESENT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -205,9 +207,12 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.0.0
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
         id: docker_build
@@ -216,16 +221,22 @@ jobs:
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: true
+          push: ${{ env.DOCKERHUB_TOKEN != '' }}
           tags:  ${{ env.IMAGE_NAME }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
 
+      - name: Set outputs
+        id: set-outputs
+        run: |-
+          echo "CREDS_PRESENT=${{ secrets.DOCKERHUB_TOKEN != ''}}" >> $GITHUB_OUTPUT
+
   e2e_smokes:
     name: Site e2e smokes
     runs-on: ubuntu-22.04
     needs: [build_docker_image]
+    if: ${{ needs.build_docker_image.outputs.image_is_pushed == 'true'}}
     defaults:
       run:
         working-directory: td.vue
@@ -326,6 +337,7 @@ jobs:
     name: Site zap scan
     runs-on: ubuntu-22.04
     needs: [build_docker_image]
+    if: ${{ needs.build_docker_image.outputs.image_is_pushed == 'true'}}
     steps:
       - name: Run Threat Dragon
         run: |
@@ -373,6 +385,7 @@ jobs:
     name: Scan with trivy
     runs-on: ubuntu-22.04
     needs: [build_docker_image]
+    if: ${{ needs.build_docker_image.outputs.image_is_pushed == 'true'}}
     permissions:
       contents: write
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -222,6 +222,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.1.0
@@ -253,6 +256,7 @@ jobs:
           tags:  ${{ env.IMAGE_NAME }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
 
   heroku_deploy:
     name: Upload to Heroku

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -346,6 +346,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.1.0
@@ -377,6 +380,7 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.IMAGE_NAME }}:stable
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
 
   webapp_release:
     name: Publish web application

--- a/release-process.md
+++ b/release-process.md
@@ -22,11 +22,9 @@ The github release workflow then creates the draft release and the install image
 
 1. once tagged, the github workflow pushes the docker image to docker hub
 2. check using `docker pull threatdragon/owasp-threat-dragon:v2.2.0`
-3. on MacOS M1 this command may need to be used:
-    `docker pull --platform linux/x86_64 threatdragon/owasp-threat-dragon:v2.2.0`
-4. Test using the command to run a detached container:
+3. Test using the command to run a detached container:
     `docker run -d -p 8080:3000 -v $(pwd)/.env:/app/.env threatdragon/owasp-threat-dragon:v2.2.0`
-5. Ideally test this release on Windows, linux and MacOS using `http://localhost:8080/#/`
+4. Ideally test this release on Windows, linux and MacOS using `http://localhost:8080/#/`
 
 If the image tests correctly, promote the docker image
 from dockerhub `threatdragon/` to dockerhub `OWASP/threat-dragon/v2.2.0`.


### PR DESCRIPTION
**Summary**:
Builds Docker images also for ARM. Improves developer experience on newer Macs with ARM CPU (Mx)
Adds necessary changes to the affected GitHub workflows

**Description for the changelog**:
add build for arm64 docker image in GitHub workflows

**Other info**:
The extra build time should be bearable, if not the builds for each arch can be run in parallel using a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).

