### PR TITLE
Stop report options moving and obscuring language drop-down

### DIFF
--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -156,7 +156,7 @@
     width: 100%;
     background-color: $white;
     padding-top: 15px;
-    z-index: 9999;
+    z-index: 100;
 }
 
 .right {

--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -152,8 +152,8 @@
 
 .sticky {
     position: sticky;
-    top: 45px;
-    width: 100%;
+    top: 55px;
+    margin-top: -5px;
     background-color: $white;
     padding-top: 15px;
     z-index: 100;


### PR DESCRIPTION
**Summary**:

When on the report page, scrolling down the content causes the report options bar to move upwards slightly. Additionally, the report options bar appears above the language selection drop-down menu in the nav bar.

**Description for the changelog**:

This change tweaks the CSS to correct the heights and margins of the report options bar so that it does not move and it changes the z-index of the report options bar to place it below the language drop-down.

**Other info**:

Before:

![report-options-bar-before](https://github.com/OWASP/threat-dragon/assets/5932424/02d94b18-fdcc-4eff-b61d-f3143475ce13)

![language-drop-down-before](https://github.com/OWASP/threat-dragon/assets/5932424/e2c2f6b5-904b-4502-b1c7-6c8cbdb525da)

After:

![report-options-bar-after](https://github.com/OWASP/threat-dragon/assets/5932424/c3b50762-6c8e-4c3b-9f8d-f8a380056430)

![language-drop-down-after](https://github.com/OWASP/threat-dragon/assets/5932424/e4730a32-ab93-4911-94bd-0faef0a23faf)

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
