### PR TITLE
Fix typos in demo threat descriptions

### DIFF
--- a/ThreatDragonModels/demo-threat-model.json
+++ b/ThreatDragonModels/demo-threat-model.json
@@ -88,7 +88,7 @@
                 {
                   "status": "Open",
                   "severity": "Medium",
-                  "description": "An attacker could obtain the DB credentials ans use them to make unauthorised queries.",
+                  "description": "An attacker could obtain the DB credentials and use them to make unauthorised queries.",
                   "title": "Credential theft",
                   "type": "Information disclosure",
                   "mitigation": "Use a firewall to restrict access to the DB to only the Background Worker IP address."
@@ -133,7 +133,7 @@
                   "severity": "High",
                   "title": "Credentials should be encrypted",
                   "type": "Information disclosure",
-                  "description": "The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
+                  "description": "The Web Application Config stores credentials used by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
                   "mitigation": "The Message Queue credentials should be encrypted."
                 }
               ],

--- a/ThreatDragonModels/v2-threat-model.json
+++ b/ThreatDragonModels/v2-threat-model.json
@@ -118,7 +118,7 @@
                 {
                   "status": "Open",
                   "severity": "Medium",
-                  "description": "An attacker could obtain the DB credentials ans use them to make unauthorised queries.",
+                  "description": "An attacker could obtain the DB credentials and use them to make unauthorised queries.",
                   "title": "Credential theft",
                   "type": "Information disclosure",
                   "mitigation": "Use a firewall to restrict access to the DB to only the Background Worker IP address.",
@@ -173,7 +173,7 @@
                   "severity": "High",
                   "title": "Credentials should be encrypted",
                   "type": "Information disclosure",
-                  "description": "The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
+                  "description": "The Web Application Config stores credentials used by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
                   "mitigation": "The Message Queue credentials should be encrypted.",
                   "modelType": "STRIDE",
                   "id": "aaea0238-2984-4b25-8268-3798e63bed34"

--- a/td.vue/src/service/demo/demo-threat-model.js
+++ b/td.vue/src/service/demo/demo-threat-model.js
@@ -89,7 +89,7 @@ export default {
                                 {
                                     'status': 'Open',
                                     'severity': 'Medium',
-                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'description': 'An attacker could obtain the DB credentials and use them to make unauthorised queries.',
                                     'title': 'Credential theft',
                                     'type': 'Information disclosure',
                                     'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.'
@@ -134,7 +134,7 @@ export default {
                                     'severity': 'High',
                                     'title': 'Credentials should be encrypted',
                                     'type': 'Information disclosure',
-                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'description': 'The Web Application Config stores credentials used by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
                                     'mitigation': 'The Message Queue credentials should be encrypted.'
                                 }
                             ],

--- a/td.vue/src/service/demo/v2-threat-model.js
+++ b/td.vue/src/service/demo/v2-threat-model.js
@@ -118,7 +118,7 @@ export default {
                                 {
                                     'status': 'Open',
                                     'severity': 'Medium',
-                                    'description': 'An attacker could obtain the DB credentials ans use them to make unauthorised queries.',
+                                    'description': 'An attacker could obtain the DB credentials and use them to make unauthorised queries.',
                                     'title': 'Credential theft',
                                     'type': 'Information disclosure',
                                     'mitigation': 'Use a firewall to restrict access to the DB to only the Background Worker IP address.',
@@ -173,7 +173,7 @@ export default {
                                     'severity': 'High',
                                     'title': 'Credentials should be encrypted',
                                     'type': 'Information disclosure',
-                                    'description': 'The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
+                                    'description': 'The Web Application Config stores credentials used by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.',
                                     'mitigation': 'The Message Queue credentials should be encrypted.',
                                     'modelType': 'STRIDE',
                                     'id': 'aaea0238-2984-4b25-8268-3798e63bed34'

--- a/td.vue/tests/e2e/fixtures/v1-model.json
+++ b/td.vue/tests/e2e/fixtures/v1-model.json
@@ -88,7 +88,7 @@
                 {
                   "status": "Open",
                   "severity": "Medium",
-                  "description": "An attacker could obtain the DB credentials ans use them to make unauthorised queries.",
+                  "description": "An attacker could obtain the DB credentials and use them to make unauthorised queries.",
                   "title": "Credential theft",
                   "type": "Information disclosure",
                   "mitigation": "Use a firewall to restrict access to the DB to only the Background Worker IP address."
@@ -133,7 +133,7 @@
                   "severity": "High",
                   "title": "Credentials should be encrypted",
                   "type": "Information disclosure",
-                  "description": "The Web Application Config stores credentials used  by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
+                  "description": "The Web Application Config stores credentials used by the Web App to access the message queue. These could be stolen by an attacker and used to read confidential data or place poison message on the queue.",
                   "mitigation": "The Message Queue credentials should be encrypted."
                 }
               ],


### PR DESCRIPTION
**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->

This pull request fixes some minor typos in the threat descriptions of the demo models (and a test fixture). These aren't critical in the sense that they'd distort the meaning, but the fix may help to improve the first impression of Threat Dragon.

**Description for the changelog**:
<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->
Fix typos in demo threat descriptions

**Other info**:
<!--
Add here any other information that may be of help to the reviewer
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->

Based on my understanding of the end-to-end test that uses the fixture in question ([`td.vue/tests/e2e/specs/threatmodel/import.cy.js`](https://github.com/OWASP/threat-dragon/blob/01b1bcc35365bb376e81aba3a480f2789a122660/td.vue/tests/e2e/specs/threatmodel/import.cy.js#L83)), the change shouldn't have any effect on the test because the changed description isn't checked. The test is also skipped at the moment.