### PR TITLE
Fix undo for edges

### DIFF
--- a/td.vue/src/service/x6/shapes/index.js
+++ b/td.vue/src/service/x6/shapes/index.js
@@ -14,12 +14,12 @@ import { TrustBoundaryCurveStencil } from './trust-boundary-curve-stencil.js';
 Graph.registerNode('trust-broundary-curve', TrustBoundaryCurve);
 
 Graph.registerNode('actor', ActorShape);
-Graph.registerNode('flow', Flow);
+Graph.registerEdge('flow', Flow);
 Graph.registerNode('process', ProcessShape);
 Graph.registerNode('store', StoreShape);
 Graph.registerNode('td-text-block', TextBlock);
 Graph.registerNode('trust-boundary-box', TrustBoundaryBox);
-Graph.registerNode('trust-boundary-curve', TrustBoundaryCurve);
+Graph.registerEdge('trust-boundary-curve', TrustBoundaryCurve);
 
 export default {
     ActorShape,


### PR DESCRIPTION

**Summary**:
This change should fix the undo of edges in the model. Both when deleting a node with connected edges and a single edge.

Here is the undo behavior before this change (on the public website):

https://github.com/OWASP/threat-dragon/assets/1309462/20b4f66a-b992-4454-873c-48c83c1af27f


Here is the undo behavior after this change (locally hosted):

https://github.com/OWASP/threat-dragon/assets/1309462/033493f5-3991-4715-989b-e07df08145b9

**Description for the changelog**:
Register Edges in the x6 model instead of registering Edges as Nodes.

**Other info**:
Closes #428

Line 14 might need a similar change, but I am not familiar with the compatibility concerns.
