### PR TITLE
Set model storage path via env var

### DIFF
--- a/td.server/src/env/Bitbucket.js
+++ b/td.server/src/env/Bitbucket.js
@@ -20,7 +20,8 @@ class BitbucketEnv extends Env {
             { key: 'ENTERPRISE_PROTOCOL', required: false, defaultValue: 'https' },
             { key: 'USE_SEARCH', required: false, defaultValue: false },
             { key: 'SEARCH_QUERY', required: false },
-            { key: 'WORKSPACE', required: false }
+            { key: 'WORKSPACE', required: false },
+            { key: 'REPO_ROOT_DIRECTORY', required: false }
         ];
     }
 }

--- a/td.server/src/env/Github.js
+++ b/td.server/src/env/Github.js
@@ -19,7 +19,8 @@ class GithubEnv extends Env {
             { key: 'ENTERPRISE_PORT', required: false, defaultValue: 443 },
             { key: 'ENTERPRISE_PROTOCOL', required: false, defaultValue: 'https' },
             { key: 'USE_SEARCH', required: false, defaultValue: false },
-            { key: 'SEARCH_QUERY', required: false }
+            { key: 'SEARCH_QUERY', required: false },
+            { key: 'REPO_ROOT_DIRECTORY', required: false }
         ];
     }
 }

--- a/td.server/src/env/Gitlab.js
+++ b/td.server/src/env/Gitlab.js
@@ -19,7 +19,8 @@ class GitlabEnv extends Env {
             { key: 'ENTERPRISE_PORT', required: false },
             { key: 'USE_SEARCH', required: false },
             { key: 'SEARCH_QUERY', required: false },
-            { key: 'REDIRECT_URI', required: false }
+            { key: 'REDIRECT_URI', required: false },
+            { key: 'REPO_ROOT_DIRECTORY', required: false }
         ];
     }
 }

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -16,7 +16,8 @@ class ThreatDragonEnv extends Env {
             { key: 'PORT', required: false, defaultValue: 3000 },
             { key: 'LOG_MAX_FILE_SIZE', required: false, defaultValue: 24 },
             { key: 'LOG_LEVEL', required: false, defaultValue: 'warn' },
-            { key: 'SERVER_API_PROTOCOL', required: false, defaultValue: 'https' }
+            { key: 'SERVER_API_PROTOCOL', required: false, defaultValue: 'https' },
+            { key: 'REPO_ROOT_DIRECTORY', required: false, defaultValue: 'ThreatDragonModels' }
         ];
     }
 }

--- a/td.server/src/repositories/bitbucketrepo.js
+++ b/td.server/src/repositories/bitbucketrepo.js
@@ -1,6 +1,8 @@
 import {Bitbucket} from 'bitbucket';
 import env from '../env/Env.js';
 
+const repoRootDirectory = () => env.get().config.BITBUCKET_REPO_ROOT_DIRECTORY || env.get().config.REPO_ROOT_DIRECTORY;
+
 export class BitbucketClientWrapper {
     static getClient(clientOptions){
         return new Bitbucket(clientOptions);
@@ -74,14 +76,14 @@ export const modelsAsync = async (branchInfo, accessToken) => {
     });
     const commitId = data.target.hash;
     const tree = await client.source.read({
-        path: 'ThreatDragonModels',
+        path: repoRootDirectory,
         workspace: workspace,
         repo_slug: branchInfo.repo,
         commit: commitId
     });
 
     tree.data.values.map((x) => {
-        x.name = x.path.replace('ThreatDragonModels/', '');
+        x.name = x.path.replace(`${repoRootDirectory()}/`, '');
         return x;
     });
     return [tree.data.values];
@@ -153,7 +155,7 @@ export const deleteAsync = async (modelInfo, accessToken) => {
 };
 
 const getRepoFullName = (info) => `${info.repo}`;
-const getModelPath = (modelInfo) => `ThreatDragonModels/${modelInfo.model}/${modelInfo.model}.json`;
+const getModelPath = (modelInfo) => `${repoRootDirectory()}/${modelInfo.model}/${modelInfo.model}.json`;
 const getModelContent = (modelInfo) => JSON.stringify(modelInfo.body, null, '  ');
 
 export default {

--- a/td.server/src/repositories/bitbucketrepo.js
+++ b/td.server/src/repositories/bitbucketrepo.js
@@ -76,7 +76,7 @@ export const modelsAsync = async (branchInfo, accessToken) => {
     });
     const commitId = data.target.hash;
     const tree = await client.source.read({
-        path: repoRootDirectory,
+        path: repoRootDirectory(),
         workspace: workspace,
         repo_slug: branchInfo.repo,
         commit: commitId

--- a/td.server/src/repositories/githubrepo.js
+++ b/td.server/src/repositories/githubrepo.js
@@ -1,6 +1,8 @@
 import env from '../env/Env.js';
 import github from 'octonode';
 
+const repoRootDirectory = () => env.get().config.GITHUB_REPO_ROOT_DIRECTORY || env.get().config.REPO_ROOT_DIRECTORY;
+
 const getClient = (accessToken) => {
     const enterpriseHostname = env.get().config.GITHUB_ENTERPRISE_HOSTNAME;
     if (enterpriseHostname) {
@@ -35,7 +37,7 @@ const branchesAsync = (repoInfo, accessToken) => {
 
 const modelsAsync = (branchInfo, accessToken) => getClient(accessToken).
     repo(getRepoFullName(branchInfo)).
-    contentsAsync('ThreatDragonModels', branchInfo.branch);
+    contentsAsync(repoRootDirectory(), branchInfo.branch);
 
 const modelAsync = (modelInfo, accessToken) => getClient(accessToken).
     repo(getRepoFullName(modelInfo)).
@@ -80,7 +82,7 @@ const deleteAsync = async (modelInfo, accessToken) => {
 };
 
 const getRepoFullName = (info) => `${info.organisation}/${info.repo}`;
-const getModelPath = (modelInfo) => `ThreatDragonModels/${modelInfo.model}/${modelInfo.model}.json`;
+const getModelPath = (modelInfo) => `${repoRootDirectory()}/${modelInfo.model}/${modelInfo.model}.json`;
 const getModelContent = (modelInfo) => JSON.stringify(modelInfo.body, null, '  ');
 
 export default {

--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -2,6 +2,8 @@ import env from '../env/Env.js';
 import {Gitlab} from "@gitbeaker/rest";
 
 
+const repoRootDirectory = () => env.get().config.GITLAB_REPO_ROOT_DIRECTORY || env.get().config.REPO_ROOT_DIRECTORY;
+
 export class GitlabClientWrapper {
     static getClient(clientOptions) {
         return new Gitlab(clientOptions);
@@ -62,7 +64,7 @@ export const branchesAsync = async (repoInfo, accessToken) => {
 };
 
 export const modelsAsync = async (branchInfo, accessToken) => {
-    const models = await getClient(accessToken).Repositories.allRepositoryTrees(getRepoFullName(branchInfo), {path: 'ThreatDragonModels', ref:branchInfo.branch });
+    const models = await getClient(accessToken).Repositories.allRepositoryTrees(getRepoFullName(branchInfo), {path: repoRootDirectory(), ref:branchInfo.branch });
     return [models];
 };
 
@@ -101,7 +103,7 @@ export const deleteAsync = (modelInfo, accessToken) => getClient(accessToken).Re
     );
 
 const getRepoFullName = (info) => `${info.organisation}/${info.repo}`;
-const getModelPath = (modelInfo) => `ThreatDragonModels/${modelInfo.model}/${modelInfo.model}.json`;
+const getModelPath = (modelInfo) => `${repoRootDirectory()}/${modelInfo.model}/${modelInfo.model}.json`;
 const getModelContent = (modelInfo) => JSON.stringify(modelInfo.body, null, '  ');
 
 export default {

--- a/td.server/test/repositories/bitbucketrepo.spec.js
+++ b/td.server/test/repositories/bitbucketrepo.spec.js
@@ -9,6 +9,7 @@ import {getClient, userAsync} from '../../src/repositories/bitbucketrepo.js';
 
 describe('repositories/bitbucketrepo.js', () => {
     const workspace = 'threat-workspace';
+    const repoPath = 'ThreatDragonModels'
 
     const info = {
         body: {
@@ -30,13 +31,13 @@ describe('repositories/bitbucketrepo.js', () => {
             name: 'branch_name'
         },
         readInfo: {
-            path: 'ThreatDragonModels',
+            path: repoPath,
             workspace: workspace,
             repo_slug: 'repoInfo.repo',
             commit: '123'
         },
         modelReadInfo: {
-            path: 'ThreatDragonModels/my model/my model.json',
+            path: `${repoPath}/my model/my model.json`,
             workspace: workspace,
             repo_slug: 'repoInfo.repo',
             commit: '123'
@@ -183,7 +184,7 @@ describe('repositories/bitbucketrepo.js', () => {
         let branchInfo = {branch: info.branchInfo.name, repo: info.branchInfo.repo_slug};
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace, BITBUCKET_REPO_ROOT_DIRECTORY: repoPath}});
             sinon.stub(mockClient.source, 'read').returns(Promise.resolve({data: {values: [{path: 'ThreatDragonModels/model1'},
                         {path: 'ThreatDragonModels/model2'},
                         {path: 'ThreatDragonModels/model3'}]}}));
@@ -224,7 +225,7 @@ describe('repositories/bitbucketrepo.js', () => {
         let modelInfo = {branch: info.modelInfo.name, repo: info.modelInfo.repo_slug, model: info.modelInfo.model};
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace, BITBUCKET_REPO_ROOT_DIRECTORY: repoPath}});
             sinon.stub(mockClient.source, 'read').returns(Promise.resolve({data: "m34o1m"}));
             await threatModelRepository.modelAsync(modelInfo, accessToken);
         });
@@ -261,7 +262,7 @@ describe('repositories/bitbucketrepo.js', () => {
 
         };
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace, BITBUCKET_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.createAsync(createAysncInfo, accessToken);
         });
 
@@ -297,7 +298,7 @@ describe('repositories/bitbucketrepo.js', () => {
         };
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {BITBUCKET_WORKSPACE: workspace, BITBUCKET_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.updateAsync(updateAysncInfo, accessToken);
         });
 

--- a/td.server/test/repositories/gitlabrepo.spec.js
+++ b/td.server/test/repositories/gitlabrepo.spec.js
@@ -9,6 +9,7 @@ import {getClient, userAsync} from '../../src/repositories/gitlabrepo.js';
 
 describe('repositories/gitlabrepo.js', () => {
     const workspace = 'threat-workspace';
+    const repoPath = 'ThreatDragonModels'
 
     const info = {
         body: {
@@ -20,15 +21,15 @@ describe('repositories/gitlabrepo.js', () => {
         page: 'testPage',
         listBranches: { page: 'repoInfo.page', showExpanded: true }
         ,
-        branchInfo: { path: 'ThreatDragonModels', ref: 'main' } ,
+        branchInfo: { path: repoPath, ref: 'main' } ,
         readInfo: {
-            path: 'ThreatDragonModels',
+            path: repoPath,
             workspace: workspace,
             repo_slug: 'repoInfo.repo',
             commit: '123'
         },
         modelReadInfo: {
-            path: 'ThreatDragonModels/my model/my model.json',
+            path: `${repoPath}/my model/my model.json`,
             workspace: workspace,
             repo_slug: 'repoInfo.repo',
             commit: '123'
@@ -125,7 +126,7 @@ describe('repositories/gitlabrepo.js', () => {
         });
 
         it('creates the gitlab client', async () => {
-            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace, GITLAB_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.getClient(accessToken);
             expect(GitlabClientWrapper.getClient).to.have.been.calledWith(clientOptions.auth);
         });
@@ -204,7 +205,7 @@ describe('repositories/gitlabrepo.js', () => {
         let branchInfo = {branch: "main", repo: "repo"};
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace, GITLAB_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.modelsAsync(branchInfo, accessToken);
         });
 
@@ -221,7 +222,7 @@ describe('repositories/gitlabrepo.js', () => {
         let modelInfo = {page: info.listBranches.page, repo: "repo", organisation: "org", model: "model"}
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace, GITLAB_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.modelAsync(modelInfo, accessToken);
         });
 
@@ -245,7 +246,7 @@ describe('repositories/gitlabrepo.js', () => {
         };
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace, GITLAB_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.createAsync(createAysncInfo, accessToken);
         });
 
@@ -278,7 +279,7 @@ describe('repositories/gitlabrepo.js', () => {
         };
 
         beforeEach(async () => {
-            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace}});
+            sinon.stub(env, 'get').returns({config: {GITLAB_WORKSPACE: workspace, GITLAB_REPO_ROOT_DIRECTORY: repoPath}});
             await threatModelRepository.updateAsync(updateAysncInfo, accessToken);
         });
 


### PR DESCRIPTION
**Summary**:
As per the documentation found here: https://owasp.org/www-project-threat-dragon/docs-2/getting-started#opening-an-existing-model

> Note that Threat Dragon is fairly strict on where the threat models can be stored. The threat models must be under a parent directory called ‘ThreatDragonModels’ and the JSON file must then be stored in a sub-directory with the same name as the model.
> As an example, shown is a directory containing two models ‘test-reports’ and ‘New Threat Model’ under the directory ‘ThreatDragonModels’. This directory structure has been carried over from Threat Dragon versions 1.x, and in future it may become less strict.

I was hoping there would be a way of configuring where saved models are stored on a repo (ie in a `/doc` directory), and seeing this thought to add the functionality myself.

With this change, if no changes are made to the environment variables nothing changes in the directory structure - it is entirely opt-in and backwards compatible. If you would like to customize where models are stored, you can now set the `REPO_ROOT_DIRECTORY` environment variable. You can also override it per platform, ie `GITHUB_REPO_ROOT_DIRECTORY`, `BITBUCKET_REPO_ROOT_DIRECTORY`, etc.

**Description for the changelog**:

Customizable model storage path
