### PR TITLE
[Feature]: Threat type suggestion

### DIFF
--- a/td.server/src/providers/gitlab.js
+++ b/td.server/src/providers/gitlab.js
@@ -19,9 +19,7 @@ const isConfigured = () => Boolean(env.get().config.GITLAB_CLIENT_ID);
  * Gets the Gitlab endpoint, which will be gitlab.com by default OR a custom endpoint for Gitlab enterprise scenarios
  * @returns {String}
  */
-const getGitlabUrl = () => {
-    return env.get().config.GITLAB_HOST || 'https://gitlab.com';
-};
+const getGitlabUrl = () => env.get().config.GITLAB_HOST || 'https://gitlab.com';
 
 /**
  * Gets the Gitlab OAuth Login URL

--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -11,13 +11,13 @@ export class GitlabClientWrapper {
 }
 
 export const getClient = (accessToken) => {
-    let clientOptions = {
+    const clientOptions = {
         auth: {
             oauthToken: accessToken,
         },
     };
     if (env.get().config.GITLAB_HOST) {
-        clientOptions.auth['host']=env.get().config.GITLAB_HOST
+        clientOptions.auth.host=env.get().config.GITLAB_HOST;
     }
 
     return GitlabClientWrapper.getClient(clientOptions.auth);

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -229,10 +229,17 @@ export default {
         updateThreat() {
             const threatRef = this.cellRef.data.threats.find(x => x.id === this.threat.id);
             const objRef = this.cellRef.data;
-            if(!objRef.threatFrequency)
-                objRef.threatFrequency = threatModels.getFrequencyMapByElement(this.threat.modelType,this.cellRef.data.type);
-            objRef.threatFrequency[this.threat.type.toLowerCase()]++;
-            console.log(objRef);
+            if(!objRef.threatFrequency){
+                const tmpfreq = threatModels.getFrequencyMapByElement(this.threat.modelType,this.cellRef.data.type);
+                if(tmpfreq!==null)
+                    objRef.threatFrequency = tmpfreq;
+            }
+            if(objRef.threatFrequency){
+                Object.keys(objRef.threatFrequency).forEach((k)=>{
+                    if(this.$t(`threats.model.${this.threat.modelType.toLowerCase()}.${k}`)===this.threat.type)
+                        objRef.threatFrequency[k]++;
+                });
+            }
             if (threatRef) {
                 threatRef.status = this.threat.status;
                 threatRef.severity = this.threat.severity;
@@ -251,6 +258,13 @@ export default {
             this.hideModal();
         },
         deleteThreat() {
+            if(!this.threat.new){
+                const threatMap = this.cellRef.data.threatFrequency;
+                Object.keys(threatMap).forEach((k)=>{
+                    if(this.$t(`threats.model.${this.threat.modelType.toLowerCase()}.${k}`)===this.threat.type)
+                        threatMap[k]--;
+                });
+            }
             this.cellRef.data.threats = this.cellRef.data.threats.filter(x => x.id !== this.threat.id);
             this.cellRef.data.hasOpenThreats = this.cellRef.data.threats.length > 0;
             this.$store.dispatch(CELL_DATA_UPDATED, this.cellRef.data);

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -228,7 +228,11 @@ export default {
         },
         updateThreat() {
             const threatRef = this.cellRef.data.threats.find(x => x.id === this.threat.id);
-
+            const objRef = this.cellRef.data;
+            if(!objRef.threatFrequency)
+                objRef.threatFrequency = threatModels.getFrequencyMapByElement(this.threat.modelType,this.cellRef.data.type);
+            objRef.threatFrequency[this.threat.type.toLowerCase()]++;
+            console.log(objRef);
             if (threatRef) {
                 threatRef.status = this.threat.status;
                 threatRef.severity = this.threat.severity;

--- a/td.vue/src/service/threats/index.js
+++ b/td.vue/src/service/threats/index.js
@@ -2,6 +2,9 @@ import { v4 } from 'uuid';
 
 import models from './models/index.js';
 import { tc } from '../../i18n/index.js';
+import store from '@/store/index.js';
+
+
 
 const valuesToTranslations = {
     /* CIA */
@@ -47,47 +50,61 @@ export const createNewTypedThreat = function (modelType, cellType,number) {
         modelType = 'STRIDE';
     }
     let title, type;
-
-    switch (modelType) {
-
-    case 'CIA':
-        title = tc('threats.generic.cia');
-        type = tc('threats.model.cia.confidentiality');
-        break;
-
-    case 'DIE':
-        title = tc('threats.generic.die');
-        type = tc('threats.model.die.distributed');
-        break;
-
-    case 'LINDDUN':
-        title = tc('threats.generic.linddun');
-        type = tc('threats.model.linddun.linkability');
-        break;
-
-    case 'PLOT4ai':
-        title = tc('threats.generic.plot4ai');
-        if (cellType === 'tm.Actor') {
-            type = tc('threats.model.plot4ai.accessibility');
-        } else {
-            type = tc('threats.model.plot4ai.techniqueProcesses');
-        }
-        break;
-
-    case 'STRIDE':
-        title = tc('threats.generic.stride');
-        if (cellType === 'tm.Actor' || cellType === 'tm.Process') {
-            type = tc('threats.model.stride.spoofing');
-        } else {
-            type = tc('threats.model.stride.tampering');
-        }
-        break;
-
-    default:
-        title = tc('threats.generic.default');
-        type = tc('threats.model.stride.spoofing');
-        break;
+    if(modelType.toLowerCase()==='generic') modelType='default';
+    title = tc(`threats.generic.${modelType.toLowerCase()}`);
+    const freqMap = store.get().state.cell?.ref?.data.threatFrequency;
+    if(freqMap){
+        let min =freqMap[Object.keys(freqMap)[0]],choice=Object.keys(freqMap)[0];
+        Object.keys(freqMap).forEach((k)=>{
+            if(freqMap[k]<min)
+            {
+                min = freqMap[k];
+                choice = k;
+            }
+        });
+        type = tc(`threats.model.${modelType.toLowerCase()}.${choice}`);
     }
+    else
+        switch (modelType) {
+
+        case 'CIA':
+            title = tc('threats.generic.cia');
+            type = tc('threats.model.cia.confidentiality');
+            break;
+
+        case 'DIE':
+            title = tc('threats.generic.die');
+            type = tc('threats.model.die.distributed');
+            break;
+
+        case 'LINDDUN':
+            title = tc('threats.generic.linddun');
+            type = tc('threats.model.linddun.linkability');
+            break;
+
+        case 'PLOT4ai':
+            title = tc('threats.generic.plot4ai');
+            if (cellType === 'tm.Actor') {
+                type = tc('threats.model.plot4ai.accessibility');
+            } else {
+                type = tc('threats.model.plot4ai.techniqueProcesses');
+            }
+            break;
+
+        case 'STRIDE':
+            title = tc('threats.generic.stride');
+            if (cellType === 'tm.Actor' || cellType === 'tm.Process') {
+                type = tc('threats.model.stride.spoofing');
+            } else {
+                type = tc('threats.model.stride.tampering');
+            }
+            break;
+
+        default:
+            title = tc('threats.generic.default');
+            type = tc('threats.model.stride.spoofing');
+            break;
+        }
 
     return {
         id: v4(),

--- a/td.vue/src/service/threats/models/index.js
+++ b/td.vue/src/service/threats/models/index.js
@@ -122,10 +122,66 @@ const getThreatTypesByElement = (modelType, cellType) => {
     return swapKeyValuePairs(types);
 };
 
+const getFrequencyMapByElement = (modelType,cellType) => {
+    let freqMap={};
+    switch(modelType.toUpperCase()){
+    case 'CIA':
+        freqMap = {confidentiality: 0,integrity: 0,availability:0};
+        break;
+    case 'DIE':
+        freqMap = {distributed: 0,immutable: 0,ephemeral: 0};
+        break;
+    case 'LINDDUN':
+        if(cellType==='tm.Actor')
+            freqMap = {linkability: 0,identifiability: 0,unawareness: 0};
+        else{
+            Object.keys(linddun.default).map((k)=>{freqMap[k]=0;});
+        }
+        break;
+    case 'PLOT4AI':
+        switch(cellType){
+        case 'tm.Actor' :
+            Object.keys(plot4ai.actor).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Process' :
+            Object.keys(plot4ai.process).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Store' :
+            Object.keys(plot4ai.store).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Flow' :
+        default:
+            Object.keys(plot4ai.flow).map((k)=>{freqMap[k]=0;});
+            break;
+        }
+        break;
+    case 'STRIDE':
+        switch(cellType){
+        case 'tm.Actor' :
+            Object.keys(stride.actor).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Process' :
+            Object.keys(stride.process).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Store' :
+            Object.keys(stride.store).map((k)=>{freqMap[k]=0;});
+            break;
+        case 'tm.Flow' :
+        default:
+            Object.keys(stride.flow).map((k)=>{freqMap[k]=0;});
+            break;
+        }
+        break;
+    }
+    console.log(freqMap);
+    return freqMap;
+};
+
 const allModels = ['CIA', 'DIE', 'LINDDUN', 'PLOT4ai', 'STRIDE'];
 
 export default {
     getByTranslationValue,
     getThreatTypesByElement,
+    getFrequencyMapByElement,
     allModels
 };

--- a/td.vue/src/service/threats/models/index.js
+++ b/td.vue/src/service/threats/models/index.js
@@ -172,8 +172,8 @@ const getFrequencyMapByElement = (modelType,cellType) => {
             break;
         }
         break;
+    default: return null;
     }
-    console.log(freqMap);
     return freqMap;
 };
 

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -24,7 +24,7 @@ describe('components/ThreatEditDialog.vue', () => {
     });
 
     const getStore = () => new Vuex.Store({
-        state: { cell: { ref: { getData: jest.fn(), data: { threats: [ getThreatData() ]}}}},
+        state: { cell: { ref: { getData: jest.fn(), data: { threatFrequency:{availability: 0,confidentiality: 0,integrity: 0}, threats: [ getThreatData() ]}}}},
         actions: { CELL_DATA_UPDATED: () => {} }
     });
 
@@ -158,6 +158,7 @@ describe('components/ThreatEditDialog.vue', () => {
                 expect(mockStore.dispatch)
                     .toHaveBeenCalledWith('CELL_DATA_UPDATED', {
                         hasOpenThreats: false,
+                        threatFrequency:{availability: 0,confidentiality: 0,integrity: 0},
                         threats: []
                     });
             });
@@ -184,7 +185,8 @@ describe('components/ThreatEditDialog.vue', () => {
         });
 
         it('updates the data', () => {
-            expect(mockStore.dispatch).toHaveBeenCalledWith('CELL_DATA_UPDATED', { threats: [ getThreatData() ] });
+            expect(mockStore.dispatch).toHaveBeenNthCalledWith(1,'CELL_DATA_UPDATED',{threatFrequency:{availability: 0,confidentiality: 0,integrity: 0}, threats: [ getThreatData() ] });
+            expect(mockStore.dispatch).toHaveBeenNthCalledWith(2,'THREATMODEL_MODIFIED;');
         });
 
         it('updates the styles', () => {


### PR DESCRIPTION
## Summary: 
Suggesting the type of the threat upon creation

### Description for the change log: 
works with all diagram models (except generic)

### Specifically what changed?
1- added a frequency mapping to keep track of threat type for each cell.
2- suggesting the least frequent type each time.
3- the map won't be attached to the element until it has a saved threat first.

Related to the issues #987 and #985