### PR TITLE
Aligned scope param default value with oauth spec

### DIFF
--- a/td.server/src/providers/gitlab.js
+++ b/td.server/src/providers/gitlab.js
@@ -28,7 +28,7 @@ const getGitlabUrl = () => {
  * @returns {String}
  */
 const getOauthRedirectUrl = () => {
-    const scope = env.get().config.GITLAB_SCOPE || 'read_user,read_repository,write_repository,profile';
+    const scope = env.get().config.GITLAB_SCOPE || 'read_user read_repository write_repository profile';
     return `${getGitlabUrl()}/oauth/authorize?scope=${scope}&redirect_uri=${env.get().config.GITLAB_REDIRECT_URI}&response_type=code&client_id=${env.get().config.GITLAB_CLIENT_ID}`;
 };
 


### PR DESCRIPTION
**Summary**:
Closes #995 

**Description for the changelog**:
The scope params default value is separated by spaces instead of commas as defined by [the oauth spec](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
