### PR TITLE
fix: SEARCH envs renamed and searchAsync fixed for gitlabrepo

### DIFF
--- a/td.server/src/controllers/auth.js
+++ b/td.server/src/controllers/auth.js
@@ -9,7 +9,7 @@ import tokenRepo from '../repositories/token.js';
 const logger = loggerHelper.get('controllers/auth.js');
 
 const login = (req, res) => {
-    logger.debug('API login request: ' + req);
+    logger.debug(`API login request: ${JSON.stringify(req)}`);
 
     try {
         const provider = providers.get(req.params.provider);
@@ -20,7 +20,7 @@ const login = (req, res) => {
 };
 
 const oauthReturn = (req, res) => {
-    logger.debug('API oauthReturn request: ' + req);
+    logger.debug(`API oauthReturn request: ${JSON.stringify(req)}`);
 
     let returnUrl = `/#/oauth-return?code=${req.query.code}`;
     if (env.get().config.NODE_ENV === 'development') {
@@ -30,7 +30,7 @@ const oauthReturn = (req, res) => {
 };
 
 const completeLogin = (req, res) => {
-    logger.debug('API completeLogin request: ' + req);
+    logger.debug(`API completeLogin request: ${JSON.stringify(req)}`);
 
     try {
         const provider = providers.get(req.params.provider);
@@ -51,7 +51,7 @@ const completeLogin = (req, res) => {
 };
 
 const logout = (req, res) => responseWrapper.sendResponse(() => {
-    logger.debug('API logout request: ' + req);
+    logger.debug(`API logout request: ${JSON.stringify(req)}`);
 
     try {
         const refreshToken = req.body.refreshToken;
@@ -71,7 +71,7 @@ const logout = (req, res) => responseWrapper.sendResponse(() => {
 }, req, res, logger);
 
 const refresh = (req, res) => {
-    logger.debug('API refresh request: ' + req);
+    logger.debug(`API refresh request: ${JSON.stringify(req)}`);
 
     const tokenBody = tokenRepo.verify(req.body.refreshToken);
     if (!tokenBody) {

--- a/td.server/src/controllers/threatmodelcontroller.js
+++ b/td.server/src/controllers/threatmodelcontroller.js
@@ -12,9 +12,9 @@ const repos = (req, res) => responseWrapper.sendResponseAsync(async () => {
     const page = req.query.page || 1;
     let reposResp;
     let repos;
-    if (env.get().config.GITHUB_USE_SEARCH === 'true') {
+    if (env.get().config.REPO_USE_SEARCH === 'true') {
         logger.debug('Using searchAsync');
-        const searchQuery = env.get().config.GITHUB_SEARCH_QUERY;
+        const searchQuery = env.get().config.REPO_SEARCH_QUERY;
         reposResp = await repository.searchAsync(page, req.provider.access_token, searchQuery);
         repos = reposResp[0].items;
     } else {

--- a/td.server/src/controllers/threatmodelcontroller.js
+++ b/td.server/src/controllers/threatmodelcontroller.js
@@ -24,7 +24,7 @@ const repos = (req, res) => responseWrapper.sendResponseAsync(async () => {
     }
     const headers = reposResp[1];
     const pageLinks = reposResp[2];
-    logger.debug('API repos request: ' + req);
+    logger.debug(`API repos request: ${JSON.stringify(req)}`);
 
     const pagination = getPagination(headers, pageLinks, page);
 
@@ -45,7 +45,7 @@ const branches = (req, res) => responseWrapper.sendResponseAsync(async () => {
         repo: req.params.repo,
         page: req.query.page || 1
     };
-    logger.debug('API branches request: ' + req);
+    logger.debug(`API branches request: ${JSON.stringify(req)}`);
 
     const branchesResp = await repository.branchesAsync(repoInfo, req.provider.access_token);
     const branches = branchesResp[0];
@@ -70,7 +70,7 @@ const models = (req, res) => responseWrapper.sendResponseAsync(async () => {
         repo: req.params.repo,
         branch: req.params.branch
     };
-    logger.debug('API models request: ' + req);
+    logger.debug(`API models request: ${JSON.stringify(req)}`);
 
     let modelsResp;
     try {
@@ -93,7 +93,7 @@ const model = (req, res) => responseWrapper.sendResponseAsync(async () => {
         branch: req.params.branch,
         model: req.params.model
     };
-    logger.debug('API model request: ' + req);
+    logger.debug(`API model request: ${JSON.stringify(req)}`);
 
     const modelResp = await repository.modelAsync(modelInfo, req.provider.access_token);
     return JSON.parse(Buffer.from(modelResp[0].content, 'base64').toString('utf8'));
@@ -109,7 +109,7 @@ const create = async (req, res) => {
         model: req.params.model,
         body: req.body
     };
-    logger.debug('API create request: ' + req);
+    logger.debug(`API create request: ${JSON.stringify(req)}`);
 
     try {
         const createResp = await repository.createAsync(modelBody, req.provider.access_token);
@@ -130,7 +130,7 @@ const update = async (req, res) => {
         model: req.params.model,
         body: req.body
     };
-    logger.debug('API update request: ' + req);
+    logger.debug(`API update request: ${JSON.stringify(req)}`);
 
     try {
         const updateResp = await repository.updateAsync(modelBody, req.provider.access_token);
@@ -150,7 +150,7 @@ const deleteModel = async (req, res) => {
         branch: req.params.branch,
         model: req.params.model
     };
-    logger.debug('API deleteModel request: ' + req);
+    logger.debug(`API deleteModel request: ${JSON.stringify(req)}`);
 
     try {
         const deleteResp = await repository.deleteAsync(modelInfo, req.provider.access_token);
@@ -205,7 +205,7 @@ const organisation = (req, res) => {
         hostname: env.get().config.GITHUB_ENTERPRISE_HOSTNAME || 'www.github.com',
         port: env.get().config.GITHUB_ENTERPRISE_PORT || '',
     };
-    logger.debug('API organisation request: ' + req);
+    logger.debug(`API organisation request: ${JSON.stringify(req)}`);
 
     return res.status(200).send(organisation);
 };

--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -23,7 +23,7 @@ export const getClient = (accessToken) => {
     return GitlabClientWrapper.getClient(clientOptions.auth);
 };
 
-export const reposAsync = async (page, accessToken) => searchAsync(page, accessToken, undefined)
+export const reposAsync = (page, accessToken) => searchAsync(page, accessToken, undefined)
 
 export const getPagination = (paginationInfo, page) => {
     const pagination = {page, next: false, prev: false};

--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -23,14 +23,7 @@ export const getClient = (accessToken) => {
     return GitlabClientWrapper.getClient(clientOptions.auth);
 };
 
-export const reposAsync = async (page, accessToken) => {
-    const repos = await getClient(accessToken).Projects.all({page: page, membership: true, showExpanded: true});
-    repos.data.map((repo) => {
-        repo.full_name = repo.path_with_namespace;
-        return repo;
-    });
-    return [repos.data, null, getPagination(repos.paginationInfo)];
-};
+export const reposAsync = async (page, accessToken) => searchAsync(page, accessToken, undefined)
 
 export const getPagination = (paginationInfo, page) => {
     const pagination = {page, next: false, prev: false};
@@ -43,7 +36,14 @@ export const getPagination = (paginationInfo, page) => {
     return pagination;
 };
 
-export const searchAsync = (page, accessToken, searchQuery) => getClient(accessToken).reposAsync({page: page, q: searchQuery});
+export const searchAsync = async (page, accessToken, searchQuery) => {
+    const repos = await getClient(accessToken).Projects.all({page: page, membership: true, showExpanded: true, search: searchQuery});
+    repos.data.map((repo) => {
+        repo.full_name = repo.path_with_namespace;
+        return repo;
+    });
+    return [repos.data, null, getPagination(repos.paginationInfo)];
+};
 
 export const userAsync = (accessToken) => getClient(accessToken).Users.showCurrentUser();
 


### PR DESCRIPTION
**Summary**:
Fixes [Issue 1001](https://github.com/OWASP/threat-dragon/issues/1001)

The two env vars GITHUB_SEARCH_QUERRY and GITHUB_USE_SEARCH renamed to REPO_SEARCH_QUERRY and REPO_USE_SEARCH respectively to better reflect that they are applied for every repo integration.

Fixed the searchAsync method of the gitlabrepo to work properly.

**Description for the changelog**:
some envs renamed and searchAsync fixed for gitlabrepo
