### PR TITLE
do not scare the users with version 1.x warnings

### DIFF
--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -23,7 +23,7 @@ export const getClient = (accessToken) => {
     return GitlabClientWrapper.getClient(clientOptions.auth);
 };
 
-export const reposAsync = (page, accessToken) => searchAsync(page, accessToken, undefined)
+export const reposAsync = (page, accessToken) => searchAsync(page, accessToken, undefined);
 
 export const getPagination = (paginationInfo, page) => {
     const pagination = {page, next: false, prev: false};

--- a/td.vue/src/App.vue
+++ b/td.vue/src/App.vue
@@ -35,7 +35,6 @@ export default {
     }),
     mounted() {
         this.$store.dispatch(LOADER_FINISHED);
-        this.$toast.warning(this.$t('nav.v2Warning'), { timeout: false });
     }
 };
 </script>

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -1,9 +1,3 @@
-/**
- * @name diagram
- * @description Reads an existing v1 diagram to create components for the v2 UI
- * This is not for persistence, and is done on a diagram by diagram basis
- */
-
 import cells from './cells.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import graphFactory from '@/service/x6/graph/graph.js';
@@ -42,10 +36,10 @@ const upgradeAndDraw = (diagram, graph) => {
 
 const drawGraph = (diagram, graph) => {
     if (diagram.version && diagram.version.startsWith('2.')) {
-	    console.debug('open version 2.x diagram');
+        console.debug('open version 2.x diagram');
         graph.fromJSON(diagram);
     } else {
-	    console.debug('upgrade version 1.x diagram');
+        console.debug('upgrade version 1.x diagram');
         upgradeAndDraw(diagram, graph);
     }
     return graph;

--- a/td.vue/src/service/schema/ajv.js
+++ b/td.vue/src/service/schema/ajv.js
@@ -1,4 +1,7 @@
 import Ajv from 'ajv';
+import Vue from 'vue';
+import i18n from '@/i18n/index.js';
+
 import { schema } from './threat-model-schema';
 import { schema as schemaV2 } from './threat-model-schema.V2';
 import { schema as schemaOTM } from './open-threat-model-schema';
@@ -20,6 +23,7 @@ export const isValidSchema = (jsonFile) => {
     valid = validate(jsonFile);
     if (valid) {
         console.debug('Schema validate success for V1.x model');
+        Vue.$toast.warning(i18n.get().t('nav.v2Warning'), { timeout: false });
         return true;
     }
 

--- a/td.vue/tests/e2e/support/e2e.js
+++ b/td.vue/tests/e2e/support/e2e.js
@@ -6,7 +6,5 @@ beforeEach(() => {
     cy.visit('/', {
         onBeforeLoad: (win) => win.sessionStorage.clear()
     });
-    cy.get('.Vue-Toastification__toast--warning').should('be.visible');
-    cy.get('.Vue-Toastification__close-button').click();
     cy.get('#local-login-btn').should('be.visible');
 });

--- a/td.vue/tests/unit/app.spec.js
+++ b/td.vue/tests/unit/app.spec.js
@@ -9,13 +9,10 @@ import { LOADER_FINISHED } from '@/store/actions/loader.js';
 import Navbar from '@/components/Navbar.vue';
 
 describe('App.vue', () => {
-    let wrapper, localVue, mockStore, mockToast;
+    let wrapper, localVue, mockStore;
 
     beforeEach(() => {
         console.log = jest.fn();
-        mockToast = {
-            warning: jest.fn()
-        };
         localVue = createLocalVue();
         localVue.use(BootstrapVue);
         localVue.use(Vuex);
@@ -36,8 +33,7 @@ describe('App.vue', () => {
             stubs: ['router-view'],
             store: mockStore,
             mocks: {
-                $t: key => key,
-                $toast: mockToast
+                $t: key => key
             }
         });
     });
@@ -52,9 +48,5 @@ describe('App.vue', () => {
 
     it('has a b-container', () => {
         expect(wrapper.findComponent(BContainer).exists()).toBe(true);
-    });
-
-    it('shows a warning toast for v2', () => {
-        expect(mockToast.warning).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
**Summary**:
Only show warning about version 1.x files being moved to version 2.x if the file is at version 1.x
Otherwise keep quiet and do not scare the users

**Description for the changelog**:
show v1.x warning only when opening v1.x diagrams

**Other info**:
closes #1005 
this came about after hearing the feedback from Threat Model Connect conference in Lisbon 2024
