### PR TITLE
trust boundaries given heavier dash ratio

### DIFF
--- a/td.server/src/repositories/gitlabrepo.js
+++ b/td.server/src/repositories/gitlabrepo.js
@@ -23,7 +23,7 @@ export const getClient = (accessToken) => {
     return GitlabClientWrapper.getClient(clientOptions.auth);
 };
 
-export const reposAsync = (page, accessToken) => searchAsync(page, accessToken, undefined)
+export const reposAsync = (page, accessToken) => searchAsync(page, accessToken, undefined);
 
 export const getPagination = (paginationInfo, page) => {
     const pagination = {page, next: false, prev: false};

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -14,8 +14,8 @@ export const TrustBoundaryBox = Shape.HeaderedRect.define({
         body: {
             rx: 10,
             ry: 10,
-            strokeDasharray: '5 5',
             strokeWidth: 3,
+            strokeDasharray: '10 5',
             fill: 'transparent',
             fillOpacity: 0
         },

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
@@ -27,7 +27,7 @@ export const TrustBoundaryCurveStencil = Shape.Empty.define({
             strokeWidth: 3,
             stroke: '#333333',
             fill: 'transparent',
-            strokeDasharray: '5 5',
+            strokeDasharray: '10 5',
             refD: 'M 30 20 C 70 20 70 100 110 100'
         },
         label: {

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -13,7 +13,7 @@ export const TrustBoundaryCurve = Shape.Edge.define({
     attrs: {
         line: {
             strokeWidth: 3,
-            strokeDasharray: '5 5',
+            strokeDasharray: '10 5',
             sourceMarker: null,
             targetMarker: null
         }

--- a/td.vue/tests/unit/service/x6/shapes/trust-boundary-box.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/trust-boundary-box.spec.js
@@ -13,6 +13,16 @@ describe('service/x6/shapes/trust-boundary-box.js', () => {
         expect(victim.constructor.name).toEqual('TrustBoundaryBox');
     });
 
+    describe('get victim attributes', () => {
+        it('sets the stroke dash array', () => {
+            expect(victim.attrs.body.strokeDasharray).toEqual('10 5');
+        });
+
+        it('sets the stroke width', () => {
+            expect(victim.attrs.body.strokeWidth).toEqual(3);
+        });
+    });
+
     describe('setName', () => {
         it('sets the name', () => {
             const name = 'tbbName';

--- a/td.vue/tests/unit/service/x6/shapes/trust-boundary-curve.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/trust-boundary-curve.spec.js
@@ -12,13 +12,17 @@ describe('service/x6/shapes/trust-boundary-curve.js', () => {
         expect(victim.constructor.name).toEqual('TrustBoundaryCurve');
     });
 
-    describe('get edge victim', () => {
+    describe('get edge victim attributes', () => {
         it('uses the smooth connector', () => {
             expect(victim.connector).toEqual('smooth');
         });
 
         it('sets the stroke dash array', () => {
-            expect(victim.attrs.line.strokeDasharray).toEqual('5 5');
+            expect(victim.attrs.line.strokeDasharray).toEqual('10 5');
+        });
+
+        it('sets the stroke width', () => {
+            expect(victim.attrs.line.strokeWidth).toEqual(3);
         });
 
         it('does not have a source marker', () => {


### PR DESCRIPTION
**Summary**:
trust boundaries looked too much like an out of scope diagram element, so use a heavier dash ratio for trust boundaries

**Description for the changelog**:
trust boundaries given heavier dash ratio

**Other info**:
closes #1006 