### PR TITLE
fix: REPO_SEARCH envs are processed by the application

### DIFF
--- a/td.server/src/controllers/threatmodelcontroller.js
+++ b/td.server/src/controllers/threatmodelcontroller.js
@@ -16,7 +16,7 @@ const repos = (req, res) => responseWrapper.sendResponseAsync(async () => {
         logger.debug('Using searchAsync');
         const searchQuery = env.get().config.REPO_SEARCH_QUERY;
         reposResp = await repository.searchAsync(page, req.provider.access_token, searchQuery);
-        repos = reposResp[0].items;
+        repos = reposResp[0].items ?? reposResp[0];
     } else {
         logger.debug('Using reposAsync');
         reposResp = await repository.reposAsync(page, req.provider.access_token);

--- a/td.server/src/env/Github.js
+++ b/td.server/src/env/Github.js
@@ -18,8 +18,6 @@ class GithubEnv extends Env {
             { key: 'ENTERPRISE_HOSTNAME', required: false },
             { key: 'ENTERPRISE_PORT', required: false, defaultValue: 443 },
             { key: 'ENTERPRISE_PROTOCOL', required: false, defaultValue: 'https' },
-            { key: 'USE_SEARCH', required: false, defaultValue: false },
-            { key: 'SEARCH_QUERY', required: false },
             { key: 'REPO_ROOT_DIRECTORY', required: false }
         ];
     }

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -17,7 +17,9 @@ class ThreatDragonEnv extends Env {
             { key: 'LOG_MAX_FILE_SIZE', required: false, defaultValue: 24 },
             { key: 'LOG_LEVEL', required: false, defaultValue: 'warn' },
             { key: 'SERVER_API_PROTOCOL', required: false, defaultValue: 'https' },
-            { key: 'REPO_ROOT_DIRECTORY', required: false, defaultValue: 'ThreatDragonModels' }
+            { key: 'REPO_ROOT_DIRECTORY', required: false, defaultValue: 'ThreatDragonModels' },
+            { key: 'REPO_USE_SEARCH', required: false, defaultValue: false },
+            { key: 'REPO_SEARCH_QUERY', required: false }
         ];
     }
 }

--- a/td.server/test/env/ThreatDragon.spec.js
+++ b/td.server/test/env/ThreatDragon.spec.js
@@ -56,4 +56,18 @@ describe('env/ThreatDragon.js', () => {
             .required;
         expect(isRequired).to.be.false;
     });
+
+    it('has the optional property REPO_USE_SEARCH', () => {
+        const isRequired = tdEnv.properties
+            .find(x => x.key === 'REPO_USE_SEARCH')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has the optional property REPO_SEARCH_QUERY', () => {
+        const isRequired = tdEnv.properties
+            .find(x => x.key === 'REPO_SEARCH_QUERY')
+            .required;
+        expect(isRequired).to.be.false;
+    });
 });


### PR DESCRIPTION
**Summary**:
The renamed env vars REPO_USE_SEARCH and REPO_SEARCH_QUERY have not been processed by the application, because the app still expected to load env vars calles GITHUB_USE_SEARCH and GITHUB_SEARCH_QUERY.

So I moved the two env vars from the **env/Github.js** file to the general **env/ThreatDragon.js** file...

Additionally the gitlab search does not return an object with an atribute named items but simply just an array.
So i slightly tweak the `threadmodelcontroller` to handle the return value accordingly..
Fixes #1001 

**Description for the changelog**:
