### PR TITLE
Encode url params to handle deeply nested repositories

### DIFF
--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -46,7 +46,7 @@ const branchesAsync = (fullRepoName, page = 1) => {
  */
 const modelsAsync = (fullRepoName, branch) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    const { encodedOrg, encodedRepo, encodedBranch } = encodeUrlComponents(org, repo, branch);
+    const [ encodedOrg, encodedRepo, encodedBranch ] = encodeUrlComponents(org, repo, branch);
     return api.getAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/models`);
 };
 
@@ -59,19 +59,19 @@ const modelsAsync = (fullRepoName, branch) => {
  */
 const modelAsync = (fullRepoName, branch, model) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    const { encodedOrg, encodedRepo, encodedBranch, encodedModel } = encodeUrlComponents(org, repo, branch, model);
+    const [ encodedOrg, encodedRepo, encodedBranch, encodedModel ] = encodeUrlComponents(org, repo, branch, model);
     return api.getAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModel}/data`);
 };
 
 const createAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    const { encodedOrg, encodedRepo, encodedBranch, encodedModelName } = encodeUrlComponents(org, repo, branch, modelName);
+    const [ encodedOrg, encodedRepo, encodedBranch, encodedModelName ] = encodeUrlComponents(org, repo, branch, modelName);
     return api.postAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModelName}/create`, threatModel);
 };
 
 const updateAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    const { encodedOrg, encodedRepo, encodedBranch, encodedModelName } = encodeUrlComponents(org, repo, branch, modelName);
+    const [ encodedOrg, encodedRepo, encodedBranch, encodedModelName ] = encodeUrlComponents(org, repo, branch, modelName);
     return api.putAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModelName}/update`, threatModel);
 };
 

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -8,6 +8,10 @@ const extractRepoParts = (fullRepoName) => {
     return { org, repo };
 };
 
+const encodeUrlComponents = (... uriComponents) => {
+    return uriComponents.map(uriComponent => encodeURIComponent(uriComponent));
+};
+
 
 /**
  * Gets the organisation data configured for the express server
@@ -30,7 +34,8 @@ const reposAsync = (page = 1) => {
  */
 const branchesAsync = (fullRepoName, page = 1) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.getAsync(`${resource}/${org}/${repo}/branches`, { params: { page: page } });
+    const [ encodedOrg, encodedRepo ] = encodeUrlComponents(org, repo);
+    return api.getAsync(`${resource}/${encodedOrg}/${encodedRepo}/branches`, { params: { page: page } });
 };
 
 /**
@@ -41,7 +46,8 @@ const branchesAsync = (fullRepoName, page = 1) => {
  */
 const modelsAsync = (fullRepoName, branch) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.getAsync(`${resource}/${org}/${repo}/${encodeURIComponent(branch)}/models`);
+    const { encodedOrg, encodedRepo, encodedBranch } = encodeUrlComponents(org, repo, branch);
+    return api.getAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/models`);
 };
 
 /**
@@ -53,17 +59,20 @@ const modelsAsync = (fullRepoName, branch) => {
  */
 const modelAsync = (fullRepoName, branch, model) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.getAsync(`${resource}/${org}/${repo}/${branch}/${model}/data`);
+    const { encodedOrg, encodedRepo, encodedBranch, encodedModel } = encodeUrlComponents(org, repo, branch, model);
+    return api.getAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModel}/data`);
 };
 
 const createAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.postAsync(`${resource}/${org}/${repo}/${branch}/${modelName}/create`, threatModel);
+    const { encodedOrg, encodedRepo, encodedBranch, encodedModelName } = encodeUrlComponents(org, repo, branch, modelName);
+    return api.postAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModelName}/create`, threatModel);
 };
 
 const updateAsync = (fullRepoName, branch, modelName, threatModel) => {
     const { org, repo } = extractRepoParts(fullRepoName);
-    return api.putAsync(`${resource}/${org}/${repo}/${branch}/${modelName}/update`, threatModel);
+    const { encodedOrg, encodedRepo, encodedBranch, encodedModelName } = encodeUrlComponents(org, repo, branch, modelName);
+    return api.putAsync(`${resource}/${encodedOrg}/${encodedRepo}/${encodedBranch}/${encodedModelName}/update`, threatModel);
 };
 
 export default {

--- a/td.vue/tests/unit/service/api/threatmodelApi.spec.js
+++ b/td.vue/tests/unit/service/api/threatmodelApi.spec.js
@@ -28,19 +28,19 @@ describe('service/threatmodelApi.js', () => {
     });
 
     describe('branchesAsync', () => {
-        const repo = 'owasp/threat-dragon';
+        const repo = 'owasp/with/deep/layers/threat-dragon';
 
         beforeEach(async () => {
             await threatmodelApi.branchesAsync(repo);
         });
 
         it('calls the branches endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/threat-dragon/branches', {'params': {'page': 1}});
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/branches', {'params': {'page': 1}});
         });
     });
 
     describe('modelsAsync', () => {
-        const repo = 'owasp/threat-dragon';
+        const repo = 'owasp/with/deep/layers/threat-dragon';
         const branch = 'feature/some-feature';
 
         beforeEach(async () => {
@@ -48,28 +48,28 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the models endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/threat-dragon/feature%2Fsome-feature/models');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/feature%2Fsome-feature/models');
         });
     });
 
     describe('modelAsync', () => {
-        const repo = 'owasp/threat-dragon';
-        const branch = 'main';
-        const model = 'test';
+        const repo = 'owasp/with/deep/layers/threat-dragon';
+        const branch = 'main&';
+        const model = 'test?';
 
         beforeEach(async () => {
             await threatmodelApi.modelAsync(repo, branch, model);
         });
 
         it('calls the model endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/threat-dragon/main/test/data');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/main%26/test%3F/data');
         });
     });
 
     describe('updateAsync', () => {
-        const repo = 'owasp/threat-dragon';
-        const branch = 'main';
-        const modelName = 'test';
+        const repo = 'owasp/with/deep/layers/threat-dragon';
+        const branch = 'main&';
+        const modelName = 'test?';
         const body = { foo: 'bar' };
 
         beforeEach(async () => {
@@ -78,7 +78,7 @@ describe('service/threatmodelApi.js', () => {
 
         it('calls the update endpoint', () => {
             expect(api.putAsync).toHaveBeenCalledWith(
-                '/api/threatmodel/owasp/threat-dragon/main/test/update',
+                '/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/main%26/test%3F/update',
                 body
             );
         });

--- a/td.vue/tests/unit/service/api/threatmodelApi.spec.js
+++ b/td.vue/tests/unit/service/api/threatmodelApi.spec.js
@@ -35,7 +35,7 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the branches endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/branches', {'params': {'page': 1}});
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/branches', {'params': {'page': 1}});
         });
     });
 
@@ -48,7 +48,7 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the models endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/feature%2Fsome-feature/models');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/feature%2Fsome-feature/models');
         });
     });
 
@@ -62,7 +62,7 @@ describe('service/threatmodelApi.js', () => {
         });
 
         it('calls the model endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/main%26/test%3F/data');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/main%26/test%3F/data');
         });
     });
 
@@ -78,7 +78,7 @@ describe('service/threatmodelApi.js', () => {
 
         it('calls the update endpoint', () => {
             expect(api.putAsync).toHaveBeenCalledWith(
-                '/api/threatmodel/owasp%2Fwith%2Fdeep%2Flayers/threat-dragon/main%26/test%3F/update',
+                '/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/main%26/test%3F/update',
                 body
             );
         });


### PR DESCRIPTION
**Summary**:
Some url params are now properly encoded, so that threat-dragon can handle deeply nested repositories.
Fixes #1003 

**Description for the changelog**:
encode url params to handle deeply nested repositories

