### PR TITLE
correct pdf extension when saving file

### DIFF
--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -344,7 +344,8 @@ function savePDFReport (pdfPath) {
     var dialogOptions = {
         title: messages[language].forms.exportPdf,
         defaultPath: pdfPath,
-        filters: [{ name: 'PDF report', extensions: ['.pdf'] }, { name: 'All Files', extensions: ['*'] }]
+        properties: ['openFile'],
+        filters: [{ name: 'PDF report', extensions: ['pdf'] }, { name: 'All Files', extensions: ['*'] }]
     };
 
     dialog.showSaveDialog(dialogOptions).then(result => {


### PR DESCRIPTION
**Summary**:
The pdf extension is incorrect when saving files in the desktop app

**Description for the changelog**:
correct pdf extension when saving file

**Other info**:
fixes #1023 
