### PR TITLE
desktop recent file sub-menu only for MacOS

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -31,6 +31,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: |

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build for amd64
         id: docker_build
-        uses: docker/build-push-action@v6.3.0
+        uses: docker/build-push-action@v6.4.1
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -35,6 +35,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -57,7 +58,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -68,6 +69,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -90,7 +92,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -101,6 +103,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -163,6 +166,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+            ${{ runner.os }}-
 
       - name: Build for amd64
         id: docker_build
@@ -232,7 +236,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -243,6 +247,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -38,6 +38,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -69,7 +70,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -80,6 +81,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -102,7 +104,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -113,6 +115,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -163,7 +166,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.1.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -178,6 +181,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+            ${{ runner.os }}-
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.2.0
@@ -262,7 +266,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -273,6 +277,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -312,7 +317,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -323,6 +328,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -363,7 +369,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -374,6 +380,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -452,7 +459,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -463,6 +470,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm install
@@ -490,7 +498,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -501,6 +509,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm install
@@ -530,7 +539,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -541,6 +550,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm install
@@ -575,7 +585,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -586,6 +596,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm install

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -192,7 +192,7 @@ jobs:
       # platform manifests not (yet) supported, so split out architectures
       - name: Build  for amd64 and push latest
         id: docker_build_amd64
-        uses: docker/build-push-action@v6.3.0
+        uses: docker/build-push-action@v6.4.1
         with:
           context: ./
           file: ./Dockerfile
@@ -206,7 +206,7 @@ jobs:
 
       - name: Build for arm64 and push latest-arm64
         id: docker_build_arm64
-        uses: docker/build-push-action@v6.3.0
+        uses: docker/build-push-action@v6.4.1
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -37,6 +37,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -59,7 +60,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -70,6 +71,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -101,7 +103,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -112,6 +114,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install packages
         run: npm clean-install
@@ -136,7 +139,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -147,6 +150,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install clean packages
         run: npm clean-install
@@ -185,7 +189,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -196,6 +200,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install clean packages
         run: npm clean-install
@@ -242,7 +247,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -253,6 +258,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install clean packages
         run: npm clean-install
@@ -290,7 +296,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Use node LTS 20.14.0
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.14.0'
 
@@ -301,6 +307,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install clean packages
         run: npm clean-install
@@ -342,7 +349,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.1.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -357,6 +364,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+            ${{ runner.os }}-
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,7 +375,7 @@ jobs:
       # platform manifests not (yet) supported, so split out architectures
       - name: Build for amd64 and push to Docker Hub
         id: docker_build_amd64
-        uses: docker/build-push-action@v6.3.0
+        uses: docker/build-push-action@v6.4.1
         with:
           context: ./
           file: ./Dockerfile
@@ -389,7 +389,7 @@ jobs:
 
       - name: Build for arm64 and push to Docker Hub
         id: docker_build_arm64
-        uses: docker/build-push-action@v6.3.0
+        uses: docker/build-push-action@v6.4.1
         with:
           context: ./
           file: ./Dockerfile

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -42,8 +42,8 @@ export const model = {
 };
 
 export function getMenuTemplate () {
-    return [
-        ...(isMacOS ? [{ role: 'appMenu' }] : []),
+    var menuTemplate = (isMacOS ? [{ role: 'appMenu' }] : []);
+    menuTemplate.push(
         {
             label: messages[language].desktop.file.heading,
             submenu: [
@@ -52,16 +52,6 @@ export function getMenuTemplate () {
                     click () {
                         openModelRequest('');
                     }
-                },
-                {
-                    label: messages[language].desktop.file.recentDocs,
-                    role: 'recentdocuments',
-                    submenu: [
-                        {
-                            label: messages[language].desktop.file.clearRecentDocs,
-                            role: 'clearrecentdocuments'
-                        }
-                    ]
                 },
                 {
                     label: messages[language].desktop.file.save,
@@ -166,7 +156,25 @@ export function getMenuTemplate () {
                 { role: 'about' }
             ]
         }
-    ];
+    );
+
+    if (isMacOS) {
+        // recent docs only for macos, see www.electronjs.org/docs/latest/api/menu-item#roles
+        menuTemplate[1].submenu.push(
+            {
+                label: messages[language].desktop.file.recentDocs,
+                role: 'recentdocuments',
+                submenu: [
+                    {
+                        label: messages[language].desktop.file.clearRecentDocs,
+                        role: 'clearrecentdocuments'
+                    }
+                ]
+            }
+        );
+    }
+
+    return menuTemplate;
 }
 
 // Open file system dialog and read file contents into model

--- a/td.vue/tests/unit/desktop/menu.spec.js
+++ b/td.vue/tests/unit/desktop/menu.spec.js
@@ -56,15 +56,6 @@ describe('desktop/menu.js', () => {
             expect(openModelItem).toBeDefined();
         });
 
-        it('contains recent items', () => {
-            const recentItems = {
-                'label': 'Open Recent',
-                'role': 'recentdocuments',
-                'submenu': [{'label': 'Clear Menu', 'role': 'clearrecentdocuments'}]
-            };
-            expect(fileItems.submenu).toContainEqual(recentItems);
-        });
-
         it('contains save model', () => {
             const saveModelItem = fileItems.submenu.find((item) => item.label === 'Save Model');
             expect(saveModelItem).toBeDefined();


### PR DESCRIPTION
**Summary**:
Electron for Linux and Windows does not implement 'recent files' or 'clear recent files', so make this specific for MacOS only

**Description for the changelog**:
desktop recent file sub-menu only for MacOS

**Other info**:
Only electron for MacOS [implements 'recent files'](www.electronjs.org/docs/latest/api/menu-item#roles)
Closes #990 