### PR TITLE
update workflows for versions and staleness

### DIFF
--- a/.github/workflows/.zap-rules-web.tsv
+++ b/.github/workflows/.zap-rules-web.tsv
@@ -7,14 +7,3 @@
 10062	OUTOFSCOPE	.*_bom\..*
 10094	OUTOFSCOPE	.*_bom\..*
 10110	OUTOFSCOPE	.*jquery\.min\.js
-10003	IGNORE	(docs/assets/js/jquery.dataTables.min.js)
-10094	IGNORE	Base64 Disclosure
-10027	IGNORE	Information Disclosure - Suspicious Comments
-10096	IGNORE	Timestamp Disclosure - Unix
-10099	IGNORE	Source Code Disclosure - SQL
-10109	IGNORE	Modern Web Application
-10049	IGNORE	Non-Storable Content
-10055	IGNORE	(CSP: style-src unsafe-inline)
-10063	IGNORE	(Feature Policy Header Not Set)
-90005	IGNORE	(Sec-Fetch-Dest Header is Missing)
-40039	IGNORE	Web Cache Deception

--- a/.github/workflows/.zap-rules-web.tsv
+++ b/.github/workflows/.zap-rules-web.tsv
@@ -7,3 +7,5 @@
 10062	OUTOFSCOPE	.*_bom\..*
 10094	OUTOFSCOPE	.*_bom\..*
 10110	OUTOFSCOPE	.*jquery\.min\.js
+10063	IGNORE	(Feature Policy Header Not Set)
+40039	IGNORE	Web Cache Deception

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -41,15 +41,15 @@ jobs:
       - name: Tidy stale PRs and issues
         uses: actions/stale@v9
         with:
-          days-before-issue-stale: 182
+          days-before-issue-stale: 190
           days-before-issue-close: -1
-          stale-issue-message: 'This issue is stale because it has been open for 6 months with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open for more than 6 months with no activity'
           stale-issue-label: stale
           remove-issue-stale-when-updated: true
           days-before-pr-stale: 21
           days-before-pr-close: 7
-          stale-pr-message: 'This PR is stale because it has been open 21 days with no activity. Remove stale label, or add a comment, otherwise it will be closed in 7 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 28 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 21 days with no activity. Remove stale label, or add a comment, otherwise it will be closed in 7 days'
+          close-pr-message: 'This PR was closed because it has been stalled for 28 days with no activity'
 
   trivy:
     name: Scan with trivy

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -363,6 +363,7 @@ jobs:
           rules_file_name: '.github/workflows/.zap-rules-web.tsv'
           allow_issue_writing: false
           fail_action: true
+          artifact_name: zap-scan-report
           cmd_options: '-a'
 
   scan_image_with_trivy:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
         with:
           install: true
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build for amd64
         id: docker_build
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -166,11 +166,11 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
         with:
           install: true
 
@@ -184,7 +184,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.2.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -192,7 +192,7 @@ jobs:
       # platform manifests not (yet) supported, so split out architectures
       - name: Build  for amd64 and push latest
         id: docker_build_amd64
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ./
           file: ./Dockerfile
@@ -206,7 +206,7 @@ jobs:
 
       - name: Build for arm64 and push latest-arm64
         id: docker_build_arm64
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -425,6 +425,7 @@ jobs:
           rules_file_name: '.github/workflows/.zap-rules-web.tsv'
           allow_issue_writing: false
           fail_action: true
+          artifact_name: zap-scan-report
           cmd_options: '-a'
 
   scan_image_with_trivy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -349,11 +349,11 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
+        uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3.4.0
+        uses: docker/setup-buildx-action@v3.5.0
         with:
           install: true
 
@@ -367,7 +367,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.2.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -375,7 +375,7 @@ jobs:
       # platform manifests not (yet) supported, so split out architectures
       - name: Build for amd64 and push to Docker Hub
         id: docker_build_amd64
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ./
           file: ./Dockerfile
@@ -389,7 +389,7 @@ jobs:
 
       - name: Build for arm64 and push to Docker Hub
         id: docker_build_arm64
-        uses: docker/build-push-action@v6.4.1
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ./
           file: ./Dockerfile

--- a/td.server/package-lock.json
+++ b/td.server/package-lock.json
@@ -15,6 +15,7 @@
         "bitbucket": "^2.11.0",
         "dotenv": "^16.0.3",
         "express": "^4.19.2",
+        "express-csp-header": "^5.2.1",
         "express-rate-limit": "^7.2.0",
         "helmet": "^6.0.1",
         "jsonwebtoken": "^9.0.0",
@@ -4082,6 +4083,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csp-header": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/csp-header/-/csp-header-5.2.1.tgz",
+      "integrity": "sha512-qOJNu39JZkPrbrAM40a1tQCePEPYVIoI6nMDhX4RA07QjU8efS+zyd/zE83XJu85KKazH9NjKlvvlswFMteMgg==",
+      "license": "WTFPL",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/culvert": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
@@ -4959,6 +4969,25 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-csp-header": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express-csp-header/-/express-csp-header-5.2.1.tgz",
+      "integrity": "sha512-HvVCUa3GwqH9m4rG0y+s6bHENNxtPzLccM1bSmZNiMIWwMc38Q2Gkz6byiDkrqmnqaCJ9+9cc/p2Pd4QqOmx9Q==",
+      "license": "WTFPL",
+      "dependencies": {
+        "csp-header": "^5.2.1",
+        "psl": "1.8.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/express-csp-header/node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "license": "MIT"
     },
     "node_modules/express-rate-limit": {
       "version": "7.2.0",

--- a/td.server/package.json
+++ b/td.server/package.json
@@ -44,6 +44,7 @@
     "bitbucket": "^2.11.0",
     "dotenv": "^16.0.3",
     "express": "^4.19.2",
+    "express-csp-header": "^5.2.1",    
     "express-rate-limit": "^7.2.0",
     "helmet": "^6.0.1",
     "jsonwebtoken": "^9.0.0",

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -28,6 +28,8 @@ const limiter = rateLimit({
 const cspDirectives = {
     directives: {
         'default-src': [SELF],
+        'frame-ancestors': [NONE],
+        'form-action': [NONE],
         'script-src': [SELF],
         'style-src': [SELF],
         'img-src': [SELF],

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -1,3 +1,5 @@
+import { expressCspHeader, NONE, SELF } from 'express-csp-header';
+
 import express from 'express';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
@@ -23,6 +25,17 @@ const limiter = rateLimit({
     legacyHeaders: false // Disable the `X-RateLimit-*` headers
 });
 
+const cspDirectives = {
+    directives: {
+        'default-src': [SELF],
+        'script-src': [SELF],
+        'style-src': [SELF],
+        'img-src': [SELF],
+        'worker-src': [NONE],
+        'block-all-mixed-content': true
+    }
+};
+
 const create = () => {
     let logger;
 
@@ -46,6 +59,7 @@ const create = () => {
 
         // Force HTTPS in production
         app.use(https.middleware);
+        app.use(expressCspHeader(cspDirectives));
 
         // static content
         app.use('/public', express.static(siteDir));


### PR DESCRIPTION
**Summary**:
Updates various versions of workflow actions
Mark issues as stale after 190 days rather than 182 days
Applies content security policy (CSP) and closes #950 
ZAP scan rules cleaned up, closes #945 

**Description for the changelog**:
update workflows for versions and staleness

**Other info**:
also tested issue and fixes #629, provided in update to documentation commit [d11919ad](https://github.com/OWASP/www-project-threat-dragon/commit/d11919adf1c96b58383dc754dfd24e3d6ffd07ff)
