### PR TITLE
Change vertices properties from integer to number so they can be imported

### DIFF
--- a/td.vue/src/service/schema/threat-model-schema.V2.js
+++ b/td.vue/src/service/schema/threat-model-schema.V2.js
@@ -393,11 +393,11 @@ export const schema = {
                                                 'properties': {
                                                     'x': {
                                                         'description': 'The horizontal value of the curve point',
-                                                        'type': 'integer'
+                                                        'type': 'number'
                                                     },
                                                     'y': {
                                                         'description': 'The vertical value of the curve point',
-                                                        'type': 'integer'
+                                                        'type': 'number'
                                                     }
                                                 },
                                                 'required': [ 'x', 'y' ]


### PR DESCRIPTION
**Summary**:
This Pull Request solved the issue: closes #1046 

**Description for the changelog**:
I have changed the type in the Schema for the `vertices` types to be able to accept decimals, tested it locally and it succesfully imports a model where the x or y vertices are decimals.
