### PR TITLE
Add ctrl+s to save graph

### DIFF
--- a/td.vue/src/components/KeyboardShortcuts.vue
+++ b/td.vue/src/components/KeyboardShortcuts.vue
@@ -49,6 +49,10 @@ export default {
                 {
                     shortcut: this.$t('threatmodel.shortcuts.zoom.shortcut'),
                     action: this.$t('threatmodel.shortcuts.zoom.action')
+                },
+                {
+                    shortcut: this.$t('threatmodel.shortcuts.save.shortcut'),
+                    action: this.$t('threatmodel.shortcuts.save.action')
                 }
             ]
         };

--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -207,6 +207,10 @@ const ara = {
             zoom: {
                 shortcut: '(ctrl/cmd) + عجلة الماوس',
                 action: 'تكبير/تصغير'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -207,6 +207,10 @@ const deu = {
             zoom: {
                 shortcut: '(Strg/cmd) + Mausrad',
                 action: 'Zoomen'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -207,6 +207,10 @@ const ell = {
             zoom: {
                 shortcut: '(ctrl/cmd) + τροχός κύλισης',
                 action: 'Εστίαση'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -207,6 +207,10 @@ const eng = {
             zoom: {
                 shortcut: '(ctrl/cmd) + mousewheel',
                 action: 'Zoom'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -207,6 +207,10 @@ const spa = {
             zoom: {
                 shortcut: '(ctrl/cmd) + rueda de desplazamiento del ratón',
                 action: 'Zoom'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -207,6 +207,10 @@ const fin = {
             zoom: {
                 shortcut: '(ctrl/cmd) + rulla',
                 action: 'Suurennos'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -207,6 +207,10 @@ const fra = {
             zoom: {
                 shortcut: '(ctrl/cmd) + molette de souris',
                 action: 'Agrandir'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -207,6 +207,10 @@ const hin = {
             zoom: {
                 shortcut: '(ctrl/cmd) + mousewheel',
                 action: 'ज़ूम'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -207,6 +207,10 @@ const id = {
             zoom: {
                 shortcut: '(ctrl/cmd) + roda mouse',
                 action: 'Perbesar/Perkecil'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -203,6 +203,10 @@ const jpn = {
             zoom: {
                 shortcut: '(コントロール/コマンド) + ホイール',
                 action: '拡大・縮小'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -207,6 +207,10 @@ const ms = {
             zoom: {
                 shortcut: '(ctrl/cmd) + roda tetikus',
                 action: 'Zum'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -207,6 +207,10 @@ const por = {
             zoom: {
                 shortcut: '(ctrl/cmd) + rolagem do mouse',
                 action: 'Zoom'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -207,6 +207,10 @@ const rus = {
             zoom: {
                 shortcut: '(ctrl/cmd) + mousewheel',
                 action: 'Zoom'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -207,6 +207,10 @@ const ukr = {
             zoom: {
                 shortcut: '(ctrl/cmd) + mousewheel',
                 action: 'Zoom'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -207,6 +207,10 @@ const zho = {
             zoom: {
                 shortcut: '(ctrl/cmd) + 鼠标滚轮',
                 action: '缩放'
+            },
+            save: {
+                shortcut: '(ctrl/cmd) + s',
+                action: 'Save'
             }
         },
         stencil: {

--- a/td.vue/src/service/x6/graph/keys.js
+++ b/td.vue/src/service/x6/graph/keys.js
@@ -2,6 +2,12 @@
  * @name keys
  * @description Adds key bindings to the graph
  */
+
+import store from '@/store/index.js';
+
+import { THREATMODEL_SAVE } from '@/store/actions/threatmodel.js';
+
+
 const del = (graph) => () => graph.removeCells(graph.getSelectedCells());
 
 const undo = (graph) => () => {
@@ -35,12 +41,18 @@ const paste = (graph) => () => {
     graph.select(cells);
 };
 
+const save = () => (evt) => {
+    evt?.preventDefault();
+    store.get().dispatch(THREATMODEL_SAVE);
+};
+
 const bind = (graph) => {
     graph.bindKey('del', del(graph));
     graph.bindKey('ctrl+z', undo(graph));
     graph.bindKey('ctrl+y', redo(graph));
     graph.bindKey('ctrl+c', copy(graph));
     graph.bindKey('ctrl+v', paste(graph));
+    graph.bindKey('ctrl+s', save());
 };
 
 export default {

--- a/td.vue/tests/unit/service/x6/graph/keys.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/keys.spec.js
@@ -1,9 +1,12 @@
 import keys from '@/service/x6/graph/keys.js';
+import store from '@/store/index.js';
 
 describe('service/x6/graph/keys.js', () => {
-    let graph;
+    let graph, mockStore;
 
     beforeEach(() => {
+        mockStore = { dispatch: jest.fn() };
+        store.get = jest.fn().mockReturnValue(mockStore);
         graph = {
             removeCells: jest.fn(),
             getSelectedCells: jest.fn(),
@@ -156,7 +159,7 @@ describe('service/x6/graph/keys.js', () => {
             });
 
             it('binds the ctrl+v keys', () => {
-                expect(graph.bindKey).toHaveBeenLastCalledWith('ctrl+v', expect.any(Function));
+                expect(graph.bindKey).toHaveBeenCalledWith('ctrl+v', expect.any(Function));
             });
 
             it('does not paste the cells', () => {
@@ -193,6 +196,16 @@ describe('service/x6/graph/keys.js', () => {
             it('selects the cells', () => {
                 expect(graph.select).toHaveBeenCalledWith(cells);
             });
+        });
+    });
+
+    describe('save', () => {
+        beforeEach(() => {
+            keys.bind(graph);
+        });
+
+        it('binds to the delete key', () => {
+            expect(graph.bindKey).toHaveBeenLastCalledWith('ctrl+s', expect.any(Function));
         });
     });
 });


### PR DESCRIPTION
**Summary**:
Adds the ctrl+s keyboard shortcut to save the diagram. Closes #1066 

**Description for the changelog**:
Added ctrl+s shortcut for saving
