### PR TITLE
set autoResize true for graph diagram

### DIFF
--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -21,7 +21,7 @@
     "start:serve": "pm2 --name td.vue start 'vue-cli-service serve'",
     "stop:serve": "pm2 delete td.vue",
     "test": "vue-cli-service test:unit",
-    "test:desktop": "vue-cli-service test:unit --testMatch '**/unit/desktop/**/*.spec.js' --collectCoverageFrom 'src/desktop/**/*.js'",
+    "test:desktop": "vue-cli-service test:unit --testMatch '**/tests/unit/desktop/**/*.spec.js' --collectCoverageFrom 'src/desktop/**/*.js'",
     "test:e2e": "vue-cli-service test:e2e -C e2e.local.config.js",
     "test:e2e:desktop": "wdio run ./wdio.config.js",
     "test:e2e:local": "vue-cli-service test:e2e -C e2e.local.config.js --url http://localhost:8080/",

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -42,7 +42,7 @@ const drawGraph = (diagram, graph) => {
         console.debug('upgrade version 1.x diagram');
         upgradeAndDraw(diagram, graph);
     }
-	console.debug('graph canvas width ', graph.width, ' height ', graph.height);
+    console.debug('graph canvas width ', graph.width, ' height ', graph.height);
     return graph;
 };
 

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -42,6 +42,7 @@ const drawGraph = (diagram, graph) => {
         console.debug('upgrade version 1.x diagram');
         upgradeAndDraw(diagram, graph);
     }
+	console.debug('graph canvas width ', graph.width, ' height ', graph.height);
     return graph;
 };
 

--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -12,7 +12,7 @@ const getReadOnlyConfig = (container) => ({
     history: {
         enabled: false
     },
-    autoResize: container
+    autoResize: true
 });
 
 const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container), {
@@ -70,7 +70,8 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
         restricted: false,
         autoScroll: true,
         preserveAspectRatio: false,
-        allowReverse: true
+        allowReverse: true,
+        autoResize: true
     },
     mousewheel: {
         enabled: true,
@@ -91,9 +92,7 @@ const getEditConfig = (container) => Object.assign(getReadOnlyConfig(container),
         pannable: false, // disable because it interferes with rubberbanding, see panning above
         pageVisible: true,
         pageBreak: false
-    },
-    // container: container,  // still not able to auto-size, see https://x6.antv.vision/en/docs/api/graph/graph#autoresize
-    //autoResize: true        // note that this is inherited from getReadOnlyConfig
+    }
 });
 
 const getEditGraph = (container) => {

--- a/td.vue/tests/unit/service/x6/graph/graph.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/graph.spec.js
@@ -36,7 +36,7 @@ describe('service/x6/graph/graph.js', () => {
 
         it('auto resizes', () => {
             expect(factory.graph).toHaveBeenCalledWith(
-                expect.objectContaining({ autoResize: container })
+                expect.objectContaining({ autoResize: true })
             );
         });
 
@@ -69,7 +69,7 @@ describe('service/x6/graph/graph.js', () => {
 
         it('auto resizes', () => {
             expect(factory.graph).toHaveBeenCalledWith(
-                expect.objectContaining({ autoResize: container })
+                expect.objectContaining({ autoResize: true })
             );
         });
 
@@ -150,7 +150,8 @@ describe('service/x6/graph/graph.js', () => {
                 restricted: false,
                 autoScroll: true,
                 preserveAspectRatio: false,
-                allowReverse: true
+                allowReverse: true,
+                autoResize: true
             });
         });
 


### PR DESCRIPTION
**Summary**:
helps to debug the bug where canvas does not resize properly when opening and saving a diagram

**Description for the changelog**:
set autoResize true for graph diagram

**Other info**:
related to #1041 but does not close it
