### PR TITLE
use File System Access API if supported on the browser

### DIFF
--- a/td.vue/src/service/save.js
+++ b/td.vue/src/service/save.js
@@ -8,15 +8,62 @@ const local = (data, fileName) => {
 };
 
 function saveTD (data, fileName) {
-    // saving using local browser  
+    if ('showSaveFilePicker' in self) {
+        console.debug('File picker is supported on this browser');
+        writeFile(data, fileName);
+    } else {
+        console.debug('Save using browser local filesystem download');
+        downloadFile(data, fileName);
+    }
+}
+
+function downloadFile(data, fileName) {
     const contentType = 'application/json';
     const jsonData = JSON.stringify(data, null, 2);
     const blob = new Blob([jsonData], { type: contentType });
     const a = document.createElement('a');
+
     a.href = window.URL.createObjectURL(blob);
     a.download = fileName;
     a.click();
     a.remove();
+}
+
+async function writeFile(data, fileName) {
+    const jsonData = JSON.stringify(data, null, 2);
+    const options = {
+        suggestedName: fileName,
+        types: [
+            {
+                description: 'Threat Model',
+                accept: {
+                    'application/json': ['.json'],
+                },
+            },
+        ],
+    };
+    const fileHandle = await window.showSaveFilePicker(options);
+
+    await verifyPermission(fileHandle);
+    const writable = await fileHandle.createWritable();
+    await writable.write({ type: 'write', position: 0, data: jsonData });
+    await writable.close();
+}
+
+async function verifyPermission(fileHandle) {
+    const options = { mode: 'readwrite' };
+
+    // Check if permission was already granted. If so, return true.
+    if ((await fileHandle.queryPermission(options)) === 'granted') {
+        return true;
+    }
+
+    // Request permission. If the user grants permission, return true.
+    if ((await fileHandle.requestPermission(options)) === 'granted') {
+        return true;
+    }
+
+    return false;
 }
 
 export default {


### PR DESCRIPTION
**Summary**:
Use File System Access API supported by Chrome/Chromium, Edge and most browsers except Safari

**Description for the changelog**:
use File System Access API if supported on the browser

**Other info**:
closes #643 
tested with Chrome and Safari to get both use cases
