### PR TITLE
Adding GitHub action for winget-releaser

### DIFF
--- a/.github/workflows/publish-release-to-winget-pkgs.yml
+++ b/.github/workflows/publish-release-to-winget-pkgs.yml
@@ -1,0 +1,21 @@
+name: Publish releases to winget-pkgs
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Get version
+        id: get-version
+        run: |
+          # Finding the version from release name
+          $VERSION="${{ github.event.release.name }}" -replace '^v '
+          "version=$VERSION" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: OWASP.ThreatDragon
+          version: ${{ steps.get-version.outputs.version }}
+          installers-regex: '[sS]etup-.+?\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->

This would conclude #848 (which also requires microsoft/winget-pkgs#184453 to be merged).

**Description for the changelog**:

<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->

* It is now possible to install OWASP Threat Dragon with WinGet, using `winget install -e --id OWASP.ThreatDragon` or subsequently keep it up-to-date with `winget upgrade -e --id OWASP.ThreatDragon`

**Other info**:

Below follows the commit message in full:

------

- This is meant to automate releases to `winget-pkgs`
- Resolves #848 and should work as soon as microsoft/winget-pkgs#184453 has been merged (baseline manifest for the 2.2.0 version)
- DO NOT MERGE BEFORE PREREQUISITES ARE IN PLACE (see below)

## Instructions for prerequisites
The `WINGET_TOKEN` needs to be created and registered in the repo _which does the release_. For good measure we need to clone `winget-pkgs` on the same user (or org) or set via `fork-user` it as per the README for [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser).

Configure the [Pull app](https://github.com/apps/pull) to keep the `winget-pkgs` fork in sync with its upstream.

That `winget-pkgs` fork is going to be the _source_ of the PR filed at `microsoft/winget-pkgs` and the PRs are being opened on behalf of the owner of the used token.

1. Head to https://github.com/settings/tokens and create a new (classic) personal access token with _only_ the `public_repo` scope activated for it
2. In https://github.com/OWASP/threat-dragon/settings/secrets/actions create a secret named WINGET_TOKEN (as per vedantmgoyal9/winget-releaser)
3. Merge this PR
4. Create a (subsequent) release
