### PR TITLE
fix for type/context errors

### DIFF
--- a/td.vue/src/components/GraphMeta.vue
+++ b/td.vue/src/components/GraphMeta.vue
@@ -51,13 +51,21 @@
                     </b-card-text>
                 </b-card-body>
             </b-card>
-            <a href="javascript:void(0)" v-if="!!cellRef" @click="AddThreatByType()" class="new-threat-by-type m-2">
-                <font-awesome-icon icon="plus"></font-awesome-icon>
-                {{ $t('threats.newThreatByType') }}
+            <a href="javascript:void(0)"
+                v-if="!disableNewThreat"
+                @click="AddThreatByType()"
+                class="new-threat-by-type m-2"
+            >
+                    <font-awesome-icon icon="plus"></font-awesome-icon>
+                    {{ $t('threats.newThreatByType') }}
             </a>
-            <a href="javascript:void(0)" v-if="!!cellRef" @click="AddThreatByContext()" class="new-threat-by-type m-2">
-                <font-awesome-icon icon="plus"></font-awesome-icon>
-                {{ $t('threats.newThreatByContext') }}
+            <a href="javascript:void(0)"
+                v-if="!disableNewThreat"
+                @click="AddThreatByContext()"
+                class="new-threat-by-type m-2"
+            >
+                    <font-awesome-icon icon="plus"></font-awesome-icon>
+                    {{ $t('threats.newThreatByContext') }}
             </a>
         </b-col>
     </b-row>

--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -3,7 +3,8 @@
         <b-card-text>
             <b-row>
                 <b-col>
-                    <a href="javascript:void(0)" @click="threatSelected()">#{{ number }} {{ title || 'Unknown Threat' }}</a>
+                    <a href="javascript:void(0)" @click="threatSelected()" v-if="!!number">#{{ number }} {{ title || 'Unknown Threat' }}</a>
+                    <a href="javascript:void(0)" @click="threatSelected()" v-else>{{ title || 'Unknown Threat' }}</a>
                 </b-col>
             </b-row>
             <b-row>

--- a/td.vue/src/components/ThreatSuggestDialog.vue
+++ b/td.vue/src/components/ThreatSuggestDialog.vue
@@ -155,13 +155,13 @@
 
 
 <script>
-import {mapState} from 'vuex';
+import { mapState } from 'vuex';
 import { createNewTypedThreat } from '@/service/threats/index.js';
 import { CELL_DATA_UPDATED} from '@/store/actions/cell.js';
 import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
-import {GetContextSuggestions} from '@/service/threats/oats/context-generator.js';
+import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
 export default {
     name: 'TdThreatSuggest',
     computed: {
@@ -194,7 +194,7 @@ export default {
                 { value: 'High', text: this.$t('threats.priority.high') }
             ];
         },
-        modalTitle() { return this.$t('threats.newThreatByType') + ' #' + (this.threatTop+1); }
+        modalTitle() { return this.$t('threats.newThreat') + ' #' + (this.threatTop + 1); }
     },
     data() {
         return {
@@ -207,19 +207,19 @@ export default {
     methods: {
         showModal(type) {
             this.index = 0;
-            const tmpThreat = createNewTypedThreat(this.modelType,this.cellRef.data.type,this.threatTop+1);
+            const tmpThreat = createNewTypedThreat(this.modelType, this.cellRef.data.type, this.threatTop + 1);
             this.types = [...this.threatTypes];
-            if(type=='type'){
-                this.threatTypes.map((t,ind)=>{
+            if (type == 'type') {
+                this.threatTypes.map((t, ind)=>{
                     console.log(t);
                     this.suggestions.push({...tmpThreat});
                     this.suggestions[ind].type=t;
                 });
             } else {
-                this.suggestions = GetContextSuggestions(this.cellRef.data,this.modelType).map((suggestion)=>{
+                this.suggestions = GetContextSuggestions(this.cellRef.data, this.modelType).map((suggestion) => {
                     tmpThreat.title = suggestion.title;
                     tmpThreat.type = this.$t(suggestion.type);
-                    if(!this.types.includes(tmpThreat.type)&&tmpThreat.type!=='')
+                    if(!this.types.includes(tmpThreat.type)&&tmpThreat.type !== '')
                         this.types.push(tmpThreat.type);
                     tmpThreat.description = suggestion.description;
                     tmpThreat.mitigation = suggestion.mitigation;

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -42,7 +42,6 @@ const drawGraph = (diagram, graph) => {
         console.debug('upgrade version 1.x diagram');
         upgradeAndDraw(diagram, graph);
     }
-    console.debug('graph canvas width ', graph.width, ' height ', graph.height);
     return graph;
 };
 


### PR DESCRIPTION
**Summary**:
Only enables contextual/type threat suggestions when new threat button is enabled, otherwise disabled

**Description for the changelog**:
fix for type/context errors on edges and nodes that are out of scope

**Other info**:
closes #1110 
