### PR TITLE
Update release pipeline for notarytool

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -211,10 +211,12 @@ jobs:
           # MacOS signing certificate and password, see electron.build/code-signing
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
           CSC_LINK:  ${{ secrets.MAC_CERTS }}
-          # MacOS notarization, see electron.build/configuration/mac.html
-          # see also github.com/samuelmeuli/action-electron-builder#notarization
-          API_KEY_ID: ${{ secrets.API_KEY_ID }}
-          API_KEY_ISSUER_ID: ${{ secrets.API_KEY_ISSUER_ID }}
+          # MacOS notarization:
+          # API_KEY_ID: ${{ secrets.API_KEY_ID }}
+          # API_KEY_ISSUER_ID: ${{ secrets.API_KEY_ISSUER_ID }}
+          APPLE_ID: ${{ secrets.APPPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPPLE_TEAM_ID }}
         run: npm run build:desktop -- --mac --publish always
 
       - name: Print logs on error

--- a/.release-note-template.md
+++ b/.release-note-template.md
@@ -11,33 +11,37 @@ Pull from docker hub using `docker pull --platform linux/x86_64 owasp/threat-dra
 |Platform | File | SHA512 |
 |-- | -- | -- |
 |Windows NSIS installer | [Threat-Dragon-ng-Setup-2.x.x.exe][exe] | [checksum.yml][execs] |
-|MacOS installer | [Threat-Dragon-ng-2.x.x.dmg][dmg] | [checksum-mac.yml][dmgcs] |
+|MacOS installer x86 | [Threat-Dragon-ng-2.x.x.dmg][dmg] | [checksum-mac.yml][dmgcsx86] |
+|MacOS installer arm64 | [Threat-Dragon-ng-2.x.x.dmg][dmg] | [checksum-mac-arm64.yml][dmgcsarm64] |
 |Linux AppImage | [Threat-Dragon-ng-2.x.x.AppImage][app] | [checksum-linux.yml][appcs] |
 |Debian package, AMD64 | [threat-dragon_2.x.x_amd64.deb][deb] |  |
 |Redhat package manager, X86 64 bit | [threat-dragon-2.x.x.x86_64.rpm][rpm] |  |
 
 #### Installing on Windows
 
-Depending on the security applied in your Windows system, you may need to open the file properties
-and check the 'Unblock' checkbox to allow Threat Dragon to run  
+Download and run the NSIS executable. Depending on the security applied in your Windows system,
+you may need to open the file properties and check the 'Unblock' checkbox to allow Threat Dragon to run
 
 #### Installing on MacOS
 
-Use the disk image `.dmg` file to install on MacOS systems,
-the Threat Dragon application `.zip` is used for automatic updates only
+To install on MacOS systems download the disk image `.dmg` file , either the x86 or arm64 version, and invoke the file.
+Note that the MacOS `.zip` files are used for automatic updates only, not for installation.
 
-#### Selecting the Linux package to use
+#### Installing on Linux
 
-`AppImage` can be used for most Linux distributions and hardware platforms  
-The Snap image is available from the [official snapcraft distribution][snap]  
-`.rpm` for Red Hat Linux, AIX, CentOS, Fedora  
-`.deb` for debian based Linux such as Ubuntu, Trisqel and Debian itself  
+Select the method that is most convenient for your distribution of Linux:
+
+- `AppImage` can be used for most Linux distributions and hardware platforms
+- a Snap image is available from the [official snapcraft distribution][snap]
+- `.rpm` for Red Hat Linux, AIX, CentOS, Fedora
+- `.deb` for debian based Linux such as Ubuntu, Trisqel and Debian itself
 
 [app]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/Threat-Dragon-ng-2.x.x.AppImage
 [appcs]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-linux.yml
 [deb]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/threat-dragon_2.x.x_amd64.deb
 [dmg]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/Threat-Dragon-ng-2.x.x.dmg
-[dmgcs]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-mac.yml
+[dmgcsx86]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-mac.yml
+[dmgcsarm64]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-mac-arm64.yml
 [exe]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/Threat-Dragon-ng-Setup-2.x.x.exe
 [execs]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum.yml
 [rpm]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/threat-dragon-2.x.x.x86_64.rpm

--- a/release-process.md
+++ b/release-process.md
@@ -1,6 +1,6 @@
 The steps used during the release process, including release candidates
 
-## Release candidate
+## Create release candidate
 
 Before a release it is required that a release candidate version is created.
 This allows the Threat Dragon community to review and feedback on the proposed release.
@@ -80,6 +80,20 @@ ensure the tag now exists within the OWASP Docker hub: `https://hub.docker.com/r
 3. Inspect logs using `heroku logs --app=threatdragon-v2 --tail`
 4. Ensure no rollback shown in [dashboard][herokudash]
 
+### Notarize and staple the MacOS images
+
+It used to be that [altool][altool] could be used to notarize the MacOS `.dmg` files in the pipeline.
+As of early 2024 this is no longer available and [notarytool][notarize] must be used in a secure environment.
+Used in the pipeline, this is how to do it manually.
+
+- Download both x86 and arm64 images for the MacOS installer (`*.dmg`)
+- ensure that the apple developer [environment is set up][notarize]
+- notarize and staple, for example with version 2.3.0:
+  - `xcrun notarytool submit --apple-id <apple-account-email> --team-id <teamid> \`
+    `--password <password> --verbose --wait Threat-Dragon-ng-2.3.0-arm64.dmg`
+  - `xcrun stapler staple --verbose Threat-Dragon-ng-2.3.0-arm64.dmg`
+- similarly for the x86 image `Threat-Dragon-ng-2.3.0.dmg`
+
 ### Check desktop downloads
 
 - Download desktop AppImage for Linux and installers for MacOS `.dmg` and Windows `.exe`
@@ -89,10 +103,12 @@ ensure the tag now exists within the OWASP Docker hub: `https://hub.docker.com/r
  ```text
 grep sha512 latest-linux.yml | head -n 2 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
     hexdump -ve '1/1 "%.2x"' >> checksum-linux.yml
-grep sha512 latest-mac.yml | head -n 2 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
-    hexdump -ve '1/1 "%.2x"' >> checksum-mac.yml
 grep sha512 latest.yml | head -n 2 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
     hexdump -ve '1/1 "%.2x"' >> checksum.yml
+grep sha512 latest-mac.yml | head -n 3 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
+    hexdump -ve '1/1 "%.2x"' >> checksum-mac.yml
+grep sha512 latest-mac.yml | head -n 4 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
+    hexdump -ve '1/1 "%.2x"' >> checksum-mac-arm64.yml
 ```
 
 - Confirm SHA512 with:
@@ -100,6 +116,7 @@ grep sha512 latest.yml | head -n 2 | tail -n 1 | cut -d ":" -f 2 | base64 -d |  
 ```text
 echo "$(cat checksum-linux.yml) Threat-Dragon-ng-2.3.0.AppImage" | sha512sum --check
 echo "$(cat checksum-mac.yml) Threat-Dragon-ng-2.3.0.dmg" | sha512sum --check
+echo "$(cat checksum-mac-arm64.yml) Threat-Dragon-ng-2.3.0-arm64.dmg" | sha512sum --check
 echo "$(cat checksum.yml) Threat-Dragon-ng-Setup-2.3.0.exe" | sha512sum --check
 ```
 
@@ -124,10 +141,12 @@ Update the [releases tab][releases] and the [info pane][td-info] on the OWASP Th
 Finally ensure Threat Dragon announces the new release on the [OWASP Threat Dragon][td-slack] slack channel
 and any other relevant channels
 
+[altool]: https://successfulsoftware.net/2023/04/28/moving-from-altool-to-notarytool-for-mac-notarization/
 [area]: https://github.com/OWASP/threat-dragon/releases
 [heroku]: https://id.heroku.com/login
 [herokucli]: https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli
 [herokudash]: https://dashboard.heroku.com/apps
+[notarize]: https://developer.apple.com/documentation/security/resolving-common-notarization-issues
 [releases]: https://github.com/OWASP/www-project-threat-dragon/blob/main/tab_releases.md
 [td-info]: https://github.com/OWASP/www-project-threat-dragon/blob/main/info.md
 [td-slack]: https://owasp.slack.com/messages/CURE8PQ68


### PR DESCRIPTION
**Summary**:
Update the release pipeline to use notary tool via :
- APPLE_ID
- APPLE_APP_SPECIFIC_PASSWORD
- APPLE_TEAM_ID

**Description for the changelog**:
use notarytool for MacOS images

**Other info**:
Closes #978 
