### PR TITLE
disable trivy until it can be reliably downloaded

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -52,11 +52,13 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 28 days with no activity'
 
   trivy:
-    name: Scan with trivy
+    name: Scan with trivy (disabled)
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       security-events: write
+    if: ${{ ! always() }}
+    # disable trivy until it can be reliably downloaded in the pipeline
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -327,11 +327,13 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   scan_image_with_trivy:
-    name: Scan with trivy
+    name: Scan with trivy (disabled)
     runs-on: ubuntu-24.04
     needs: build_docker_image
     permissions:
       contents: write
+    if: ${{ ! always() }}
+    # disable trivy until it can be reliably downloaded in the pipeline
 
     steps:
       - name: Checkout

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -432,12 +432,14 @@ jobs:
           cmd_options: '-a'
 
   scan_image_with_trivy:
-    name: Scan image with trivy
+    name: Scan image with trivy (disabled)
     runs-on: ubuntu-24.04
     needs: build_docker_image
     permissions:
       contents: write
       security-events: write
+    if: ${{ ! always() }}
+    # disable trivy until it can be reliably downloaded in the pipeline
 
     steps:
       - name: Checkout

--- a/release-process.md
+++ b/release-process.md
@@ -80,20 +80,6 @@ ensure the tag now exists within the OWASP Docker hub: `https://hub.docker.com/r
 3. Inspect logs using `heroku logs --app=threatdragon-v2 --tail`
 4. Ensure no rollback shown in [dashboard][herokudash]
 
-### Notarize and staple the MacOS images
-
-It used to be that [altool][altool] could be used to notarize the MacOS `.dmg` files in the pipeline.
-As of early 2024 this is no longer available and [notarytool][notarize] must be used in a secure environment.
-Used in the pipeline, this is how to do it manually.
-
-- Download both x86 and arm64 images for the MacOS installer (`*.dmg`)
-- ensure that the apple developer [environment is set up][notarize]
-- notarize and staple, for example with version 2.3.0:
-  - `xcrun notarytool submit --apple-id <apple-account-email> --team-id <teamid> \`
-    `--password <password> --verbose --wait Threat-Dragon-ng-2.3.0-arm64.dmg`
-  - `xcrun stapler staple --verbose Threat-Dragon-ng-2.3.0-arm64.dmg`
-- similarly for the x86 image `Threat-Dragon-ng-2.3.0.dmg`
-
 ### Check desktop downloads
 
 - Download desktop AppImage for Linux and installers for MacOS `.dmg` and Windows `.exe`
@@ -141,12 +127,39 @@ Update the [releases tab][releases] and the [info pane][td-info] on the OWASP Th
 Finally ensure Threat Dragon announces the new release on the [OWASP Threat Dragon][td-slack] slack channel
 and any other relevant channels
 
+### Manually notarize / staple for MacOS images
+
+It used to be that [altool][altool] could be used to notarize the MacOS `.dmg` files in the pipeline.
+As of early 2024 this is no longer available and [notarytool][notarize] must be used in a secure environment.
+Used in [the pipeline][notarytool], it can also be done/checked manually:
+
+- Download both x86 and arm64 images for the MacOS installer (`*.dmg`)
+- ensure that the apple developer [environment is set up][notarize]
+- notarize and staple, for example with version 2.3.0:
+  - `xcrun notarytool submit --apple-id <apple-account-email> --team-id <teamid> \`
+    `--password <password> --verbose --wait Threat-Dragon-ng-2.3.0-arm64.dmg`
+  - `xcrun stapler staple --verbose Threat-Dragon-ng-2.3.0-arm64.dmg`
+- similarly for the x86 image `Threat-Dragon-ng-2.3.0.dmg`
+
+### Manually check Snap images
+
+https://snapcraft.io/install/threat-dragon/arch
+https://login.ubuntu.com/
+
+Full name: Threat Dragon
+username: threat-dragon
+`snapcraft login` using email: jon.gadsden@owasp.org and Ubuntu One password?
+
+Token used in the Threat Dragon pipeline as 'SNAPCRAFT_TOKEN', use command to refresh creds:
+`snapcraft export-login --snaps threat-dragon --channels stable`
+
 [altool]: https://successfulsoftware.net/2023/04/28/moving-from-altool-to-notarytool-for-mac-notarization/
 [area]: https://github.com/OWASP/threat-dragon/releases
 [heroku]: https://id.heroku.com/login
 [herokucli]: https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli
 [herokudash]: https://dashboard.heroku.com/apps
 [notarize]: https://developer.apple.com/documentation/security/resolving-common-notarization-issues
+[notarytool]: https://www.electron.build/app-builder-lib.interface.macconfiguration#notarize
 [releases]: https://github.com/OWASP/www-project-threat-dragon/blob/main/tab_releases.md
 [td-info]: https://github.com/OWASP/www-project-threat-dragon/blob/main/info.md
 [td-slack]: https://owasp.slack.com/messages/CURE8PQ68


### PR DESCRIPTION
**Summary**:
Trivy download is not stable enough, and the pipeline action randomly fails

**Description for the changelog**:
disable trivy until it can be reliably downloaded

**Other info**:
