### PR TITLE
Update actions/download-artifact to consistently use 4.1.8

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -645,7 +645,7 @@ jobs:
       - build_docker_image
     steps:
       - name: Fetch prepared SBOM artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           pattern: 'sboms-*'
           merge-multiple: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -435,7 +435,7 @@ jobs:
 
     steps:
       - name: Fetch prepared SBOM artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           pattern: 'sboms-*'
           merge-multiple: false


### PR DESCRIPTION
**Summary**:

Update `actions/download-artifact` in workflows to consistently use 4.1.8.
Fixes #1136

**Description for the changelog**:

Update actions/download-artifact in workflows to consistently use 4.1.8.

**Other info**:

4.1.8 is the current latest (at the time of submission): https://github.com/actions/download-artifact/releases
