### PR TITLE
Fix: Add custom About dialog for non-macOS platforms (#421)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "2.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "electron-about-window": "^1.15.2"
+      },
       "devDependencies": {
         "@wdio/cli": "^8.38.2",
         "npm-run-all": "^4.1.5",
@@ -2066,6 +2069,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/electron-about-window": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/electron-about-window/-/electron-about-window-1.15.2.tgz",
+      "integrity": "sha512-iKQOdMOxybXRAycwr8rGYfCky1lcADlFGdQRnOW+ZUq24agIOgzQqRsaVv+2Tiah24wS13yKuHMuyORcKybEEg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "micromatch": ">=4.0.8",
     "minimatch@<3.0.5": ">=3.0.5",
     "ws": ">=8.18.0"
+  },
+  "dependencies": {
+    "electron-about-window": "^1.15.2"
   }
 }

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -1,9 +1,40 @@
 'use strict';
 
-import { app, dialog, BrowserWindow } from 'electron';
+import { app, dialog, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
 import logger from './logger.js';
 import { isMacOS } from './utils.js';
+
+
+
+
+function openAboutWindow({ app, BrowserWindow, ipcMain }) {
+    const aboutWindow = new BrowserWindow({
+        width: 400,
+        height: 300,
+        resizable: false,
+        title: 'About',
+        modal: true,
+        parent: BrowserWindow.getFocusedWindow(), // Open as a modal window
+        show: false,
+    });
+
+    aboutWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(`
+        <h1>About</h1>
+        <p>${app.getName()}</p>
+        <p>App version: ${app.getVersion()}</p>
+        
+    `));
+
+    aboutWindow.once('ready-to-show', () => {
+        aboutWindow.show();
+    });
+
+    ipcMain.on('close-about', () => {
+        aboutWindow.close();
+    });
+}
+
 
 const { shell } = require('electron');
 const fs = require('fs');
@@ -153,89 +184,22 @@ export function getMenuTemplate() {
                     }
                 },
                 { type: 'separator' },
-                {
-                    label: 'About', // "About Electron" label
-                    click: () => {
-                        if (process.platform !== 'darwin') { // Check for non-macOS systems
-                            const aboutWin = new BrowserWindow({
-                                width: 800,
-                                height: 700,
-                                modal: true,
-                                parent: mainWindow, // Use mainWindow as the parent if applicable
-                                resizable: false,
-                                webPreferences: {
-                                    nodeIntegration: true, // Optional, if you need node integration
-                                }
+                process.platform === 'darwin'
+                    ? { role: 'about' } // Use native "About" role for macOS
+                    : {
+                        label: 'About', // For non mac os
+                        click: () => {
+                            openAboutWindow({
+                                app,
+                                BrowserWindow,
+                                ipcMain,
                             });
-
-                            // Set the content directly within the BrowserWindow
-                            const aboutContent = `
-                                <html>
-                                    <head>
-                                        <title>About Threat Dragon</title>
-                                        <style>
-                                            body {
-                                                font-family: Arial, sans-serif;
-                                                padding: 20px;
-                                                background-color: #f4f4f9;
-                                                color: #333;
-                                            }
-                                            h1 {
-                                                color: #2d3a4f;
-                                            }
-                                            p {
-                                                color: #666;
-                                                line-height: 1.6;
-                                            }
-                                            a {
-                                                color: #007bff;
-                                                text-decoration: none;
-                                            }
-                                            a:hover {
-                                                text-decoration: underline;
-                                            }
-                                        </style>
-                                    </head>
-                                    <body>
-                                        <h1>About Threat Dragon</h1>
-                                        <p>Threat Dragon is an open-source threat modeling tool developed by OWASP (Open Web Application Security Project). It allows you to design and analyze your application’s security by identifying potential threats and vulnerabilities.</p>
-                                        <p>It is available as a desktop application that works across multiple platforms, helping you create threat models that can be shared and collaborated upon. This tool is designed for developers and security professionals to visualize their system architecture and the threats that could potentially affect it.</p>
-                                        <h2>Features</h2>
-                                        <ul>
-                                            <li>Drag-and-drop interface for building threat models.</li>
-                                            <li>Automatic threat analysis and risk scoring.</li>
-                                            <li>Integration with other security tools and frameworks.</li>
-                                            <li>Export models to various formats (PDF, HTML, JSON).</li>
-                                            <li>Collaborative features for team-based threat modeling.</li>
-                                        </ul>
-                                        <h2>Learn More</h2>
-                                        <p>For more information, visit the official <a href="https://owasp.org/www-project-threat-dragon/">OWASP Threat Dragon Project Page</a>.</p>
-                                        <p>Visit our <a href="https://github.com/owasp/threat-dragon/">GitHub repository</a> for source code, bug reports, and contributing guidelines.</p>
-                                        <p>If you encounter any issues or have suggestions, feel free to <a href="https://github.com/owasp/threat-dragon/issues">submit an issue</a> or create a <a href="https://github.com/owasp/threat-dragon/pulls">pull request</a>.</p>
-                                    </body>
-                                </html>
-                            `;
-
-                            // Load the content directly into the window
-                            aboutWin.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(aboutContent));
-
-                            // Optional: Open DevTools to debug
-                            aboutWin.webContents.openDevTools();
-
-                            // Optional: Log load success
-                            aboutWin.webContents.on('did-finish-load', () => {
-                                console.log('About page content loaded');
-                            });
-                        }
-                    },
-                    ...(process.platform === 'darwin' && { role: 'about' }) // Only add 'role: about' for macOS
-                }
-                ,
-
-                // { role: 'about' }
+                        },
+                    }
             ]
         }
     );
+
 
     if (isMacOS) {
         // recent docs only for macos, see www.electronjs.org/docs/latest/api/menu-item#roles

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { app, dialog } from 'electron';
+import { app, dialog, BrowserWindow } from 'electron';
 import path from 'path';
 import logger from './logger.js';
 import { isMacOS } from './utils.js';
@@ -154,18 +154,18 @@ export function getMenuTemplate() {
                 },
                 { type: 'separator' },
                 {
-                    label: 'about Electron',  // New "About Electron" label
+                    label: 'about Electron', // New "About Electron" label
                     click: () => {
                         const aboutWin = new BrowserWindow({
                             width: 300,
                             height: 200,
                             modal: true,
-                            parent: win,
-                            resizable: false
+                            parent: mainWindow, // Use mainWindow as the parent if applicable
+                            resizable: false,
                         });
-                        aboutWin.loadFile('about.html');  // Load the 'about.html' file in the modal
+                        aboutWin.loadFile('about.html'); // Load the 'about.html' file in the modal
                     },
-                    ...(process.platform === 'darwin' && { role: 'about' }) // Only add 'role: about' for macOS
+                    ...(process.platform === 'darwin' && { role: 'about' }), // Only add 'role: about' for macOS
                 },
 
                 { role: 'about' }

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -154,21 +154,85 @@ export function getMenuTemplate() {
                 },
                 { type: 'separator' },
                 {
-                    label: 'about Electron', // New "About Electron" label
+                    label: 'About', // "About Electron" label
                     click: () => {
-                        const aboutWin = new BrowserWindow({
-                            width: 300,
-                            height: 200,
-                            modal: true,
-                            parent: mainWindow, // Use mainWindow as the parent if applicable
-                            resizable: false,
-                        });
-                        aboutWin.loadFile('about.html'); // Load the 'about.html' file in the modal
-                    },
-                    ...(process.platform === 'darwin' && { role: 'about' }), // Only add 'role: about' for macOS
-                },
+                        if (process.platform !== 'darwin') { // Check for non-macOS systems
+                            const aboutWin = new BrowserWindow({
+                                width: 800,
+                                height: 700,
+                                modal: true,
+                                parent: mainWindow, // Use mainWindow as the parent if applicable
+                                resizable: false,
+                                webPreferences: {
+                                    nodeIntegration: true, // Optional, if you need node integration
+                                }
+                            });
 
-                { role: 'about' }
+                            // Set the content directly within the BrowserWindow
+                            const aboutContent = `
+                                <html>
+                                    <head>
+                                        <title>About Threat Dragon</title>
+                                        <style>
+                                            body {
+                                                font-family: Arial, sans-serif;
+                                                padding: 20px;
+                                                background-color: #f4f4f9;
+                                                color: #333;
+                                            }
+                                            h1 {
+                                                color: #2d3a4f;
+                                            }
+                                            p {
+                                                color: #666;
+                                                line-height: 1.6;
+                                            }
+                                            a {
+                                                color: #007bff;
+                                                text-decoration: none;
+                                            }
+                                            a:hover {
+                                                text-decoration: underline;
+                                            }
+                                        </style>
+                                    </head>
+                                    <body>
+                                        <h1>About Threat Dragon</h1>
+                                        <p>Threat Dragon is an open-source threat modeling tool developed by OWASP (Open Web Application Security Project). It allows you to design and analyze your application’s security by identifying potential threats and vulnerabilities.</p>
+                                        <p>It is available as a desktop application that works across multiple platforms, helping you create threat models that can be shared and collaborated upon. This tool is designed for developers and security professionals to visualize their system architecture and the threats that could potentially affect it.</p>
+                                        <h2>Features</h2>
+                                        <ul>
+                                            <li>Drag-and-drop interface for building threat models.</li>
+                                            <li>Automatic threat analysis and risk scoring.</li>
+                                            <li>Integration with other security tools and frameworks.</li>
+                                            <li>Export models to various formats (PDF, HTML, JSON).</li>
+                                            <li>Collaborative features for team-based threat modeling.</li>
+                                        </ul>
+                                        <h2>Learn More</h2>
+                                        <p>For more information, visit the official <a href="https://owasp.org/www-project-threat-dragon/">OWASP Threat Dragon Project Page</a>.</p>
+                                        <p>Visit our <a href="https://github.com/owasp/threat-dragon/">GitHub repository</a> for source code, bug reports, and contributing guidelines.</p>
+                                        <p>If you encounter any issues or have suggestions, feel free to <a href="https://github.com/owasp/threat-dragon/issues">submit an issue</a> or create a <a href="https://github.com/owasp/threat-dragon/pulls">pull request</a>.</p>
+                                    </body>
+                                </html>
+                            `;
+
+                            // Load the content directly into the window
+                            aboutWin.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(aboutContent));
+
+                            // Optional: Open DevTools to debug
+                            aboutWin.webContents.openDevTools();
+
+                            // Optional: Log load success
+                            aboutWin.webContents.on('did-finish-load', () => {
+                                console.log('About page content loaded');
+                            });
+                        }
+                    },
+                    ...(process.platform === 'darwin' && { role: 'about' }) // Only add 'role: about' for macOS
+                }
+                ,
+
+                // { role: 'about' }
             ]
         }
     );

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -30,7 +30,7 @@ import zho from '@/i18n/zh.js';
 
 const messages = { ara, deu, ell, eng, fin, fra, hin, id, jpn, ms, por, spa, zho };
 // hide RUS & UKR for now: const messages = { ara, deu, ell, eng, fin, fra, hin, id, jpn, ms, por, rus, spa, ukr, zho };
-const languages = [ 'ara', 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'id', 'jpn', 'ms', 'por', 'spa', 'zho' ];
+const languages = ['ara', 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'id', 'jpn', 'ms', 'por', 'spa', 'zho'];
 // hide RUS & UKR for now: const languages = [ 'ara', 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'id', 'jpn', 'ms', 'por', 'rus', 'spa', 'ukr', 'zho' ];
 const defaultLanguage = 'eng';
 var language = defaultLanguage;
@@ -41,7 +41,7 @@ export const model = {
     isOpen: false
 };
 
-export function getMenuTemplate () {
+export function getMenuTemplate() {
     var menuTemplate = (isMacOS ? [{ role: 'appMenu' }] : []);
     menuTemplate.push(
         {
@@ -49,25 +49,25 @@ export function getMenuTemplate () {
             submenu: [
                 {
                     label: messages[language].desktop.file.open,
-                    click () {
+                    click() {
                         openModelRequest('');
                     }
                 },
                 {
                     label: messages[language].desktop.file.save,
-                    click () {
+                    click() {
                         saveModel();
                     }
                 },
                 {
                     label: messages[language].desktop.file.saveAs,
-                    click () {
+                    click() {
                         saveModelAs();
                     }
                 },
                 {
                     label: messages[language].desktop.file.new,
-                    click () {
+                    click() {
                         newModel();
                     }
                 },
@@ -76,13 +76,13 @@ export function getMenuTemplate () {
                     submenu: [
                         {
                             label: messages[language].forms.exportHtml,
-                            click () {
+                            click() {
                                 printModel('HTML');
                             }
                         },
                         {
                             label: messages[language].forms.exportPdf,
-                            click () {
+                            click() {
                                 printModel('PDF');
                             }
                         },
@@ -98,7 +98,7 @@ export function getMenuTemplate () {
                 },
                 {
                     label: messages[language].desktop.file.close,
-                    click () {
+                    click() {
                         closeModelRequest();
                     }
                 },
@@ -153,6 +153,21 @@ export function getMenuTemplate () {
                     }
                 },
                 { type: 'separator' },
+                {
+                    label: 'about Electron',  // New "About Electron" label
+                    click: () => {
+                        const aboutWin = new BrowserWindow({
+                            width: 300,
+                            height: 200,
+                            modal: true,
+                            parent: win,
+                            resizable: false
+                        });
+                        aboutWin.loadFile('about.html');  // Load the 'about.html' file in the modal
+                    },
+                    ...(process.platform === 'darwin' && { role: 'about' }) // Only add 'role: about' for macOS
+                },
+
                 { role: 'about' }
             ]
         }
@@ -178,7 +193,7 @@ export function getMenuTemplate () {
 }
 
 // Open file system dialog and read file contents into model
-function openModel (filename) {
+function openModel(filename) {
     logger.log.debug('Open file with name : ' + filename);
 
     if (filename !== '') {
@@ -207,13 +222,13 @@ function openModel (filename) {
 }
 
 // request to the renderer for confirmation that it is OK to open a model file
-function openModelRequest (filename) {
+function openModelRequest(filename) {
     logger.log.debug('Request to renderer to open an existing model');
     mainWindow.webContents.send('open-model-request', filename);
 }
 
 // request to the renderer for confirmation that it is OK to open a model file
-function openModelFile (filename) {
+function openModelFile(filename) {
     logger.log.debug(messages[language].desktop.file.open + ': ' + filename);
     fs.readFile(filename, (err, data) => {
         if (!err) {
@@ -231,7 +246,7 @@ function openModelFile (filename) {
 }
 
 // request that the renderer send the model data, retain existing filename
-function saveModel () {
+function saveModel() {
     if (model.isOpen === false) {
         logger.log.debug('Skip save request because no model is open');
         return;
@@ -241,7 +256,7 @@ function saveModel () {
 }
 
 // request that the renderer send the model data
-function saveModelAs () {
+function saveModelAs() {
     if (model.isOpen === false) {
         logger.log.debug('Skip saveAs request because no model is open');
         return;
@@ -253,7 +268,7 @@ function saveModelAs () {
 }
 
 // Open saveAs file system dialog and write contents to new file location
-function saveModelDataAs (modelData, fileName) {
+function saveModelDataAs(modelData, fileName) {
     let newName = 'new-model.json';
     if (fileName) {
         newName = fileName;
@@ -282,31 +297,31 @@ function saveModelDataAs (modelData, fileName) {
 }
 
 // request that the renderer open a new model
-function newModel () {
+function newModel() {
     let newName = 'new-model.json';
     logger.log.debug(messages[language].desktop.file.new + ': ' + newName);
     mainWindow.webContents.send('new-model-request', newName);
 }
 
 // request that the renderer display the model report/print page
-function printModel (format) {
+function printModel(format) {
     if (model.isOpen === false) {
         logger.log.debug('Skip print request because no model open');
         return;
     }
-    logger.log.debug(messages[language].forms.exportPdf+ ': ' + model.filePath);
+    logger.log.debug(messages[language].forms.exportPdf + ': ' + model.filePath);
     // prompt the renderer to open the print/report window
     mainWindow.webContents.send('print-model-request', format);
 }
 
 // request that the renderer close the model
-function closeModelRequest () {
+function closeModelRequest() {
     logger.log.debug(messages[language].desktop.file.close + ': ' + model.filePath);
     mainWindow.webContents.send('close-model-request', path.basename(model.filePath));
 }
 
 // save the threat model
-function saveModelData (modelData) {
+function saveModelData(modelData) {
     if (model.isOpen === true) {
         fs.writeFile(model.filePath, JSON.stringify(modelData, undefined, 2), (err) => {
             if (err) {
@@ -322,7 +337,7 @@ function saveModelData (modelData) {
 }
 
 // Open saveAs file system dialog and write report contents as HTML
-function saveHTMLReport (htmlPath) {
+function saveHTMLReport(htmlPath) {
     htmlPath += '.html';
     var dialogOptions = {
         title: messages[language].forms.saveAS,
@@ -347,7 +362,7 @@ function saveHTMLReport (htmlPath) {
 }
 
 // Open saveAs file system dialog and write PDF report
-function savePDFReport (pdfPath) {
+function savePDFReport(pdfPath) {
     pdfPath += '.pdf';
     var dialogOptions = {
         title: messages[language].forms.exportPdf,


### PR DESCRIPTION
**Summary**:
This pull request addresses Issue #421, which involves fixing the behavior of the "About" menu item in the application. Currently, the "About" dialog is not functioning as expected on non-macOS platforms. The fix ensures that the "About" dialog appears as a modal window for all platforms except macOS, where the native "About" dialog behavior is retained.

**Description for the changelog**:
Fixed the "About" menu behavior: non-macOS platforms now open a custom modal window, while macOS retains the native About dialog.

**Other info**:
This PR closes #421 and ensures the "About" menu item behaves appropriately across different platforms.

For macOS, the menu uses the default system behavior.
For non-macOS platforms, the "About" item opens a custom modal window displaying about.html.
This change ensures a more consistent and expected behavior for the "About" dialog across all platforms.


