### PR TITLE
Fix id duplication on ThreatSuggestDialog

### DIFF
--- a/td.vue/src/components/ThreatSuggestDialog.vue
+++ b/td.vue/src/components/ThreatSuggestDialog.vue
@@ -95,6 +95,7 @@ import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
 import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
+import { v4 } from 'uuid';
 export default {
     name: 'TdThreatSuggest',
     computed: {
@@ -184,6 +185,8 @@ export default {
         },
         acceptSuggestion() {
             const objRef = this.cellRef.data;
+            this.threat.number = this.threatTop + 1;
+            this.threat.id = v4();
             if (!objRef.threatFrequency) {
                 const tmpfreq = threatModels.getFrequencyMapByElement(this.threat.modelType, this.cellRef.data.type);
                 if (tmpfreq !== null)


### PR DESCRIPTION
**Summary**:
Fix Issue #1183 

**Description for the changelog**:
- Forces Id renewal on suggestion acceptance

**Other info**:
closes #1183 

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
