### PR TITLE
Reinstate the label text for trust boundary boxes

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -7,3 +7,8 @@ CVE-2022-37434
 # request version prior to 2.88.2
 # this vulnerability is for the build system, not run time, so ignore
 CVE-2023-28155
+
+# https://avd.aquasec.com/nvd/cve-2024-9143 
+# alpine 3.20.3 is pulling in a Low priority vuln for libcrypto3 version 3.3.2-r2,
+# ignore for now until alpine is updated
+CVE-2024-9143

--- a/td.vue/src/service/x6/shapes/actor.js
+++ b/td.vue/src/service/x6/shapes/actor.js
@@ -6,7 +6,7 @@ import { ports } from '../ports.js';
 
 const name = 'actor';
 
-// actor (rectangle, white background)
+// actor (rectangle, transparent background)
 export const ActorShape = Shape.Rect.define({
     constructorName: name,
     width: 150,

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -4,7 +4,7 @@ import { tc } from '@/i18n/index.js';
 
 const name = 'trust-boundary-box';
 
-// trust boundary box (dotted line, gray opaque background)
+// trust boundary box (dotted line, transparent background)
 export const TrustBoundaryBox = Shape.Rect.define({
     constructorName: name,
     width: 500,
@@ -19,32 +19,20 @@ export const TrustBoundaryBox = Shape.Rect.define({
             fill: 'transparent',
             fillOpacity: 0
         },
-        headerText: {
+        label: {
             text: tc('threatmodel.shapes.trustBoundary'),
-            fill: '#333',
-            strokeWidth: 0
-        },
-        header: {
-            rx: 10,
-            ry: 10,
-            strokeWidth: 0,
-            fillOpacity: 0
+            textAnchor : 'bottom',
+            textVerticalAnchor : 'top',
+            refX: '15%',
+            refY: '12'
         }
     }
 });
 
-TrustBoundaryBox.prototype.setLabel = function (label) {
-    this.setAttrByPath('headerText/text', label);
-};
-
-TrustBoundaryBox.prototype.getLabel = function () {
-    return this.getAttrByPath('headerText/text');
-};
-
 TrustBoundaryBox.prototype.type = 'tm.BoundaryBox';
 
 TrustBoundaryBox.prototype.setName = function (name) {
-    this.setAttrByPath('headerText/text', name);
+    this.setAttrByPath('label/text', name);
 };
 
 TrustBoundaryBox.prototype.updateStyle = function () {};

--- a/td.vue/tests/unit/service/x6/shapes/trust-boundary-box.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/trust-boundary-box.spec.js
@@ -27,22 +27,7 @@ describe('service/x6/shapes/trust-boundary-box.js', () => {
         it('sets the name', () => {
             const name = 'tbbName';
             victim.setName(name);
-            expect(victim.setAttrByPath).toHaveBeenCalledWith('headerText/text', name);
-        });
-    });
-
-    describe('getLabel', () => {
-        it('gets the label', () => {
-            victim.getLabel();
-            expect(victim.getAttrByPath).toHaveBeenCalledWith('headerText/text');
-        });
-    });
-
-    describe('setLabel', () => {
-        it('sets the label', () => {
-            const name = 'tbbName';
-            victim.setLabel(name);
-            expect(victim.setAttrByPath).toHaveBeenCalledWith('headerText/text', name);
+            expect(victim.setAttrByPath).toHaveBeenCalledWith('label/text', name);
         });
     });
 


### PR DESCRIPTION
**Summary**:
The trust boundary boxes label was no longer visible after moving to AntV/X6 version 2.x, probably due to some incompatibility wioth version 1.x

**Description for the changelog**:
make label visible for trust boundary box

**Other info**:
This issue was introduced in Threat Dragon version 2.3
fixes #1160 
