### PR TITLE
clean up console of warnings and errors

### DIFF
--- a/td.vue/jest.config.js
+++ b/td.vue/jest.config.js
@@ -22,7 +22,7 @@ module.exports = async () => {
         resetMocks: true,
         restoreMocks: true,
         transformIgnorePatterns: [
-            '<rootDir>/node_modules/(?!lodash-es|axios)'
+            '<rootDir>/node_modules/(?!lodash-es|axios|passive-events-support)'
         ]
     };
 };

--- a/td.vue/package-lock.json
+++ b/td.vue/package-lock.json
@@ -33,6 +33,7 @@
         "electron-updater": "^6.3.0",
         "is-electron": "^2.2.1",
         "jquery": "^3.7.1",
+        "passive-events-support": "^1.1.0",
         "uuid": "^8.3.2",
         "vue": "^2.7.3",
         "vue-i18n": "^8.27.2",
@@ -27826,6 +27827,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/passive-events-support": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passive-events-support/-/passive-events-support-1.1.0.tgz",
+      "integrity": "sha512-MNkNItIS7Ufwp0OrBIImkYlJmGmdFullI7KaEUPnKRpxf/QYQu6rI1VpCXVnW2LiRcnKPcpLvwFY5KfXOXqqWA==",
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "0.0.1",

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -78,6 +78,7 @@
     "electron-updater": "^6.3.0",
     "is-electron": "^2.2.1",
     "jquery": "^3.7.1",
+    "passive-events-support": "^1.1.0",
     "uuid": "^8.3.2",
     "vue": "^2.7.3",
     "vue-i18n": "^8.27.2",

--- a/td.vue/src/service/migration/diagram.js
+++ b/td.vue/src/service/migration/diagram.js
@@ -4,8 +4,13 @@ import graphFactory from '@/service/x6/graph/graph.js';
 import events from '@/service/x6/graph/events.js';
 import store from '@/store/index.js';
 import tmActions from '@/store/actions/threatmodel.js';
+import { passiveSupport } from 'passive-events-support/src/utils';
 
 const appVersion = require('../../../package.json').version;
+
+passiveSupport({
+    events: ['touchstart', 'mousewheel']
+});
 
 const drawV1 = (diagram, graph) => {
     const { nodes, edges } = cells.map(diagram);

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -30,13 +30,7 @@ const devServerConfig = hasTlsCredentials
         allowedHosts: [appHostname],
     }
     : {
-        client: {
-            webSocketURL: {
-                protocol: 'wss', // Use secure WebSocket protocol
-                hostname: appHostname,
-                port: 443, // HTTPS port
-            },
-        },
+        // note that client webSocketURL config has been removed, as it was incompatible with desktop version
         port: 8080,
         proxy: {
             '^/api': {


### PR DESCRIPTION
**Summary**:
Provides passive events support to touchstart and mousewheel events in the diagram, which prevents the warnings :

- "Added non-passive event listener to a scroll-blocking 'mousewheel' event."
- "Added non-passive event listener to a scroll-blocking 'touchstart' event."

also removes client webSocketURL from Vue devServer config due to error on the console for the desktop app:

- "WebSocket connection to 'wss://localhost/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED"

**Description for the changelog**:
clean up console of warnings and errors

**Other info**:
closes #1100 

