### PR TITLE
reinstate diagram node resizing

### DIFF
--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -127,7 +127,7 @@ const getEditGraph = (container, ctor = Graph) => {
                     maxWidth: Number.MAX_SAFE_INTEGER, // probably needs a more sane value
                     maxHeight: Number.MAX_SAFE_INTEGER, // same goes for this
                     orthogonal: true,
-                    preserveAspectRatio: true,
+                    preserveAspectRatio: false,
                     restrict: false
                 },
                 rotating: true


### PR DESCRIPTION
**Summary**:
Reinstates the resizing of graph diagram nodes, this was a regression from the upgrade to AntV/X6 version 2.x

**Description for the changelog**:
reinstate diagram node resizing

**Other info**:
