### PR TITLE
Make edge labels legible and selectable

### DIFF
--- a/td.vue/src/service/demo/v2-new-model.js
+++ b/td.vue/src/service/demo/v2-new-model.js
@@ -8,17 +8,7 @@ export default {
     },
     'detail': {
         'contributors': [],
-        'diagrams': [
-            {
-                'id': 0,
-                'title': 'New generic diagram',
-                'diagramType': 'Generic',
-                'placeholder': 'New generic diagram description',
-                'thumbnail': './public/content/images/thumbnail.stride.jpg',
-                'version': '2.3.0',
-                'cells': []
-            }
-        ],
+        'diagrams': [],
         'diagramTop': 0,
         'reviewer': '',
         'threatTop': 0

--- a/td.vue/src/service/demo/v2-new-model.js
+++ b/td.vue/src/service/demo/v2-new-model.js
@@ -11,9 +11,9 @@ export default {
         'diagrams': [
             {
                 'id': 0,
-                'title': 'New STRIDE diagram',
-                'diagramType': 'STRIDE',
-                'placeholder': 'New STRIDE diagram description',
+                'title': 'New generic diagram',
+                'diagramType': 'Generic',
+                'placeholder': 'New generic diagram description',
                 'thumbnail': './public/content/images/thumbnail.stride.jpg',
                 'version': '2.3.0',
                 'cells': []

--- a/td.vue/src/service/demo/v2-new-model.js
+++ b/td.vue/src/service/demo/v2-new-model.js
@@ -1,5 +1,5 @@
-export default{
-    'version': '2.0.0',
+export default {
+    'version': '2.3.0',
     'summary': {
         'title': 'New Threat Model',
         'owner': '',
@@ -8,7 +8,17 @@ export default{
     },
     'detail': {
         'contributors': [],
-        'diagrams': [],
+        'diagrams': [
+            {
+                'id': 0,
+                'title': 'New STRIDE diagram',
+                'diagramType': 'STRIDE',
+                'placeholder': 'New STRIDE diagram description',
+                'thumbnail': './public/content/images/thumbnail.stride.jpg',
+                'version': '2.3.0',
+                'cells': []
+            }
+        ],
         'diagramTop': 0,
         'reviewer': '',
         'threatTop': 0

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -68,9 +68,8 @@ const updateStyleAttrs = (cell) => {
 
 const updateName = (cell) => {
     if (!cell || !cell.setName || !cell.getData) {
-        console.debug('Name update ignored for empty cell');
+        console.warn('No cell found to update name');
     } else {
-        // console.debug('Update name for cell: ' + cell.getData().name);
         cell.setName(cell.getData().name);
     }
 };

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -78,24 +78,23 @@ const updateName = (cell) => {
 const updateProperties = (cell) => {
     if (cell) {
         if (cell.data) {
-            console.debug('Update properties for cell: ' + cell.getData().name);
+            console.debug('Updated properties for cell: ' + cell.getData().name);
         } else {
             if (cell.isEdge()) {
                 cell.type = defaultProperties.flow.type;
                 console.debug('Edge cell given type: ' + cell.type);
             }
             cell.setData(defaultProperties.getByType(cell.type));
-            console.debug('Setting properties for cell: ' + cell.getData().name);
+            console.debug('Default properties for cell: ' + cell.getData().name);
         }
         store.get().dispatch(CELL_DATA_UPDATED, cell.data);
         store.get().dispatch(THREATMODEL_MODIFIED);
     } else {
-        console.debug('No cell data to update');
+        console.warn('No cell found to update properties');
     }
 };
 
-// future modifications to the list of properties applied to cells that may not have them
-const upgradeProperties = (cell) => {
+const setType = (cell) => {
     // fundamentally the shape is the only constant identifier
     switch (cell.shape) {
 	    case 'actor':
@@ -129,5 +128,5 @@ export default {
     updateName,
     updateStyleAttrs,
     updateProperties,
-    upgradeProperties
+    setType
 };

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -84,7 +84,7 @@ const updateProperties = (cell) => {
                 console.debug('Edge cell given type: ' + cell.type);
             }
             cell.setData(defaultProperties.getByType(cell.type));
-            console.debug('Default properties for cell: ' + cell.getData().name);
+            console.debug('Default properties for ' + cell.shape + ' cell: ' + cell.getData().name);
         }
         store.get().dispatch(CELL_DATA_UPDATED, cell.data);
         store.get().dispatch(THREATMODEL_MODIFIED);

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -27,21 +27,13 @@ const edgeChangeVertices = () => ({ edge }) => {
     }
 };
 
-const edgeConnected = (graph) => ({ isNew, edge }) => {
-    if (isNew) {
-        if (edge.constructor.name === 'Edge') {
-            console.debug('edge connected');
-            const flow = shapes.Flow.fromEdge(edge);
-            graph.addEdge(flow);
-            edge.remove();
-            edge = flow;
-        } else {
-            console.warn('Unexpected constructor name');
-        }
-    } else {
-        if (edge.constructor.name === 'Edge') {
-            console.debug('connected unformatted edge/flow');
-        }
+const edgeConnected = (graph) => ({ edge }) => {
+    if (edge.constructor.name === 'Edge') {
+        console.debug('connected unformatted edge/flow');
+        const flow = shapes.Flow.fromEdge(edge);
+        graph.addEdge(flow);
+        edge.remove();
+        edge = flow;
     }
 };
 
@@ -126,7 +118,7 @@ const cellDeleted = () => {
 };
 
 const cellSelected =
-    () =>
+    (graph) =>
         ({ cell }) => {
             // try and get the cell name
             if (cell.data) {
@@ -154,6 +146,10 @@ const cellSelected =
 
             if (cell.shape === 'edge') {
                 console.debug('selected unformatted edge/flow');
+                const flow = shapes.Flow.fromEdge(cell);
+                graph.addEdge(flow);
+                cell.remove();
+                cell = flow;
             }
 
             store.get().dispatch(CELL_SELECTED, cell);

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -58,8 +58,9 @@ const mouseEnter = ({ cell }) => {
 const cellAdded =
     (graph) =>
         ({ cell }) => {
-            //graph.resetSelection(cell);
             console.debug('cell added with shape: ', cell.shape);
+            // ensure selection of other components is removed
+            graph.resetSelection();
 
             // Flow and trust boundary stencil need to be converted
             if (cell.convertToEdge) {
@@ -79,7 +80,7 @@ const cellAdded =
                 } else if (cell.type === shapes.TrustBoundaryCurveStencil.prototype.type) {
                     edge = graph.addEdge(new shapes.TrustBoundaryCurve(config));
                 } else {
-                    console.warn('Removed unknown edge');
+                    console.warn('Unknown edge stencil');
                 }
                 cell.remove();
                 cell = edge;
@@ -95,6 +96,14 @@ const cellAdded =
             store.get().dispatch(CELL_SELECTED, cell);
             dataChanged.updateProperties(cell);
             dataChanged.updateStyleAttrs(cell);
+
+            // do not select new data flows or trust boundaries: it surprises the user
+            if (cell.shape !== 'path'
+                && cell.shape !== 'edge'
+                && cell.shape !== 'flow'
+                && cell.shape !== 'trust-boundary-curve') {
+                graph.select(cell);
+            }
         };
 
 const cellDeleted = () => {

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -24,20 +24,18 @@ const canvasResized = ({ width, height }) => {
 const edgeConnected = (graph) => ({ isNew, edge }) => {
     if (isNew) {
         edge.connector = 'smooth';
-        replaceEdgeWithFlow(graph, edge);
-    }
-};
 
-const replaceEdgeWithFlow = (graph, edge) => {
-    if (edge.constructor.name !== 'Edge') {
-        return;
-    }
+        if (edge.constructor.name === 'Edge') {
+            console.debug('edge connected');
+            const flow = shapes.Flow.fromEdge(edge);
+            graph.addEdge(flow);
+            edge.remove();
+            edge = flow;
+        } else {
+            console.warn('Unexpected constructor name');
+        }
 
-    const flow = shapes.Flow.fromEdge(edge);
-    graph.addEdge(flow);
-    edge.remove();
-    edge = flow;
-    edge.setLabels([edge.data.name]);
+    }
 };
 
 const mouseLeave = ({ cell }) => {
@@ -66,6 +64,7 @@ const cellAdded =
             //graph.resetSelection(cell);
             console.debug('cell added with shape: ', cell.shape);
 
+            // Flow and trust boundary stencil need to be converted
             if (cell.convertToEdge) {
                 let edge = cell;
                 const position = cell.position();
@@ -136,7 +135,7 @@ const cellSelected =
             store.get().dispatch(CELL_SELECTED, cell);
             dataChanged.updateProperties(cell);
             dataChanged.updateStyleAttrs(cell);
-            dataChanged.upgradeProperties(cell);
+            dataChanged.setType(cell);
         };
 
 const cellUnselected = ({ cell }) => {

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -21,6 +21,12 @@ const canvasResized = ({ width, height }) => {
     showPorts(false);
 };
 
+const edgeChangeVertices = () => ({ edge }) => {
+    if (edge.constructor.name === 'Edge') {
+        console.debug('vertex for unformatted edge/flow');
+    }
+};
+
 const edgeConnected = (graph) => ({ isNew, edge }) => {
     if (isNew) {
         if (edge.constructor.name === 'Edge') {
@@ -31,6 +37,10 @@ const edgeConnected = (graph) => ({ isNew, edge }) => {
             edge = flow;
         } else {
             console.warn('Unexpected constructor name');
+        }
+    } else {
+        if (edge.constructor.name === 'Edge') {
+            console.debug('connected unformatted edge/flow');
         }
     }
 };
@@ -62,7 +72,7 @@ const cellAdded =
             // ensure selection of other components is removed
             graph.resetSelection();
 
-            // Flow and trust boundary stencil need to be converted
+            // Flow and trust boundary stencils need to be converted
             if (cell.convertToEdge) {
                 let edge = cell;
                 const position = cell.position();
@@ -96,6 +106,10 @@ const cellAdded =
             store.get().dispatch(CELL_SELECTED, cell);
             dataChanged.updateProperties(cell);
             dataChanged.updateStyleAttrs(cell);
+
+            if (cell.shape === 'edge') {
+                console.debug('added new edge (flow parent)');
+            }
 
             // do not select new data flows or trust boundaries: it surprises the user
             if (cell.shape !== 'path'
@@ -138,6 +152,10 @@ const cellSelected =
                 console.debug('cell selected with no name');
             }
 
+            if (cell.shape === 'edge') {
+                console.debug('selected unformatted edge/flow');
+            }
+
             store.get().dispatch(CELL_SELECTED, cell);
             dataChanged.updateProperties(cell);
             dataChanged.updateStyleAttrs(cell);
@@ -158,6 +176,7 @@ const cellDataChanged = ({ cell }) => {
 
 const listen = (graph) => {
     graph.on('resize', canvasResized);
+    graph.on('edge:change:vertices', edgeChangeVertices(graph));
     graph.on('edge:connected', edgeConnected(graph));
     graph.on('edge:dblclick', cellSelected);
     graph.on('edge:move', cellSelected);
@@ -173,6 +192,7 @@ const listen = (graph) => {
 
 const removeListeners = (graph) => {
     graph.off('resize', canvasResized);
+    graph.off('edge:change:vertices', edgeChangeVertices(graph));
     graph.off('edge:connected', edgeConnected(graph));
     graph.off('edge:dblclick', cellSelected);
     graph.off('edge:move', cellSelected);

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -23,8 +23,6 @@ const canvasResized = ({ width, height }) => {
 
 const edgeConnected = (graph) => ({ isNew, edge }) => {
     if (isNew) {
-        edge.connector = 'smooth';
-
         if (edge.constructor.name === 'Edge') {
             console.debug('edge connected');
             const flow = shapes.Flow.fromEdge(edge);
@@ -34,7 +32,6 @@ const edgeConnected = (graph) => ({ isNew, edge }) => {
         } else {
             console.warn('Unexpected constructor name');
         }
-
     }
 };
 

--- a/td.vue/src/service/x6/shapes/flow-stencil.js
+++ b/td.vue/src/service/x6/shapes/flow-stencil.js
@@ -20,6 +20,10 @@ export const FlowStencil = Shape.Path.define({
         {
             tagName: 'text',
             selector: 'label'
+        },
+        {
+            tagName: 'rect',
+            selector: 'customBoundary'
         }
     ],
     attrs: {
@@ -28,6 +32,11 @@ export const FlowStencil = Shape.Path.define({
             stroke: '#333333',
             fill: 'transparent',
             refD: 'M 30 20 C 70 20 70 100 110 100'
+        },
+        customBoundary: {
+            opacity: 0,
+            width: 150,
+            height: 80,
         },
         label: {
             text: tc('threatmodel.shapes.flowStencil'),

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -4,6 +4,41 @@ import { tc } from '@/i18n/index.js';
 import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'flow';
+const defaultLabel = [
+    {
+        markup: [
+            {
+                tagName: 'ellipse',
+                selector: 'labelBody',
+            },
+            {
+                tagName: 'text',
+                selector: 'labelText',
+            },
+        ],
+        attrs: {
+            labelText: {
+                text: tc('threatmodel.shapes.flow'),
+                textAnchor: 'middle',
+                textVerticalAnchor: 'middle',
+            },
+            labelBody: {
+                ref: 'labelText',
+                refRx: '50%',
+                refRy: '60%',
+                fill: '#fff',
+                strokeWidth: 0,
+            },
+        },
+        position: {
+            distance: 0.5,
+            args: {
+                keepGradient: true,
+                ensureLegibility: true,
+            }
+        },
+    }
+];
 
 // data flow (edge)
 export const Flow = Shape.Edge.define({
@@ -22,41 +57,7 @@ export const Flow = Shape.Edge.define({
             stroke: 'none'
         },
     },
-    labels: [
-        {
-            markup: [
-                {
-                    tagName: 'ellipse',
-                    selector: 'labelBody',
-                },
-                {
-                    tagName: 'text',
-                    selector: 'labelText',
-                },
-            ],
-            attrs: {
-                labelText: {
-                    text: tc('threatmodel.shapes.flow'),
-                    textAnchor: 'middle',
-                    textVerticalAnchor: 'middle',
-                },
-                labelBody: {
-                    ref: 'labelText',
-                    refRx: '50%',
-                    refRy: '60%',
-                    fill: '#fff',
-                    strokeWidth: 0,
-                },
-            },
-            position: {
-                distance: 0.6,
-                args: {
-                    keepGradient: true,
-                    ensureLegibility: true,
-                }
-            },
-        },
-    ],
+    labels: defaultLabel,
     connector: 'smooth',
     data: defaultProperties.flow
 });
@@ -64,7 +65,10 @@ export const Flow = Shape.Edge.define({
 Flow.prototype.type = 'tm.Flow';
 
 Flow.prototype.setName = function(name) {
-    this.setLabels([name]);
+    this.setLabels([name]); // not a good look, but forces an Edge redraw
+    let labels = defaultLabel;
+    labels[0].attrs.labelText.text = name;
+    this.setLabels(labels);
 };
 
 Flow.prototype.updateStyle = function(color, dash, strokeWidth, sourceMarker) {
@@ -75,6 +79,7 @@ Flow.prototype.updateStyle = function(color, dash, strokeWidth, sourceMarker) {
     this.setAttrByPath('line/targetMarker/name', 'block');
 };
 
+// called when flow (edge) is connected to target node, not from source node
 Flow.fromEdge = function(edge) {
     return new Flow({
         source: edge.getSourceCell(),

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -11,7 +11,6 @@ export const Flow = Shape.Edge.define({
     width: 200,
     height: 100,
     zIndex: 10,
-    label: tc('threatmodel.shapes.flow'),
     attrs: {
         line: {
             strokeWidth: 1.5,
@@ -23,6 +22,41 @@ export const Flow = Shape.Edge.define({
             stroke: 'none'
         },
     },
+    labels: [
+        {
+            markup: [
+                {
+                    tagName: 'ellipse',
+                    selector: 'labelBody',
+                },
+                {
+                    tagName: 'text',
+                    selector: 'labelText',
+                },
+            ],
+            attrs: {
+                labelText: {
+                    text: tc('threatmodel.shapes.flow'),
+                    textAnchor: 'middle',
+                    textVerticalAnchor: 'middle',
+                },
+                labelBody: {
+                    ref: 'labelText',
+                    refRx: '50%',
+                    refRy: '60%',
+                    fill: '#fff',
+                    strokeWidth: 0,
+                },
+            },
+            position: {
+                distance: 0.6,
+                args: {
+                    keepGradient: true,
+                    ensureLegibility: true,
+                }
+            },
+        },
+    ],
     connector: 'smooth',
     data: defaultProperties.flow
 });

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -79,12 +79,14 @@ Flow.prototype.updateStyle = function(color, dash, strokeWidth, sourceMarker) {
     this.setAttrByPath('line/targetMarker/name', 'block');
 };
 
-// called when flow (edge) is connected to target node, not from source node
+// a new edge (not flow) is created by AntV/X6 from an existing node port
+// and then needs to be converted to a Flow
 Flow.fromEdge = function(edge) {
     return new Flow({
         source: edge.getSourceCell(),
         target: edge.getTargetCell(),
-        data: edge.getData()
+        data: edge.getData(),
+        vertices: edge.getVertices()
     });
 };
 

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -83,8 +83,8 @@ Flow.prototype.updateStyle = function(color, dash, strokeWidth, sourceMarker) {
 // and then needs to be converted to a Flow
 Flow.fromEdge = function(edge) {
     return new Flow({
-        source: edge.getSourceCell(),
-        target: edge.getTargetCell(),
+        source: edge.getSource(),
+        target: edge.getTarget(),
         data: edge.getData(),
         vertices: edge.getVertices()
     });

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve-stencil.js
@@ -20,6 +20,10 @@ export const TrustBoundaryCurveStencil = Shape.Path.define({
         {
             tagName: 'text',
             selector: 'label'
+        },
+        {
+            tagName: 'rect',
+            selector: 'customBoundary'
         }
     ],
     attrs: {
@@ -29,6 +33,11 @@ export const TrustBoundaryCurveStencil = Shape.Path.define({
             fill: 'transparent',
             strokeDasharray: '10 5',
             refD: 'M 30 20 C 70 20 70 100 110 100'
+        },
+        customBoundary: {
+            opacity: 0,
+            width: 150,
+            height: 80,
         },
         label: {
             text: tc('threatmodel.shapes.trustBoundary'),

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -11,7 +11,6 @@ export const TrustBoundaryCurve = Shape.Edge.define({
     width: 200,
     height: 100,
     zIndex: 10,
-    label: tc('threatmodel.shapes.trustBoundary'),
     attrs: {
         line: {
             strokeWidth: 3,
@@ -24,6 +23,41 @@ export const TrustBoundaryCurve = Shape.Edge.define({
             stroke: 'none'
         },
     },
+    labels: [
+        {
+            markup: [
+                {
+                    tagName: 'ellipse',
+                    selector: 'labelBody',
+                },
+                {
+                    tagName: 'text',
+                    selector: 'labelText',
+                },
+            ],
+            attrs: {
+                labelText: {
+                    text: tc('threatmodel.shapes.trustBoundary'),
+                    textAnchor: 'middle',
+                    textVerticalAnchor: 'middle',
+                },
+                labelBody: {
+                    ref: 'labelText',
+                    refRx: '50%',
+                    refRy: '60%',
+                    fill: '#fff',
+                    strokeWidth: 0,
+                },
+            },
+            position: {
+                distance: 0.6,
+                args: {
+                    keepGradient: true,
+                    ensureLegibility: true,
+                }
+            },
+        },
+    ],
     connector: 'smooth',
     data: defaultProperties.boundary
 });

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -4,8 +4,43 @@ import { tc } from '@/i18n/index.js';
 import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'trust-boundary-curve';
+const defaultLabel = [
+    {
+        markup: [
+            {
+                tagName: 'ellipse',
+                selector: 'labelBody',
+            },
+            {
+                tagName: 'text',
+                selector: 'labelText',
+            },
+        ],
+        attrs: {
+            labelText: {
+                text: tc('threatmodel.shapes.trustBoundary'),
+                textAnchor: 'middle',
+                textVerticalAnchor: 'middle',
+            },
+            labelBody: {
+                ref: 'labelText',
+                refRx: '50%',
+                refRy: '60%',
+                fill: '#fff',
+                strokeWidth: 0,
+            },
+        },
+        position: {
+            distance: 0.5,
+            args: {
+                keepGradient: true,
+                ensureLegibility: true,
+            }
+        },
+    }
+];
 
-// trust boundary curve (edge, dotted line, gray opaque background))
+// trust boundary curve (edge, dotted line)
 export const TrustBoundaryCurve = Shape.Edge.define({
     constructorName: name,
     width: 200,
@@ -23,41 +58,7 @@ export const TrustBoundaryCurve = Shape.Edge.define({
             stroke: 'none'
         },
     },
-    labels: [
-        {
-            markup: [
-                {
-                    tagName: 'ellipse',
-                    selector: 'labelBody',
-                },
-                {
-                    tagName: 'text',
-                    selector: 'labelText',
-                },
-            ],
-            attrs: {
-                labelText: {
-                    text: tc('threatmodel.shapes.trustBoundary'),
-                    textAnchor: 'middle',
-                    textVerticalAnchor: 'middle',
-                },
-                labelBody: {
-                    ref: 'labelText',
-                    refRx: '50%',
-                    refRy: '60%',
-                    fill: '#fff',
-                    strokeWidth: 0,
-                },
-            },
-            position: {
-                distance: 0.6,
-                args: {
-                    keepGradient: true,
-                    ensureLegibility: true,
-                }
-            },
-        },
-    ],
+    labels: defaultLabel,
     connector: 'smooth',
     data: defaultProperties.boundary
 });
@@ -65,7 +66,10 @@ export const TrustBoundaryCurve = Shape.Edge.define({
 TrustBoundaryCurve.prototype.type = 'tm.Boundary';
 
 TrustBoundaryCurve.prototype.setName = function (name) {
-    this.setLabels([name]);
+    this.setLabels([name]); // not a good look, but forces an Edge redraw
+    let labels = defaultLabel;
+    labels[0].attrs.labelText.text = name;
+    this.setLabels(labels);
 };
 
 TrustBoundaryCurve.prototype.updateStyle = function () {};

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -30,9 +30,9 @@ export default {
                 'diagrams': [
                     {
                         'id': 0,
-                        'title': 'New STRIDE diagram',
-                        'diagramType': 'STRIDE',
-                        'placeholder': 'New STRIDE diagram description',
+                        'title': 'New generic diagram',
+                        'diagramType': 'Generic',
+                        'placeholder': 'New generic diagram description',
                         'thumbnail': './public/content/images/thumbnail.stride.jpg',
                         'version': '2.3.0',
                         'cells': []

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -18,29 +18,19 @@ export default {
     mounted() {
         this.$store.dispatch(tmActions.clear);
         const newTm = {
-            'version': '2.3.0',
-            'summary': {
-                'title': 'New Threat Model',
-                'owner': '',
-                'description': '',
-                'id': 0
+            version: this.version,
+            summary: {
+                title: 'New Threat Model',
+                owner: '',
+                description: '',
+                id: 0
             },
-            'detail': {
-                'contributors': [],
-                'diagrams': [
-                    {
-                        'id': 0,
-                        'title': 'New generic diagram',
-                        'diagramType': 'Generic',
-                        'placeholder': 'New generic diagram description',
-                        'thumbnail': './public/content/images/thumbnail.stride.jpg',
-                        'version': '2.3.0',
-                        'cells': []
-                    }
-                ],
-                'diagramTop': 0,
-                'reviewer': '',
-                'threatTop': 0
+            detail: {
+                contributors: [],
+                diagrams: [],
+                diagramTop: 0,
+                reviewer: '',
+                threatTop: 0
             }
         };
 

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -18,19 +18,29 @@ export default {
     mounted() {
         this.$store.dispatch(tmActions.clear);
         const newTm = {
-            version: this.version,
-            summary: {
-                title: 'New Threat Model',
-                owner: '',
-                description: '',
-                id: 0
+            'version': '2.3.0',
+            'summary': {
+                'title': 'New Threat Model',
+                'owner': '',
+                'description': '',
+                'id': 0
             },
-            detail: {
-                contributors: [],
-                diagrams: [],
-                diagramTop: 0,
-                reviewer: '',
-                threatTop: 0
+            'detail': {
+                'contributors': [],
+                'diagrams': [
+                    {
+                        'id': 0,
+                        'title': 'New STRIDE diagram',
+                        'diagramType': 'STRIDE',
+                        'placeholder': 'New STRIDE diagram description',
+                        'thumbnail': './public/content/images/thumbnail.stride.jpg',
+                        'version': '2.3.0',
+                        'cells': []
+                    }
+                ],
+                'diagramTop': 0,
+                'reviewer': '',
+                'threatTop': 0
             }
         };
 

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -77,18 +77,29 @@ export default {
         newThreatModel() {
             this.$store.dispatch(tmActions.clear);
             const newTm = {
-                summary: {
-                    title: 'New Threat Model',
-                    owner: '',
-                    description: '',
-                    id: 0
+                'version': '2.3.0',
+                'summary': {
+                    'title': 'New Threat Model',
+                    'owner': '',
+                    'description': '',
+                    'id': 0
                 },
-                detail: {
-                    contributors: [],
-                    diagrams: [],
-                    diagramTop: 0,
-                    reviewer: '',
-                    threatTop: 0
+                'detail': {
+                    'contributors': [],
+                    'diagrams': [
+                        {
+                            'id': 0,
+                            'title': 'New STRIDE diagram',
+                            'diagramType': 'STRIDE',
+                            'placeholder': 'New STRIDE diagram description',
+                            'thumbnail': './public/content/images/thumbnail.stride.jpg',
+                            'version': '2.3.0',
+                            'cells': []
+                        }
+                    ],
+                    'diagramTop': 0,
+                    'reviewer': '',
+                    'threatTop': 0
                 }
             };
             this.$store.dispatch(tmActions.create, newTm);

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -77,29 +77,19 @@ export default {
         newThreatModel() {
             this.$store.dispatch(tmActions.clear);
             const newTm = {
-                'version': '2.3.0',
-                'summary': {
-                    'title': 'New Threat Model',
-                    'owner': '',
-                    'description': '',
-                    'id': 0
+                version: '2.3.0',
+                summary: {
+                    title: 'New Threat Model',
+                    owner: '',
+                    description: '',
+                    id: 0
                 },
-                'detail': {
-                    'contributors': [],
-                    'diagrams': [
-                        {
-                            'id': 0,
-                            'title': 'New generic diagram',
-                            'diagramType': 'Generic',
-                            'placeholder': 'New generic diagram description',
-                            'thumbnail': './public/content/images/thumbnail.stride.jpg',
-                            'version': '2.3.0',
-                            'cells': []
-                        }
-                    ],
-                    'diagramTop': 0,
-                    'reviewer': '',
-                    'threatTop': 0
+                detail: {
+                    contributors: [],
+                    diagrams: [],
+                    diagramTop: 0,
+                    reviewer: '',
+                    threatTop: 0
                 }
             };
             this.$store.dispatch(tmActions.create, newTm);

--- a/td.vue/src/views/git/ThreatModelSelect.vue
+++ b/td.vue/src/views/git/ThreatModelSelect.vue
@@ -89,9 +89,9 @@ export default {
                     'diagrams': [
                         {
                             'id': 0,
-                            'title': 'New STRIDE diagram',
-                            'diagramType': 'STRIDE',
-                            'placeholder': 'New STRIDE diagram description',
+                            'title': 'New generic diagram',
+                            'diagramType': 'Generic',
+                            'placeholder': 'New generic diagram description',
                             'thumbnail': './public/content/images/thumbnail.stride.jpg',
                             'version': '2.3.0',
                             'cells': []

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -84,11 +84,6 @@ describe('service/x6/graph/events.js', () => {
                 expect(graph.on).toHaveBeenCalledWith('edge:connected', expect.any(Function));
             });
 
-            it('adds the smooth connector to the edge', () => {
-                graph.evts['edge:connected']({ isNew: true, edge, node, cell });
-                expect(edge.connector).toEqual('smooth');
-            });
-
             it('replaces the edge with flow', () => {
                 graph.evts['edge:connected']({ isNew: true, edge, node, cell });
                 expect(graph.addEdge).toHaveBeenCalled();

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -16,8 +16,9 @@ describe('service/x6/graph/events.js', () => {
             evts: {},
             off: jest.fn(),
             on: function(evt, cb) { this.evts[evt] = cb; },
+            addEdge: jest.fn(),
             resetSelection: jest.fn(),
-            addEdge: jest.fn()
+            select: jest.fn()
         };
         jest.spyOn(graph, 'on');
         cell = {
@@ -177,8 +178,9 @@ describe('service/x6/graph/events.js', () => {
             events.listen(graph);
         });
 
-        describe('not a trust boundary curve', () => {
+        describe('not a flow or trust boundary curve', () => {
             beforeEach(() => {
+                cell.shape = 'actor';
                 cell.isNode.mockImplementation(() => true);
                 cell.convertToEdge = false;
             });
@@ -191,10 +193,16 @@ describe('service/x6/graph/events.js', () => {
                 graph.evts['cell:added']({ cell });
                 expect(graph.addEdge).not.toHaveBeenCalled();
             });
+
+            it('selects the cell', () => {
+                graph.evts['cell:added']({ cell });
+                expect(graph.select).toHaveBeenCalled();
+            });
         });
 
         describe('trust boundary curve', () => {
             beforeEach(() => {
+                cell.shape = 'path';
                 cell.convertToEdge = true;
                 cell.isNode.mockImplementation(() => true);
                 cell.type = shapes.TrustBoundaryCurveStencil.prototype.type;
@@ -214,6 +222,11 @@ describe('service/x6/graph/events.js', () => {
                 graph.evts['cell:added']({ cell });
                 expect(cell.remove).toHaveBeenCalledTimes(1);
             });
+
+            it('does not select the cell', () => {
+                graph.evts['cell:added']({ cell });
+                expect(graph.select).not.toHaveBeenCalled();
+            });
         });
 
         describe('unknown edge', () => {
@@ -225,7 +238,7 @@ describe('service/x6/graph/events.js', () => {
 
             it('warns about unknown edge', () => {
                 graph.evts['cell:added']({ cell });
-                expect(console.warn).toHaveBeenCalledWith('Removed unknown edge');
+                expect(console.warn).toHaveBeenCalledWith('Unknown edge stencil');
             });
         });
     });


### PR DESCRIPTION
**Summary**:
The labels for  data flow and trust boundary curve can not be used to select the edge - it would be _**very**_ useful if they could
also the labels can be obscured by the line passing through them - this needs whitespace around the label

**Description for the changelog**:
flow and trust boundary labels made legible and selectable

**Other info**:
also applies a select box around the flow stencil and trust boundary curve stencil, for easier selection of these stencils
closes #1198 
although it does not solve #1174 , this is the best we can do. If the verticex change event is used to select the data flow then the vertex no longer becomes available for change. This comes from AntV/X6 and is unlikely to change
closes #1174 
