### PR TITLE
consolidating hostname variable

### DIFF
--- a/example.env
+++ b/example.env
@@ -26,9 +26,11 @@ GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return
 
 NODE_ENV=development
 SERVER_API_PROTOCOL=http
+# FQDN hostname needed to run if using domain
+APP_HOSTNAME= example.com
 
+# variables needed for tls configurations
 APP_PORT=443
 APP_USE_TLS=true
 APP_TLS_CERT_PATH=/path/to/certificate.pem
 APP_TLS_KEY_PATH=/path/to/privatekey.pem
-APP_TLS_HOSTNAME=server.example.com

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -10,7 +10,7 @@ const appHostname = process.env.APP_HOSTNAME || 'localhost';
 console.log('Server API protocol: ' + serverApiProtocol + ' and port: ' + serverApiPort);
 
 // Check if TLS credentials are available in the environment file
-const hasTlsCredentials = process.env.APP_USE_TLS && process.env.APP_TLS_CERT_PATH && process.env.APP_TLS_KEY_PATH && process.env.APP_TLS_HOSTNAME;
+const hasTlsCredentials = process.env.APP_USE_TLS && process.env.APP_TLS_CERT_PATH && process.env.APP_TLS_KEY_PATH && process.env.APP_HOSTNAME;
 let port;
 // Configure dev server to use HTTPS with env.port if TLS credentials are available, otherwise use HTTP with port 8080
 const devServerConfig = hasTlsCredentials


### PR DESCRIPTION
**Summary**:
When we added native TLS support to Threat Dragon, we used two environment variables for the host name - one for the app to use and one for TLS certificate validation.  This is unnecessarily complex and error prone, and we have not identified a use case where the names need to be different, so we're consolidating into a single environment variable.

**Description for the changelog**:
Remove APP_HOSTNAME_TLS, just use APP_HOSTNAME instead