### PR TITLE
Bug fix: preserves existing data flows and boundaries that have no label

### DIFF
--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -34,6 +34,7 @@ const edgeConnected = (graph) => ({ edge }) => {
         graph.addEdge(flow);
         edge.remove();
         edge = flow;
+        edge.setName(edge.data.name);
     }
 };
 
@@ -84,6 +85,7 @@ const cellAdded = (graph) => ({ cell }) => {
         }
         cell.remove();
         cell = edge;
+        cell.setName(cell.data.name);
     }
 
     mouseLeave({ cell });
@@ -141,6 +143,7 @@ const cellSelected = (graph) => ({ cell }) => {
         graph.addEdge(flow);
         cell.remove();
         cell = flow;
+        cell.setName(cell.data.name);
     }
 
     store.get().dispatch(CELL_SELECTED, cell);

--- a/td.vue/src/service/x6/shapes/flow.js
+++ b/td.vue/src/service/x6/shapes/flow.js
@@ -1,6 +1,5 @@
 import { Shape } from '@antv/x6';
 
-import { tc } from '@/i18n/index.js';
 import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'flow';
@@ -18,7 +17,7 @@ const defaultLabel = [
         ],
         attrs: {
             labelText: {
-                text: tc('threatmodel.shapes.flow'),
+                text: '',
                 textAnchor: 'middle',
                 textVerticalAnchor: 'middle',
             },

--- a/td.vue/src/service/x6/shapes/trust-boundary-curve.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-curve.js
@@ -1,6 +1,5 @@
 import { Shape } from '@antv/x6';
 
-import { tc } from '@/i18n/index.js';
 import defaultProperties from '@/service/entity/default-properties';
 
 const name = 'trust-boundary-curve';
@@ -18,7 +17,7 @@ const defaultLabel = [
         ],
         attrs: {
             labelText: {
-                text: tc('threatmodel.shapes.trustBoundary'),
+                text: '',
                 textAnchor: 'middle',
                 textVerticalAnchor: 'middle',
             },

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -35,7 +35,8 @@ describe('service/x6/graph/events.js', () => {
             data: {},
             id: 'foobar',
             position: jest.fn().mockReturnValue({ x: 1, y: 2 }),
-            setLabels: jest.fn()
+            setLabels: jest.fn(),
+            setName: jest.fn()
         };
         cell.getData.mockImplementation(() => ({ name: 'test' }));
         node = {
@@ -44,13 +45,12 @@ describe('service/x6/graph/events.js', () => {
         edge = {
             remove: jest.fn(),
             data: { name: 'edgeName' },
-            setLabels: jest.fn(),
             constructor: { name: 'Edge' }
         };
 
         // Mock shapes
         shapes.Flow = {
-            fromEdge: jest.fn().mockReturnValue({ data: { name: 'flowName' }, setLabels: jest.fn() })
+            fromEdge: jest.fn().mockReturnValue({ data: { name: 'flowName' }, setLabels: jest.fn(), setName: jest.fn() })
         };
 
         // Set up DOM


### PR DESCRIPTION
**Summary**:
previous versions of Threat Dragon have data flows and boundaries added with no labels,
this legacy needs to be preserved in version 2.4

**Description for the changelog**:
preserves existing data flows and boundaries that have no label

**Other info**:

