### PR TITLE
Rename "PORT" environment variable to "SERVER_API_PORT"

### DIFF
--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 require('dotenv').config({ path: process.env.ENV_FILE || path.resolve(__dirname, '../.env') });
 const serverApiProtocol = process.env.SERVER_API_PROTOCOL || 'http';
-const serverApiPort = process.env.PORT || '3000';
+const serverApiPort = process.env.SERVER_API_PORT || process.env.PORT || '3000';
 const PORT = process.env.APP_PORT || '8080';
 const appHostname = process.env.APP_HOSTNAME || 'localhost';
 console.log('Server API protocol: ' + serverApiProtocol + ' and port: ' + serverApiPort);


### PR DESCRIPTION
Prefers the environment variable named "SERVER_API_PORT".  If this value is falsy, then uses the environment variable "PORT" for backwards compatibility.  If this value is falsy, then use the default value of 3000.

**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->

**Description for the changelog**:
<!--
A short (one line) summary that describes the changes in this pull request for inclusion in the change log
-->

**Other info**:
<!--
Add here any other information that may be of help to the reviewer
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->

Thanks for submitting a pull request!
Please make sure you follow our code_of_conduct.md and our contributing guidelines contributing.md
