### PR TITLE
Clean up, add error checking, remove ambiguity around term "port"

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,36 +1,73 @@
-BITBUCKET_CLIENT_ID=01234567890123456789
-BITBUCKET_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-BITBUCKET_SCOPE=repository:write
-BITBUCKET_WORKSPACE=workspace_name
-
+# these keys are used to protect communication between the application and the server
+# you should generate unique values for each key using the command 'openssl rand -base64 32'
 ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'
 ENCRYPTION_JWT_SIGNING_KEY=asdfasdfasdf
 ENCRYPTION_JWT_REFRESH_SIGNING_KEY=fljasdlfkjadf
 
-GITHUB_CLIENT_ID=01234567890123456789
-GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GITHUB_ENTERPRISE_HOSTNAME=optional_if_using_enterprise
-GITHUB_ENTERPRISE_PORT=optional_if_enterprise_and_non_standard
-GITHUB_ENTERPRISE_PROTOCOL=optional_if_enterprise_and_non_standard
-GITHUB_SCOPE=public_repo
+# optional runtime environment specifier
+# valid values are 'production', 'development', 'test', 'simulated_production'
+# non-production environments change some URL paths and environment variable defaults
+# default is production
+NODE_ENV=production
 
-GITLAB_CLIENT_ID=01234567890123456789
-GITLAB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GITLAB_SCOPE=read_user read_repository write_repository profile read_api api
-GITLAB_REDIRECT_URI=http://localhost:3000/api/oauth/return
+# Express API server configuration
+# optional, valid values are 'http' or 'https', default is 'https'
+SERVER_API_PROTOCOL=https
 
-GOOGLE_CLIENT_ID=01234567890123456789
-GOOGLE_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GOOGLE_SCOPE=openid email profile
-GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return
+# optional, allows control of the port that the server listens on
+# default is 3000
+SERVER_API_PORT=3000
 
-NODE_ENV=development
-SERVER_API_PROTOCOL=http
-# FQDN hostname needed to run if using domain
-APP_HOSTNAME=example.com
+# deprecated but maintained for backwards compatibility
+# ignored when SERVER_API_PORT is used, default is 3000
+# PORT=3000
 
-# variables needed for tls configurations
-APP_PORT=443
-APP_USE_TLS=true
-APP_TLS_CERT_PATH=/path/to/certificate.pem
-APP_TLS_KEY_PATH=/path/to/privatekey.pem
+# front-end application configuration
+# optional FQDN hostname; required if using TLS, default is localhost
+APP_HOSTNAME=threatdragon.example.com
+
+# optional network port for front-end application, required if using TLS
+# using a port < 1024 requires granting the cap_net_bind_service capability to the node binary
+APP_PORT = 8080
+
+# required to enable TLS, omit for http
+# APP_USE_TLS=true
+
+# required to enable TLS, omit for http
+# node application must have RO access to these two files
+# APP_TLS_CERT_PATH=/path/to/certificate.pem
+# APP_TLS_KEY_PATH=/path/to/privatekey.pem
+
+# configuration needed to use BitBucket auth and storage
+# do not modify the BITBUCKET_SCOPE variable
+# obtain other values from BitBucket
+# BITBUCKET_SCOPE=repository:write
+# BITBUCKET_CLIENT_ID=01234567890123456789
+# BITBUCKET_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# BITBUCKET_WORKSPACE=workspace_name
+
+# configuration needed to use GitHub auth and storage
+# do not modify the GITHUB_SCOPE variable
+# obtain other values from GitHub
+# GITHUB_SCOPE=public_repo
+# GITHUB_CLIENT_ID=01234567890123456789
+# GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GITHUB_ENTERPRISE_HOSTNAME=optional_if_using_enterprise
+# GITHUB_ENTERPRISE_PORT=optional_if_enterprise_and_non_standard
+# GITHUB_ENTERPRISE_PROTOCOL=optional_if_enterprise_and_non_standard
+
+# configuration needed to use GitLab auth and storage
+# do not modify the GITLAB_SCOPE variable
+# obtain other values from GitLab
+# GITLAB_SCOPE=read_user read_repository write_repository profile read_api api
+# GITLAB_CLIENT_ID=01234567890123456789
+# GITLAB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GITLAB_REDIRECT_URI=http://localhost:3000/api/oauth/return
+
+# configuration needed to use Google auth and Google Drive storage
+# do not modify the GOOGLE_SCOPE variable
+# obtain the other values from https://console.cloud.google.com/auth
+# GOOGLE_SCOPE=openid email profile drive docs
+# GOOGLE_CLIENT_ID=01234567890123456789
+# GOOGLE_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return

--- a/example.env
+++ b/example.env
@@ -20,7 +20,7 @@ SERVER_API_PORT=3000
 
 # deprecated but maintained for backwards compatibility
 # ignored when SERVER_API_PORT is used, default is 3000
-# PORT=3000
+PORT=3000
 
 # front-end application configuration
 # optional FQDN hostname; required if using TLS, default is localhost
@@ -28,7 +28,7 @@ APP_HOSTNAME=threatdragon.example.com
 
 # optional network port for front-end application, required if using TLS
 # using a port < 1024 requires granting the cap_net_bind_service capability to the node binary
-APP_PORT = 8080
+APP_PORT=8080
 
 # required to enable TLS, omit for http
 # APP_USE_TLS=true

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -58,8 +58,9 @@ const create = () => {
         // routes
         routes.config(app);
 
-        // env will always supply a value for the PORT
-        app.set('port', env.get().config.PORT);
+        // get port for the Express server to listen on
+        const serverApiPort = env.get().SERVER_API_PORT || env.get().PORT || '3000';
+        app.set('port', serverApiPort);
         logger.info('Express server listening on ' + app.get('port'));
 
         logger.info('OWASP Threat Dragon application started');

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -14,6 +14,7 @@ class ThreatDragonEnv extends Env {
     get properties () {
         return [
             { key: 'NODE_ENV', required: false, defaultValue:  'production'},
+            { key: 'SERVER_API_PORT', required: false, defaultValue: '' },
             { key: 'PORT', required: false, defaultValue: 3000 },
             { key: 'LOG_MAX_FILE_SIZE', required: false, defaultValue: 24 },
             { key: 'LOG_LEVEL', required: false, defaultValue: 'warn' },

--- a/td.server/src/healthcheck.js
+++ b/td.server/src/healthcheck.js
@@ -6,7 +6,8 @@ import loggerHelper from 'helpers/logger.helper.js';
 const logger = loggerHelper.get('healthcheck.js');
 const http = require('http');
 
-const req = (env.get().config.SERVER_API_PROTOCOL || 'https') + '://localhost:' + (env.get().config.PORT || '3000') + '/healthz';
+const serverApiPort = env.get().config.SERVER_API_PORT || env.get().config.PORT || 3000;
+const req = (env.get().config.SERVER_API_PROTOCOL || 'https') + '://localhost:' + serverApiPort + '/healthz';
 
 http.get(req, (res) => {
     const { statusCode } = res;

--- a/td.server/test/env/ThreatDragon.spec.js
+++ b/td.server/test/env/ThreatDragon.spec.js
@@ -36,6 +36,20 @@ describe('env/ThreatDragon.js', () => {
         expect(value).to.equal('production');
     });
 
+    it('has the optional property SERVER_API_PORT', () => {
+        const isRequired = tdEnv.properties
+            .find(x => x.key === 'SERVER_API_PORT')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has a default value for property SERVER_API_PORT', () => {
+        const value = tdEnv.properties
+            .find(x => x.key === 'SERVER_API_PORT')
+            .defaultValue;
+        expect(value).to.equal('');
+    });
+
     it('has the optional property PORT', () => {
         const isRequired = tdEnv.properties
             .find(x => x.key === 'PORT')

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -28,7 +28,6 @@ if (hasTlsCredentials) {
     }
 }
 
-let port;
 const devServerConfig = hasTlsCredentials
     ? {
         https: httpsConfig,
@@ -54,9 +53,8 @@ const devServerConfig = hasTlsCredentials
         },
         allowedHosts: [appHostname],
     };
-port = devServerConfig.port;
 
-console.log(`App server running on ${hasTlsCredentials ? `HTTPS (Port ${port})` : `HTTP (Port ${port})`}`);
+console.log(`App server running on ${hasTlsCredentials ? `HTTPS (Port ${devServerConfig.port})` : `HTTP (Port ${devServerConfig.port})`}`);
 
 
 module.exports = {

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 require('dotenv').config({ path: process.env.ENV_FILE || path.resolve(__dirname, '../.env') });
 const serverApiProtocol = process.env.SERVER_API_PROTOCOL || 'http';
 const serverApiPort = process.env.SERVER_API_PORT || process.env.PORT || '3000';
-const PORT = process.env.APP_PORT || '8080';
+const appPort = process.env.APP_PORT || '8080';
 const appHostname = process.env.APP_HOSTNAME || 'localhost';
 console.log('Server API protocol: ' + serverApiProtocol + ' and port: ' + serverApiPort);
 
@@ -19,7 +19,7 @@ const devServerConfig = hasTlsCredentials
             key: fs.readFileSync(process.env.APP_TLS_KEY_PATH),
             cert: fs.readFileSync(process.env.APP_TLS_CERT_PATH),
         },
-        port: PORT,
+        port: appPort,
         proxy: {
             '^/api': {
                 target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server
@@ -31,7 +31,7 @@ const devServerConfig = hasTlsCredentials
     }
     : {
         // note that client webSocketURL config has been removed, as it was incompatible with desktop version
-        port: 8080,
+        port: appPort,
         proxy: {
             '^/api': {
                 target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server


### PR DESCRIPTION
**Summary**:
Cleans up vue.config.js to make clear what different "port" values are used for
Adds error checking for reading TLS certificate/key files
Fixes up references to renamed "PORT" variable in server app & tests
Reorganizes and heavily comments example.env 

**Description for the changelog**:
Make configuration of custom ports easier and more understandable