### PR TITLE
Bug fix for unexpected label on Trust Boundary Box

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -22,3 +22,6 @@ https://www.linddun.org/
 
 # Too many redirects: error following redirect for docker tags
 https://hub.docker.com/repository/docker/threatdragon/owasp-threat-dragon/tags
+
+# this may not be available for drafts
+https://github.com/OWASP/threat-dragon/compare

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -1,7 +1,5 @@
 import { Shape } from '@antv/x6';
 
-import { tc } from '@/i18n/index.js';
-
 const name = 'trust-boundary-box';
 
 // trust boundary box (dotted line, transparent background)
@@ -20,7 +18,7 @@ export const TrustBoundaryBox = Shape.Rect.define({
             fillOpacity: 0
         },
         label: {
-            text: tc('threatmodel.shapes.trustBoundary'),
+            text: '',
             textAnchor : 'bottom',
             textVerticalAnchor : 'top',
             refX: '15%',


### PR DESCRIPTION
**Summary**:
Bug fix for unexpected label on Trust Boundary Box - does nto apply the label 'Trust Boundary Box' when this label did not appear before

**Description for the changelog**:
Bug fix for unexpected label on Trust Boundary Box

**Other info**:
closes #1230 