### PR TITLE
Clean up, add error checking, remove ambiguity around term "port"

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,36 +1,73 @@
-BITBUCKET_CLIENT_ID=01234567890123456789
-BITBUCKET_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-BITBUCKET_SCOPE=repository:write
-BITBUCKET_WORKSPACE=workspace_name
-
+# these keys are used to protect communication between the application and the server
+# you should generate unique values for each key using the command 'openssl rand -base64 32'
 ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'
 ENCRYPTION_JWT_SIGNING_KEY=asdfasdfasdf
 ENCRYPTION_JWT_REFRESH_SIGNING_KEY=fljasdlfkjadf
 
-GITHUB_CLIENT_ID=01234567890123456789
-GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GITHUB_ENTERPRISE_HOSTNAME=optional_if_using_enterprise
-GITHUB_ENTERPRISE_PORT=optional_if_enterprise_and_non_standard
-GITHUB_ENTERPRISE_PROTOCOL=optional_if_enterprise_and_non_standard
-GITHUB_SCOPE=public_repo
+# optional runtime environment specifier
+# valid values are 'production', 'development', 'test', 'simulated_production'
+# non-production environments change some URL paths and environment variable defaults
+# default is production
+NODE_ENV=production
 
-GITLAB_CLIENT_ID=01234567890123456789
-GITLAB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GITLAB_SCOPE=read_user read_repository write_repository profile read_api api
-GITLAB_REDIRECT_URI=http://localhost:3000/api/oauth/return
+# Express API server configuration
+# optional, valid values are 'http' or 'https', default is 'https'
+SERVER_API_PROTOCOL=https
 
-GOOGLE_CLIENT_ID=01234567890123456789
-GOOGLE_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
-GOOGLE_SCOPE=openid email profile
-GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return
+# optional, allows control of the port that the server listens on
+# default is 3000
+SERVER_API_PORT=3000
 
-NODE_ENV=development
-SERVER_API_PROTOCOL=http
-# FQDN hostname needed to run if using domain
-APP_HOSTNAME=example.com
+# deprecated but maintained for backwards compatibility
+# ignored when SERVER_API_PORT is used, default is 3000
+# PORT=3000
 
-# variables needed for tls configurations
-APP_PORT=443
-APP_USE_TLS=true
-APP_TLS_CERT_PATH=/path/to/certificate.pem
-APP_TLS_KEY_PATH=/path/to/privatekey.pem
+# front-end application configuration
+# optional FQDN hostname; required if using TLS, default is localhost
+APP_HOSTNAME=threatdragon.example.com
+
+# optional network port for front-end application, required if using TLS
+# using a port < 1024 requires granting the cap_net_bind_service capability to the node binary
+APP_PORT = 8080
+
+# required to enable TLS, omit for http
+# APP_USE_TLS=true
+
+# required to enable TLS, omit for http
+# node application must have RO access to these two files
+# APP_TLS_CERT_PATH=/path/to/certificate.pem
+# APP_TLS_KEY_PATH=/path/to/privatekey.pem
+
+# configuration needed to use BitBucket auth and storage
+# do not modify the BITBUCKET_SCOPE variable
+# obtain other values from BitBucket
+# BITBUCKET_SCOPE=repository:write
+# BITBUCKET_CLIENT_ID=01234567890123456789
+# BITBUCKET_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# BITBUCKET_WORKSPACE=workspace_name
+
+# configuration needed to use GitHub auth and storage
+# do not modify the GITHUB_SCOPE variable
+# obtain other values from GitHub
+# GITHUB_SCOPE=public_repo
+# GITHUB_CLIENT_ID=01234567890123456789
+# GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GITHUB_ENTERPRISE_HOSTNAME=optional_if_using_enterprise
+# GITHUB_ENTERPRISE_PORT=optional_if_enterprise_and_non_standard
+# GITHUB_ENTERPRISE_PROTOCOL=optional_if_enterprise_and_non_standard
+
+# configuration needed to use GitLab auth and storage
+# do not modify the GITLAB_SCOPE variable
+# obtain other values from GitLab
+# GITLAB_SCOPE=read_user read_repository write_repository profile read_api api
+# GITLAB_CLIENT_ID=01234567890123456789
+# GITLAB_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GITLAB_REDIRECT_URI=http://localhost:3000/api/oauth/return
+
+# configuration needed to use Google auth and Google Drive storage
+# do not modify the GOOGLE_SCOPE variable
+# obtain the other values from https://console.cloud.google.com/auth
+# GOOGLE_SCOPE=openid email profile drive docs
+# GOOGLE_CLIENT_ID=01234567890123456789
+# GOOGLE_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
+# GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return

--- a/example.env
+++ b/example.env
@@ -20,7 +20,7 @@ SERVER_API_PORT=3000
 
 # deprecated but maintained for backwards compatibility
 # ignored when SERVER_API_PORT is used, default is 3000
-# PORT=3000
+PORT=3000
 
 # front-end application configuration
 # optional FQDN hostname; required if using TLS, default is localhost
@@ -28,7 +28,7 @@ APP_HOSTNAME=threatdragon.example.com
 
 # optional network port for front-end application, required if using TLS
 # using a port < 1024 requires granting the cap_net_bind_service capability to the node binary
-APP_PORT = 8080
+APP_PORT=8080
 
 # required to enable TLS, omit for http
 # APP_USE_TLS=true

--- a/example.env
+++ b/example.env
@@ -1,8 +1,8 @@
 # these keys are used to protect communication between the application and the server
-# you should generate unique values for each key using the command 'openssl rand -base64 32'
-ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'
-ENCRYPTION_JWT_SIGNING_KEY=asdfasdfasdf
-ENCRYPTION_JWT_REFRESH_SIGNING_KEY=fljasdlfkjadf
+# you should generate unique values for each key using the command 'openssl rand -hex 16'
+ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef0123456"}]'
+ENCRYPTION_JWT_SIGNING_KEY=0123456789abcdef0123456789abcdef0123456
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY=0123456789abcdef0123456789abcdef0123456
 
 # optional runtime environment specifier
 # valid values are 'production', 'development', 'test', 'simulated_production'
@@ -11,29 +11,37 @@ ENCRYPTION_JWT_REFRESH_SIGNING_KEY=fljasdlfkjadf
 NODE_ENV=production
 
 # Express API server configuration
-# optional, valid values are 'http' or 'https', default is 'https'
+# optional, determines whether the server will use https when checking application health
+# may need to use https if the application is hosted behind a TLS proxy or load balancer
+# valid values are 'http' or 'https', default is 'https'
 SERVER_API_PROTOCOL=https
 
-# optional, allows control of the port that the server listens on
-# default is 3000
+# optional, allows control of the port that the server listens on, default is 3000
 SERVER_API_PORT=3000
 
 # deprecated but maintained for backwards compatibility
+# this value has been renamed to SERVER_API_PORT
 # ignored when SERVER_API_PORT is used, default is 3000
-PORT=3000
+# PORT=3000
 
-# front-end application configuration
-# optional FQDN hostname; required if using TLS, default is localhost
+# optional, allows proxy/load balancer hostname to differ from local hostname
+# this is useful when using https to the LB/proxy AND https from the proxy to the app server
+# or when the API server resolves the local hostname to the load balancer/proxy IP
+# setting this correctly to the proxy/LB name will avoid "invalid host header" errors
+PROXY_HOSTNAME=threatdragon.example.com
+
+# front-end application webpack dev server configuration
+# optional FQDN hostname; required if using TLS locally, default is localhost
 APP_HOSTNAME=threatdragon.example.com
 
 # optional network port for front-end application, required if using TLS
 # using a port < 1024 requires granting the cap_net_bind_service capability to the node binary
 APP_PORT=8080
 
-# required to enable TLS, omit for http
+# required to enable TLS to the application, omit for http
 # APP_USE_TLS=true
 
-# required to enable TLS, omit for http
+# required if https is enabled, omit for http
 # node application must have RO access to these two files
 # APP_TLS_CERT_PATH=/path/to/certificate.pem
 # APP_TLS_KEY_PATH=/path/to/privatekey.pem
@@ -65,9 +73,8 @@ APP_PORT=8080
 # GITLAB_REDIRECT_URI=http://localhost:3000/api/oauth/return
 
 # configuration needed to use Google auth and Google Drive storage
-# do not modify the GOOGLE_SCOPE variable
-# obtain the other values from https://console.cloud.google.com/auth
-# GOOGLE_SCOPE=openid email profile drive docs
+# Settings for Google auth provider (Google Sign In)
+# Obtain these values here: https://console.cloud.google.com/auth/overview
 # GOOGLE_CLIENT_ID=01234567890123456789
 # GOOGLE_CLIENT_SECRET=0123456789abcdef0123456789abcdef0123456
 # GOOGLE_REDIRECT_URI=http://localhost:3000/api/oauth/return

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -59,7 +59,7 @@ const create = () => {
         routes.config(app);
 
         // get port for the Express server to listen on
-        const serverApiPort = parseInt(env.get().SERVER_API_PORT || env.get().PORT || '3000', 10);
+        const serverApiPort = parseInt(env.get().SERVER_API_PORT || env.get().PORT || '3000');
         app.set('port', serverApiPort);
         logger.info('Express server listening on ' + app.get('port'));
 

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -58,8 +58,9 @@ const create = () => {
         // routes
         routes.config(app);
 
-        // env will always supply a value for the PORT
-        app.set('port', env.get().config.PORT);
+        // get port for the Express server to listen on
+        const serverApiPort = env.get().SERVER_API_PORT || env.get().PORT || '3000';
+        app.set('port', serverApiPort);
         logger.info('Express server listening on ' + app.get('port'));
 
         logger.info('OWASP Threat Dragon application started');

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -59,7 +59,7 @@ const create = () => {
         routes.config(app);
 
         // get port for the Express server to listen on
-        const serverApiPort = parseInt(env.get().SERVER_API_PORT || env.get().PORT || '3000');
+        const serverApiPort = parseInt(env.get().SERVER_API_PORT || env.get().PORT || '3000', 10);
         app.set('port', serverApiPort);
         logger.info('Express server listening on ' + app.get('port'));
 

--- a/td.server/src/app.js
+++ b/td.server/src/app.js
@@ -59,7 +59,7 @@ const create = () => {
         routes.config(app);
 
         // get port for the Express server to listen on
-        const serverApiPort = env.get().SERVER_API_PORT || env.get().PORT || '3000';
+        const serverApiPort = parseInt(env.get().SERVER_API_PORT || env.get().PORT || '3000', 10);
         app.set('port', serverApiPort);
         logger.info('Express server listening on ' + app.get('port'));
 

--- a/td.server/src/env/Google.js
+++ b/td.server/src/env/Google.js
@@ -14,7 +14,6 @@ class GoogleEnv extends Env {
         return [
             { key: 'CLIENT_ID', required: false },
             { key: 'CLIENT_SECRET', required: false },
-            { key: 'SCOPE', required: false, defaultValue: 'openid email profile' },
             { key: 'REDIRECT_URI', required: false, defaultValue: 'http://localhost:3000/api/oauth/return' },
             { key: 'TOKEN_URL', required: false, defaultValue: 'https://oauth2.googleapis.com/token' },
             { key: 'USER_INFO_URL', required: false, defaultValue: 'https://www.googleapis.com/oauth2/v1/userinfo' }

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -14,6 +14,7 @@ class ThreatDragonEnv extends Env {
     get properties () {
         return [
             { key: 'NODE_ENV', required: false, defaultValue:  'production'},
+            { key: 'SERVER_API_PORT', required: false, defaultValue: '' },
             { key: 'PORT', required: false, defaultValue: 3000 },
             { key: 'LOG_MAX_FILE_SIZE', required: false, defaultValue: 24 },
             { key: 'LOG_LEVEL', required: false, defaultValue: 'warn' },

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -14,7 +14,7 @@ class ThreatDragonEnv extends Env {
     get properties () {
         return [
             { key: 'NODE_ENV', required: false, defaultValue:  'production'},
-            { key: 'SERVER_API_PORT', required: false, defaultValue: '' },
+            { key: 'SERVER_API_PORT', required: false, defaultValue: 3000 },
             { key: 'PORT', required: false, defaultValue: 3000 },
             { key: 'LOG_MAX_FILE_SIZE', required: false, defaultValue: 24 },
             { key: 'LOG_LEVEL', required: false, defaultValue: 'warn' },

--- a/td.server/src/healthcheck.js
+++ b/td.server/src/healthcheck.js
@@ -6,7 +6,8 @@ import loggerHelper from 'helpers/logger.helper.js';
 const logger = loggerHelper.get('healthcheck.js');
 const http = require('http');
 
-const req = (env.get().config.SERVER_API_PROTOCOL || 'https') + '://localhost:' + (env.get().config.PORT || '3000') + '/healthz';
+const serverApiPort = env.get().config.SERVER_API_PORT || env.get().config.PORT || 3000;
+const req = (env.get().config.SERVER_API_PROTOCOL || 'https') + '://localhost:' + serverApiPort + '/healthz';
 
 http.get(req, (res) => {
     const { statusCode } = res;

--- a/td.server/src/providers/google.js
+++ b/td.server/src/providers/google.js
@@ -18,7 +18,7 @@ const isConfigured = () => Boolean(env.get().config.GOOGLE_CLIENT_ID);
  * @returns {String}
  */
 const getOauthRedirectUrl = () => {
-    const scope = env.get().config.GOOGLE_SCOPE || 'openid email profile';
+    const scope = 'openid email profile';
     const redirectUri = env.get().config.GOOGLE_REDIRECT_URI;
     return `https://accounts.google.com/o/oauth2/auth?response_type=code&scope=${scope}&client_id=${env.get().config.GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 };

--- a/td.server/test/env/ThreatDragon.spec.js
+++ b/td.server/test/env/ThreatDragon.spec.js
@@ -36,6 +36,20 @@ describe('env/ThreatDragon.js', () => {
         expect(value).to.equal('production');
     });
 
+    it('has the optional property SERVER_API_PORT', () => {
+        const isRequired = tdEnv.properties
+            .find(x => x.key === 'SERVER_API_PORT')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has a default value for property SERVER_API_PORT', () => {
+        const value = tdEnv.properties
+            .find(x => x.key === 'SERVER_API_PORT')
+            .defaultValue;
+        expect(value).to.equal('');
+    });
+
     it('has the optional property PORT', () => {
         const isRequired = tdEnv.properties
             .find(x => x.key === 'PORT')

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -28,7 +28,6 @@ if (hasTlsCredentials) {
     }
 }
 
-let port;
 const devServerConfig = hasTlsCredentials
     ? {
         https: httpsConfig,
@@ -54,9 +53,8 @@ const devServerConfig = hasTlsCredentials
         },
         allowedHosts: [appHostname],
     };
-port = devServerConfig.port;
 
-console.log(`App server running on ${hasTlsCredentials ? `HTTPS (Port ${port})` : `HTTP (Port ${port})`}`);
+console.log(`App server running on ${hasTlsCredentials ? `HTTPS (Port ${devServerConfig.port})` : `HTTP (Port ${devServerConfig.port})`}`);
 
 
 module.exports = {

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 require('dotenv').config({ path: process.env.ENV_FILE || path.resolve(__dirname, '../.env') });
 const serverApiProtocol = process.env.SERVER_API_PROTOCOL || 'http';
 const serverApiPort = process.env.SERVER_API_PORT || process.env.PORT || '3000';
-const PORT = process.env.APP_PORT || '8080';
+const appPort = process.env.APP_PORT || '8080';
 const appHostname = process.env.APP_HOSTNAME || 'localhost';
 console.log('Server API protocol: ' + serverApiProtocol + ' and port: ' + serverApiPort);
 
@@ -19,7 +19,7 @@ const devServerConfig = hasTlsCredentials
             key: fs.readFileSync(process.env.APP_TLS_KEY_PATH),
             cert: fs.readFileSync(process.env.APP_TLS_CERT_PATH),
         },
-        port: PORT,
+        port: appPort,
         proxy: {
             '^/api': {
                 target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server
@@ -31,7 +31,7 @@ const devServerConfig = hasTlsCredentials
     }
     : {
         // note that client webSocketURL config has been removed, as it was incompatible with desktop version
-        port: 8080,
+        port: appPort,
         proxy: {
             '^/api': {
                 target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server


### PR DESCRIPTION
**Summary**:

Restores the changes from pull-request https://github.com/OWASP/threat-dragon/pull/1228 which was temporarily reverted during the release of version 2.4.1

- Fixes the test breakage issues from the original PR in issue #1228
- Cleans up and comments vue.config.js to make clear what the different "port" values are used for
- Adds error checking to vue.config.js for reading TLS certificate/key files
- Fixes up references to renamed "PORT" variable in server app & tests
- Reorganizes and heavily comments example.env
- Adds a PROXY_HOSTNAME environment variable for situations where Express resolves the local hostname to a proxy/load balancer IP, or where the application is listening on https behind an https proxy
- Hard codes Google auth scope; removes variable
- No AI was used for this set of changes

**Description for the changelog**:

Make configuration of custom ports easier and more understandable.  Closes #1240

**Declaration**:

- [X] appropriate unit tests have been created / modified
- [X] functional tests created / modified for changes in functionality
- [X] any use of AI has been declared in this pull request

**Other info**:
The original merge that was reverted, should not be re-merged.  This PR includes all the original changes, modified to fix the test breakage issue that the original PR was causing.

Thanks for submitting a pull request!
Please make sure you follow our [Code of Conduct](../code_of_conduct.md)
and our [contributing guidelines](../contributing.md)
