### PR TITLE
Update el.js

### DIFF
--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -74,8 +74,8 @@ const ell = {
             submit: 'Υποβάλετε ένα πρόβλημα',
             check: 'Έλεγχος για ενημερώσεις ...',
             about: {
-                about: 'About',
-                version: 'Version'
+                about: 'Σχετικά',
+                version: 'Έκδοση'
             }
         }
     },
@@ -98,6 +98,11 @@ const ell = {
         cancel: 'Ακύρωση',
         name: 'Όνομα υποκαταστήματος',
     },
+    folder: {
+        select: 'Επιλέξτε ένα',
+        from: 'φάκελο από την παρακάτω λίστα',
+        noneFound: 'Αυτός ο φάκελος είναι κενός, μπορείτε να δημιουργήσετε ένα νέο μοντέλο απειλών εδώ.'
+    },
     threatmodelSelect: {
         select: 'Επιλέξτε ένα μοντέλο απειλών από',
         from: 'από την παρακάτω λίστα, ή επιλέξτε ένα άλλο',
@@ -110,7 +115,7 @@ const ell = {
         contributors: 'Συνεισφέροντες',
         contributorsPlaceholder: 'Προσθήκη ενός νέου συνεισφέροντος',
         description: 'Περιγραφή Συστήματος Υψηλού Επιπέδου',
-        dragAndDrop: 'Drag and drop or ',
+        dragAndDrop: 'Μεταφορά & απόθεση ή ',
         editing: 'Υπό επεξεργασία',
         jsonPaste: 'Κάντε επικόλληση (Paste) του JSON από το μοντέλο απειλών σας εδώ',
         owner: 'Ιδιοκτήτης',
@@ -122,7 +127,7 @@ const ell = {
             generic: {
                 defaultTitle: 'Νέο γενικό διάγραμμα',
                 defaultDescription: 'Περιγραφή νέου γενικού διαγράμματος',
-                select: 'Generic'
+                select: 'Γενικό'
             },
             stride: {
                 defaultTitle: 'Νέο διάγραμμα STRIDE',
@@ -169,12 +174,12 @@ const ell = {
             outOfScope: 'Εκτός πεδίου εφαρμογής',
             bidirection: 'Αμφίδρομο',
             reasonOutOfScope: 'Λόγος εκτός πεδίου εφαρμογής',
-            handlesCardPayment: 'Card payment',
-            handlesGoodsOrServices: 'Goods or Services',
+            handlesCardPayment: 'Πληρωμή κάρτας',
+            handlesGoodsOrServices: 'Αγαθά ή υπηρεσίες',
             isALog: 'Είναι αρχείο καταγραφής',
             isEncrypted: 'Κρυπτογραφημένο',
             isSigned: 'Υπογεγραμμένο',
-            isWebApplication: 'Web Application',
+            isWebApplication: 'Web Εφαρμογή',
             privilegeLevel: 'Επίπεδο δικαιώματος',
             providesAuthentication: 'Παρέχει αυθεντικοποίηση',
             protocol: 'Πρωτόκολλο',
@@ -227,7 +232,7 @@ const ell = {
             },
             save: {
                 shortcut: '(ctrl/cmd) + s',
-                action: 'Save'
+                action: 'Αποθήκευση'
             }
         },
         stencil: {
@@ -257,10 +262,11 @@ const ell = {
         discardTitle: 'Απόρριψη αλλαγών;',
         discardMessage: 'Είστε σίγουροι ότι θέλετε να απορρίψετε τις αλλαγές;',
         edit: 'Επεξεργασία',
-        exportAs: 'Export Model As',
+        export: 'Εξαγωγή',
+        exportAs: 'Εξαγωγή Μοντέλου Ως',
         exportHtml: 'Αναφορά HTML',
         exportPdf: 'Αναφορά PDF',
-        exportTd: 'Original (Threat Dragon)',
+        exportTd: 'Πρωτότυπο (Threat Dragon)',
         exportOtm: 'Open Threat Model (OTM)',
         import: 'Εισαγωγή',
         ok: 'OK',
@@ -361,7 +367,7 @@ const ell = {
             low: 'Χαμηλή',
             medium: 'Μεσαία',
             high: 'Υψηλή',
-            critical: 'Κρίσιμος'
+            critical: 'Κρίσιμη'
         }
     },
     report: {
@@ -370,7 +376,7 @@ const ell = {
             showMitigatedThreats: 'Εμφάνιση απειλών που έχουν μετριαστεί',
             showModelDiagrams: 'Εμφάνιση διαγραμμάτων μοντέλων',
             showEmpty: 'Προβολή κενών στοιχείων',
-            showProperties: 'Show element properties',
+            showProperties: 'Προβολή ιδιοτήτων στοιχείου',
             showBranding: 'Λογότυπο Threat Dragon'
         },
         title: 'Αναφορά μοντέλου απειλών για',


### PR DESCRIPTION
Several strings updated for the Greek translation. Also added lines 101-105 that are in the English version.
Please ignore PR #1287 
Note that string 'duplicate' ('Διππλότυπο' or 'Διπλότυπη' in Greek, depending on the context) mentioned here was not found in en.js: https://github.com/OWASP/threat-dragon/issues/1286#issuecomment-2897270674

Summary:
Updated several strings for the Greek translation

Description for the changelog:
See diff for the exact changes

Declaration:

appropriate unit tests have been created / modified
functional tests created / modified for changes in functionality
any use of AI has been declared in this pull request: No AI used, the translation was manual.