### PR TITLE
Bug/duplicated diagram overwrites original

### DIFF
--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -330,7 +330,7 @@ export default {
             this.$store.dispatch(tmActions.modified);
         },
         onDuplicateDiagramClick(idx) {
-            let newDiagram = this.model.detail.diagrams[idx];
+            let newDiagram = JSON.parse(JSON.stringify(this.model.detail.diagrams[idx]));
             newDiagram.id = this.diagramTop;
             this.$store.dispatch(tmActions.update, { diagramTop: this.diagramTop + 1 });
             this.model.detail.diagrams.push(newDiagram);

--- a/td.vue/tests/unit/views/threatmodelEdit.spec.js
+++ b/td.vue/tests/unit/views/threatmodelEdit.spec.js
@@ -236,6 +236,20 @@ describe('views/ThreatmodelEdit.vue', () => {
             });
         });
 
+        describe('duplicate diagram', () => {
+            let diagramCount, link;
+
+            beforeEach(async () => {
+                diagramCount = diagrams.length;
+                link = wrapper.find('.td-duplicate-diagram')
+                await link.trigger('click', evt);
+            });
+
+            it('duplicates the diagram', () => {
+                expect(mockStore.state.threatmodel.data.detail.diagrams).toHaveLength(diagramCount + 1)
+            })
+        })
+
         describe('remove diagram', () => {
             let diagramCount, link;
 


### PR DESCRIPTION
**Summary**:
Modified the function that duplicates the diagram to create a deep copy of the original diagram, so changes to the copy will no longer affect the original :
- Fixed bug where copy affected the original.
- Added unit test for the diagram duplicate button.


**Description for the changelog**:
bug fix for duplicated diagram overwriting original

**Declaration**:

- [x] appropriate unit tests have been created / modified
- [x] functional tests created / modified for changes in functionality
- [x] any use of AI has been declared in this pull request

**Other info**:
closes #1296 

