### PR TITLE
Enable TM-BOM import

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -12,3 +12,7 @@ CVE-2023-28155
 # alpine 3.20.3 is pulling in a Low priority vuln for libcrypto3 version 3.3.2-r2,
 # ignore for now until alpine is updated
 CVE-2024-9143
+
+# https://avd.aquasec.com/nvd/2025/cve-2025-7783/
+# no fix available for MacOS
+CVE-2025-7783

--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -166,7 +166,7 @@ const ara = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'نماذج التهديد الإصدار 2.0 غير متوافقة مع الإصدارات السابقة مع نماذج Threat Dragon للإصدار x.1 من ستتم ترقية نماذج الإصدار x.1 المستوردة إلى مخطط الإصدار 2.0،'
         },
         prompts: {

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -166,7 +166,7 @@ const deu = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Importierte Version 1.x Modelle werden auf das Version 2.0 Schema gehoben' //in line with wording of BSI Leitfaden zur Entwicklung sicherer Webanwendungen
         },
         prompts: {

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -166,7 +166,7 @@ const ell = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Τα εισαχθέντα μοντέλα της έκδοσης 1.x models θα αναβαθμιστούν στο σχήμα της έκδοσης 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -166,7 +166,7 @@ const eng = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Imported version 1.x models will be upgraded to the version 2.0 schema'
         },
         prompts: {

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -166,7 +166,7 @@ const spa = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Los modelos importados de la versión 1.x serán actualizados acorde al esquema de la versión 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -166,7 +166,7 @@ const fin = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Version 1.x mallit päivitetään automaattisesti version 2.0 uhkamalleiksi.'
         },
         prompts: {

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -166,7 +166,7 @@ const fra = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Imported version 1.x models will be upgraded to the version 2.0 schema'
         },
         prompts: {

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -166,7 +166,7 @@ const hin = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Imported version 1.x models will be upgraded to the version 2.0 schema'
         },
         prompts: {

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -166,7 +166,7 @@ const ind = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Model versi 1.x yang diimpor akan ditingkatkan ke skema versi 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -166,7 +166,7 @@ const jpn = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'バージョン1.xのモデルは、インポート時にバージョン2.0のフォーマットに変換されます。'
         },
         prompts: {

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -166,7 +166,7 @@ const ms = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Model versi 1.x yang diimport akan dinaik tarafkan ke skema versi 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -166,7 +166,7 @@ const por = {
         warnings: {
             jsonSchema: 'Modelo não corresponde estritamente com o esquema. Detalhes no console do desenvolvedor',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Importar modelos versão 1.x serão atualizadas para os esquemas versão 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -166,7 +166,7 @@ const rus = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Imported version 1.x models will be upgraded to the version 2.0 schema'
         },
         prompts: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -166,7 +166,7 @@ const ukr = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: 'Imported version 1.x models will be upgraded to the version 2.0 schema'
         },
         prompts: {

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -166,7 +166,7 @@ const zho = {
         warnings: {
             jsonSchema: 'Model does not strictly match schema. Details from the developer console',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
-            tmUnsupported: 'Import of TM-BOM file format not yet supported',
+            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
             v1Translate: '导入的 1.x 版模型将升级到 2.0 版本'
         },
         prompts: {

--- a/td.vue/src/service/demo/huskyai.tmbom.json
+++ b/td.vue/src/service/demo/huskyai.tmbom.json
@@ -23,14 +23,14 @@
     ],
     "trust_zones": [
         {
-            "symbolic_name": "prod-zone",
-            "title": "Production Trust Zone",
-            "description": "Internal VPC with the production deployment of HuskyAI"
-        },
-        {
             "symbolic_name": "experimental-zone",
             "title": "Experimental Trust Zone",
             "description": "Internal VPC with the experimental and development deployment for HuskyAI"
+        },
+        {
+            "symbolic_name": "prod-zone",
+            "title": "Production Trust Zone",
+            "description": "Internal VPC with the production deployment of HuskyAI"
         }
     ],
     "trust_boundaries": [
@@ -165,15 +165,6 @@
             "product": "Blob"
         },
         {
-            "symbolic_name": "source-code-config-storage",
-            "title": "Source Code\nand Configuration",
-            "description": "Stores source code and configuration files for deployment and production setup.",
-            "type": "object",
-            "trust_zone": "experimental-zone",
-            "vendor": "GitHub",
-            "product": "GitHub Repositories"
-        },
-        {
             "symbolic_name": "ml-models",
             "title": "Machine\nLearning Model",
             "description": "Contains the machine learning models in serialized format.",
@@ -181,6 +172,15 @@
             "trust_zone": "experimental-zone",
             "vendor": "Azure",
             "product": "Blob"
+        },
+        {
+            "symbolic_name": "source-code-config-storage",
+            "title": "Source Code\nand Configuration",
+            "description": "Stores source code and configuration files for deployment and production setup.",
+            "type": "object",
+            "trust_zone": "experimental-zone",
+            "vendor": "GitHub",
+            "product": "GitHub Repositories"
         },
         {
             "symbolic_name": "third-party-tools",

--- a/td.vue/src/service/demo/huskyai.tmbom.json
+++ b/td.vue/src/service/demo/huskyai.tmbom.json
@@ -1,0 +1,1027 @@
+{
+    "$schema": "https://github.com/OWASP/www-project-threat-model-library/blob/v1.0.1/threat-model.schema.json",
+    "version": "1.0.1",
+    "scope": {
+      "title": "Husky AI",
+      "description": "A machine learning system to classify Huskies vs dogs. HuskyAI is a machine learning system designed to classify images and distinguish between huskies and non-huskies. It integrates secure data handling practices with a robust convolutional neural network (CNN) for image recognition. Secure Image Retrieval: HuskyAI uses TLS to securely fetch images from Azure Cognitive Services, ensuring encryption during data transmission and validating the server's authenticity to prevent man-in-the-middle attacks. Data Storage and Access Controls: Azure Blob Storage is used to store datasets, with public access fully blocked. Access is controlled using Role-Based Access Control (rbac) and Attribute-Based Access Control (ABAC) to enforce granular, identity-based permissions. Jupyter Notebooks, which host model development and experimentation, are also secured with rbac and ABAC, preventing unauthorized public access. Developer Authentication: Developers access the system through SSH keys protected by passphrases. This adds an additional layer of security, reducing the likelihood of unauthorized access even if keys are exposed. Model and Dataset Dataset Composition: The dataset comprises approximately 1,300 husky images and 3,000 non-husky images sourced via Bing's image search. Data undergoes manual cleansing and is split into training and validation sets to enhance model performance. Model Design: HuskyAI employs a CNN with: Convolutional layers for feature extraction. Max-pooling layers for dimensionality reduction. Dropout layers to prevent overfitting. Dense layers for final classification. The model is trained with the Adam optimizer and a learning rate of 0.0005, optimized for accuracy and computational efficiency. Security Considerations rbac and ABAC controls across storage and development environments ensure sensitive data and configurations are protected. TLS ensures secure communication channels, preventing eavesdropping or data interception during image retrieval. Applications HuskyAI is tailored for accurate image classification and can be adapted for other domains requiring precise visual differentiation, with a focus on maintaining strong security postures. HuskyAI combines state-of-the-art machine learning techniques with stringent security controls, including secure communications, robust access management, and encrypted developer authentication, to deliver a reliable and secure image classification system.",
+      "business_criticality": "low",
+      "data_sensitivity": ["biz"],
+      "exposure": "external",
+      "tier": "non_critical"
+    },
+    "description": "A machine learning system to classify Huskies vs dogs",
+    "frozen": false,
+    "release_docs_link": "https://github.com/wunderwuzzi23/huskyai",
+    "reviewed_at": "2025-05-28",
+    "repo_link": "https://github.com/wunderwuzzi23/huskyai",
+    "diagrams": [
+        {
+            "title": "System architecture",
+            "type": "plantuml",
+            "source": "@startuml ' External Entities card \"Azure Cognitive Services\" as ext1 card \"Third Party tools and ML libraries\" as ext5 actor \"User\" as ext2 actor \"Engineer\" as ext4 actor \"Infrastructure Admin\" as ext3 card \"Third Party tools and ML libraries\" as ext7 ' Package for Experimentation Boundary package \"Experimentation\" { ' Data Stores (Cylinders for storage) storage \"Training and Validation Images\" as ds1 storage \"API Key\" as ds2 storage \"Machine Learning Model\" as ds3 storage \"Source Code and Configuration\" as ds5 ' Processes (Circles for processes using skinparam) rectangle \"Gather Images Application - Python\" as p1 rectangle \"Jupyter Notebook\" as p2 rectangle \"Deployment\" as p3 ' Apply circle styling to processes skinparam rectangle { roundCorner 100 } ' Data Flows in Experimentation ext1 <--> p1 : Send Images via HTTPS ext5 --> p1 : imports ext5 --> p2 : imports ext4 --> p1 : VS Code (SSH) ext4 --> p2 : VS Code (SSH) ext4 --> p3 : SSH ext4 --> ds5 : stores (SSH) p1 --> ds1 : Store Images ds2 --> p1 : Loads ds1 <--> p2 : Processes p1 --> p2 : Processed Data p2 --> ds3 : Save Model as .h5 ds3 --> p3 : Package Model ds5 --> p3 : Source Code and Config via SSH } ' Package for Production Boundary package \"Production\" { ' Data Stores (Cylinders for storage) storage \"Stored Machine Learning Model\" as ds6 storage \"Bastion Logs\" as ds7 storage \"Authorized Keys\" as ds8 ' Processes (Circles for processes using skinparam) rectangle \"API Gateway\" as p4 rectangle \"Bastion\" as p5 rectangle \"Simple Python Web Server\" as p6 ' Data Flows in Production ext2 <--> p4 : Request via HTTPS p5 --> p4 : update p4 <--> p6 : HTTPS p5 --> p6 : update ds6 --> p6 : Load Model p3 --> p5 : SSH p5 --> ds7 : Update Logs ext3 --> p5 : SSH p5 --> ds6 : update ds8 --> p5 : Provide Access ext7 --> p6 : imports } @enduml"
+        }
+    ],
+    "trust_zones": [
+        {
+            "symbolic_name": "prod-zone",
+            "title": "Production Trust Zone",
+            "description": "Internal VPC with the production deployment of HuskyAI"
+        },
+        {
+            "symbolic_name": "experimental-zone",
+            "title": "Experimental Trust Zone",
+            "description": "Internal VPC with the experimental and development deployment for HuskyAI"
+        }
+    ],
+    "trust_boundaries": [
+        {
+            "trust_zone_a": "prod-zone",
+            "trust_zone_b": "experimental-zone",
+            "access_control_methods": ["rbac", "acl"],
+            "authentication_methods": ["public_key"]
+        },
+        {
+            "trust_zone_a": "public",
+            "trust_zone_b": "experimental-zone",
+            "access_control_methods": ["rbac", "acl"],
+            "authentication_methods": ["password", "password"]
+        },
+        {
+            "trust_zone_a": "public",
+            "trust_zone_b": "prod-zone",
+            "access_control_methods": ["rbac", "acl"],
+            "authentication_methods": ["sso"]
+        }
+    ],
+    "actors": [
+        {
+            "symbolic_name": "engineer",
+            "title": "Engineer",
+            "description": "A Data Engineer responsible for building, training, and deploying machine learning models.",
+            "type": "engineer",
+            "permissions": "Develop and deploy machine learning models; interact with Experimentation tools such as Jupyter Notebook."
+        },
+        {
+            "symbolic_name": "infrastructure-admin",
+            "title": "Infra Admin",
+            "description": "Administrator responsible for securing and maintaining production infrastructure.",
+            "type": "administrator",
+            "permissions": "Manage production infrastructure; control access via the Bastion; monitor logs and update keys."
+        },
+        {
+            "symbolic_name": "azure-cognitive-services",
+            "title": "Azure\nCognitive Services",
+            "description": "External service providing resources for machine learning experimentation.",
+            "type": "third_party",
+            "permissions": "Provide images for training and validation through an external service."
+        },
+        {
+            "symbolic_name": "user",
+            "title": "User",
+            "description": "External user interacting with the HuskyAI system via the API Gateway.",
+            "type": "user",
+            "permissions": "Access the HuskyAI system through the API Gateway to classify images."
+        }
+    ],
+    "components": [
+        {
+            "symbolic_name": "web-service",
+            "title": "Simple Python\nWeb Server",
+            "description": "Serves as simple web server",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "api-gateway",
+            "title": "API Gateway",
+            "description": "Serves as the entry point for external users to interact with the production environment via HTTPS. It routes user requests to the Simple Python Web Server and ensures secure communication. The API Gateway enforces request validation and manages APIs exposed to the public while ensuring access control to internal services.",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "bastion",
+            "title": "Bastion",
+            "description": "A secure access management component for administrative functions. It provides controlled SSH access for the Infrastructure Admin to internal production resources, such as the Stored Machine Learning Model and Simple Python Web Server.",
+            "trust_zone": "prod-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "gather-images",
+            "title": "Gather\nImages Application\n(Python)",
+            "description": "This is a Python-based application responsible for gathering images from external sources, specifically Azure Cognitive Services, and storing them in the designated Training and Validation Images storage. ",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "jupyter",
+            "title": "Jupyter\nNotebook",
+            "description": "A Jupyter Notebook environment that processes the images stored in Training and Validation Images, executes code using external ML libraries, and provides a UI for engineers to interact with and manipulate data, allowing for iterative model development. It can save trained machine learning models to Machine Learning Model storage.",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        },
+        {
+            "symbolic_name": "deployment-service",
+            "title": "Deployment",
+            "description": "Handles the deployment of the machine learning model by packaging the model and all necessary source code and configuration stored in Source Code and Configuration. It receives the final model from Jupyter Notebook and prepares it for deployment to the production environment.",
+            "trust_zone": "experimental-zone",
+            "repo_link": "https://github.com/wunderwuzzi23/huskyai"
+        }
+    ],
+    "data_stores": [
+        {
+            "symbolic_name": "training-images-blob",
+            "title": "Training\nand Validation\nImages",
+            "description": "Contains images used for training and validation of machine learning models.",
+            "type": "object",
+            "trust_zone": "experimental-zone",
+            "vendor": "Azure",
+            "product": "Blob"
+        },
+        {
+            "symbolic_name": "api-key-storage",
+            "title": "API Key",
+            "description": "Stores API keys for secure access to external services.",
+            "type": "key_value",
+            "trust_zone": "experimental-zone",
+            "vendor": "Azure",
+            "product": "Key Vault"
+        },
+        {
+            "symbolic_name": "secret-key-storage",
+            "title": "Authorized Keys",
+            "description": "Contains SSH keys used for securing administrative access.",
+            "type": "key_value",
+            "trust_zone": "prod-zone",
+            "vendor": "Azure",
+            "product": "Key Vault"
+        },
+        {
+            "symbolic_name": "ml-models-blob",
+            "title": "Stored Machine\nLearning Model",
+            "description": "Contains storage for machine learning models in serialized format.",
+            "type": "object",
+            "trust_zone": "prod-zone",
+            "vendor": "Azure",
+            "product": "Blob"
+        },
+        {
+            "symbolic_name": "source-code-config-storage",
+            "title": "Source Code\nand Configuration",
+            "description": "Stores source code and configuration files for deployment and production setup.",
+            "type": "object",
+            "trust_zone": "experimental-zone",
+            "vendor": "GitHub",
+            "product": "GitHub Repositories"
+        },
+        {
+            "symbolic_name": "ml-models",
+            "title": "Machine\nLearning Model",
+            "description": "Contains the machine learning models in serialized format.",
+            "type": "object",
+            "trust_zone": "experimental-zone",
+            "vendor": "Azure",
+            "product": "Blob"
+        },
+        {
+            "symbolic_name": "third-party-tools",
+            "title": "3rd party tools\nand ML libraries",
+            "description": "External third party tools for the services",
+            "type": "object",
+            "product": "3rd party tools and ML libraries"
+        }
+    ],
+    "data_sets": [
+        {
+            "symbolic_name": "training-images",
+            "title": "Training and Validation Images",
+            "description":  "Contains images used for training and validation of machine learning models.",
+            "placements": [
+                {
+                    "data_store": "training-images-blob",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 100000,
+            "data_sensitivity": ["biz"],
+            "access_control_methods": ["rbac"]
+        },
+        {
+            "symbolic_name": "api-keys",
+            "title": "API Keys",
+            "description": "Stores API keys for secure access to external services.",
+            "placements": [
+                {
+                    "data_store": "api-key-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 20,
+            "data_sensitivity": ["cred"],
+            "access_control_methods": ["rbac"]
+        },
+        {
+            "symbolic_name": "stored-ml-models",
+            "title": "Stored Machine Learning Models",
+            "description": "Contains trained machine learning models in serialized format for production use.",
+            "placements": [
+                {
+                    "data_store": "ml-models-blob",
+                    "encrypted": false
+                }
+            ],
+            "record_count": 10,
+            "data_sensitivity": ["biz"],
+            "access_control_methods": ["rbac"]
+        },
+        {
+            "symbolic_name": "source-code-config",
+            "title": "Source Code and Configuration",
+            "description": "Stores source code and configuration files for deployment and production setup.",
+            "placements": [
+                {
+                    "data_store": "source-code-config-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 200,
+            "data_sensitivity": ["biz"],
+            "access_control_methods": ["rbac"]
+        },
+        {
+            "symbolic_name": "bastion-logs",
+            "title": "Bastion Logs",
+            "description": "Contains trained machine learning models in serialized format for production use.",
+            "placements": [
+                {
+                    "data_store": "ml-models",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 5000,
+            "data_sensitivity": ["biz"],
+            "access_control_methods": ["acl"]
+        },
+        {
+            "symbolic_name": "authorized-keys",
+            "title": "Authorized Keys",
+            "description": "Contains SSH keys used for securing administrative access.",
+            "placements": [
+                {
+                    "data_store": "secret-key-storage",
+                    "encrypted": true
+                }
+            ],
+            "record_count": 100,
+            "data_sensitivity": ["cred"],
+            "access_control_methods": ["rbac"]
+        },
+        {
+            "symbolic_name": "uploaded-images",
+            "title": "Uploaded Images",
+            "description": "Contains images that users upload to understand if an image is a Husky or not.",
+            "placements": [
+                {
+                    "data_store": "uploaded-images-redis",
+                    "encrypted": false
+                }
+            ],
+            "record_count": 100000000,
+            "data_sensitivity": [],
+            "access_control_methods": []
+        }
+    ],
+
+    "data_flows": [
+        {
+            "symbolic_name": "azure-cognitive-gather-images",
+            "title": "HTTPS",
+            "description": "Transfer data from Azure Cognitive Services to Gather Images Application in Python.",
+            "source": {"type": "actor", "object": "azure-cognitive-services"},
+            "destination": {"type": "component", "object": "gather-images"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-gather-images",
+            "title": "imports",
+            "description": "Transfer data from Third Party tools and ML libraries to Gather Images Application in Python.",
+            "source": {"type": "actor", "object":"third-party-tools"},
+            "destination": {"type": "component", "object": "gather-images"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-jupyter-notebook",
+            "title": "imports",
+            "description": "Transfer data from Third Party tools and ML libraries to Jupyter Notebook.",
+            "source": {"type": "actor", "object":"third-party-tools"},
+            "destination": {"type": "component", "object": "jupyter"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "engineer-gather-images",
+            "title": "VS Code (SSH)",
+            "description": "Transfer data from Engineer to Gather Images Application in Python.",
+            "source": {"type": "actor", "object":"engineer"},
+            "destination": {"type": "component", "object": "gather-images"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "engineer-jupyter-notebook",
+            "title": "VS Code (SSH)",
+            "description": "Transfer code and ML models from Engineer locally to Jupyter Notebook.",
+            "source": {"type": "actor", "object":"engineer"},
+            "destination": {"type": "component", "object": "jupyter"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "gather-images-training-images",
+            "title": "stores",
+            "description": "Transfer images from Gather Images Application to Training and Validation Images.",
+            "source": {"type": "component", "object": "gather-images"},
+            "destination": {"type": "data_store", "object": "training-images-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "api-key-storage-gather-images",
+            "title": "loads",
+            "description": "API Key Storage to Gather Images Application in Python.",
+            "source": {"type": "data_store", "object":"api-key-storage"},
+            "destination": {"type": "component", "object": "gather-images"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "training-images-jupyter-notebook",
+            "title": "processes",
+            "description": "Load from Training and Validation Images to Jupyter Notebook.",
+            "source": {"type": "data_store", "object": "training-images-blob"},
+            "destination": {"type": "component", "object": "jupyter"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "ml-models-deployment-service",
+            "title": "package",
+            "description": "Transfer data from Machine Learning Model to Deployment.",
+            "source": {"type": "component", "object": "ml-models"},
+            "destination": {"type": "component", "object": "deployment-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "jupyter-notebook-ml-model",
+            "title": "save.h5",
+            "description": "Transfer final model from Jupyter Notebook to Machine Learning Model.",
+            "source": {"type": "component", "object": "jupyter"},
+            "destination": {"type": "data_store", "object": "ml-models"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "ml-model-deployment-service",
+            "title": "package",
+            "description": "Transfer from Machine Learning Model Blob to Deployment Service.",
+            "source": {"type": "data_store", "object": "ml-models-blob"},
+            "destination": {"type": "component", "object": "deployment-service"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "source-code-deployment",
+            "title": "package",
+            "description": "Transfer data from Source Code and Configuration to Deployment.",
+            "source": {"type": "data_store", "object":"source-code-config-storage"},
+            "destination": {"type": "component", "object": "deployment-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "user-api-gateway",
+            "title": "HTTPS",
+            "description": "Transfer from User to API Gateway.",
+            "source": {"type": "actor","object": "user"},
+            "destination": {"type": "component","object": "api-gateway"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-api-gateway",
+            "title": "update",
+            "description": "Transfer data from Bastion to API Gateway.",
+            "source": {"type": "component","object": "bastion"},
+            "destination": {"type": "component","object": "api-gateway"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "api-gateway-web-server",
+            "title": "HTTPS",
+            "description": "Transfer data from API Gateway to Simple Python Web Server.",
+            "source": {"type": "component","object": "api-gateway"},
+            "destination": {"type": "component","object": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "bastion-web-server",
+            "title": "update",
+            "description": "Transfer data from Bastion to Simple Python Web Server.",
+            "source": {"type": "component","object": "bastion"},
+            "destination": {"type": "component","object": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "stored-ml-model-web-server",
+            "title": "loads",
+            "description": "Transfer sensitive data from Stored Machine Learning Model to Simple Python Web Server.",
+            "source": {"type": "data_store", "object": "ml-models-blob"},
+            "destination": {"type": "component","object": "web-service"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "deployment-bastion",
+            "title": "SSH",
+            "description": "Transfer sensitive data from Deployment Service to Bastion",
+            "source": {"type": "component", "object": "deployment-service"},
+            "destination": {"type": "component","object": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-ml-model",
+            "title": "update",
+            "description": "Transfer sensitive data from Bastion to Stored Machine Learning Model.",
+            "source": {"type": "component","object": "bastion"},
+            "destination": {"type": "data_store","object":"ml-models-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "admin-bastion",
+            "title": "SSH",
+            "description": "Transfer data from Infrastructure Admin to Bastion.",
+            "source": {"type": "actor", "object":"infrastructure-admin"},
+            "destination": {"type": "component","object": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "bastion-stored-ml-model",
+            "title": "update",
+            "description": "Transfer sensitive data from Bastion to Stored Machine Learning Model.",
+            "source": {"type": "component","object": "bastion"},
+            "destination": {"type": "data_store", "object": "ml-models-blob"},
+            "has_sensitive_data": true,
+            "encrypted": false
+        },
+        {
+            "symbolic_name": "authorized-keys-bastion",
+            "title": "",
+            "description": "Transfer sensitive data from Authorized Keys Storage to Bastion.",
+            "source": {"type": "data_store","object":"secret-key-storage"},
+            "destination": {"type": "data_store", "object": "bastion"},
+            "has_sensitive_data": true,
+            "encrypted": true
+        },
+        {
+            "symbolic_name": "third-party-tools-web-server",
+            "title": "imports",
+            "description": "Transfer data from Third Party tools and ML libraries to Simple Python Web Server.",
+            "source": {"type": "actor", "object": "third-party-tools"},
+            "destination": {"type": "component", "object": "web-service"},
+            "has_sensitive_data": false,
+            "encrypted": true
+        }
+    ],
+    "assumptions": [
+        {
+            "description": "All services within the trust boundary validate tokens via Auth Service",
+            "topics": ["prod-zone", "experimental-zone"],
+            "validity": "confirmed"
+        }
+    ],
+    "threat_personas": [
+        {
+            "symbolic_name": "ratimir",
+            "title": "Ratimir",
+            "description": "An expert social engineer, great at writing its own exploits and malware - Ratimir is a worthy adversary to consider",
+            "is_person": true,
+            "skill_level": "expert_engineer",
+            "access_level": "user",
+            "malicious_intent": true,
+            "applicability_to_org": "high"
+        },
+        {
+            "symbolic_name": "michiko",
+            "title": "Michiko",
+            "description": "Michiko levareges a lot of acquired knowledge from her e-crime organization which enables her to launch sophisticated attacks penetrating internal corporate networks",
+            "is_person": true,
+            "skill_level": "oc_sponsored",
+            "access_level": "admin",
+            "malicious_intent": true,
+            "applicability_to_org": "moderate"
+        }
+    ],
+    "threats":[
+        {
+            "symbolic_name": "buffer-overflow-image-processing",
+            "title": "Buffer overflow in image processing causing remote code execution or DoS",
+            "description": "An attacker crafts an image to cause buffer overflow in image processing, leading to potential remote code execution, denial of service, and errors.",
+            "threat_persona": "ratimir",
+            "event": "denial of service or remote code execution",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 100,
+                    "capec_title": "Overflow Buffers"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 120,
+                    "cwe_title": "Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "supply-chain-attack",
+            "title": "Supply chain attack on third-party libraries compromising system outputs",
+            "description": "An attacker poisons the supply chain of third-party libraries, leading to network or system compromise.",
+            "threat_persona": "ratimir",
+            "event": "supply chain attack",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 438,
+                    "capec_title": "Modification During Manufacture"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 1104,
+                    "cwe_title": "Use of Unmaintained Third Party Components"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "image-tampering",
+            "title": "Image Tampering",
+            "description": "An attacker tampers with or deletes stored images to impact training or testing results and/or cause denial of service.",
+            "threat_persona": "michiko",
+            "event": "Image tampering",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 276,
+                    "cwe_title": "Incorrect Default Permissions"
+                },
+                {
+                    "cwe_id": 285,
+                    "cwe_title": "Improper Authorization"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "notebook-tampering",
+            "title": "Notebook tampering to insert a backdoor",
+            "description": "An attacker modifies a notebook file to insert a backdoor, such as a keylogger or data stealer.",
+            "threat_persona": "michiko",
+            "event": "notebook tampering",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 276,
+                    "cwe_title": "Incorrect Default Permissions"
+                },
+                {
+                    "cwe_id": 285,
+                    "cwe_title": "Improper Authorization"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "model-tampering",
+            "title": "Machine learning model tampering causing low accuracy or IP theft",
+            "description": "An attacker or insider modifies or reads persisted model files to steal intellectual property or degrade prediction accuracy.",
+            "threat_persona": "michiko",
+            "event": "machine learning model tampering",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 1,
+                    "capec_title": "Accessing Functionality Not Properly Constrained by acls"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 276,
+                    "cwe_title": "Incorrect Default Permissions"
+                },
+                {
+                    "cwe_id": 285,
+                    "cwe_title": "Improper Authorization"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "perturbation-attack",
+            "title": "Image perturbation attack resulting in incorrect classifications",
+            "description": "An attacker uses brute force with random or systematic perturbations to create images that lead to incorrect classifications.",
+            "threat_persona": "ratimir",
+            "event": "perturbation attack",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 28,
+                    "capec_title": "Fuzzing"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 20,
+                    "cwe_title": "Improper Input Validation"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "sensitive-image-exposure",
+            "title": "Sensitive image exposure due to accidental access",
+            "description": "An attacker or malicious insider gains access to sensitive uploaded images.",
+            "threat_persona": "michiko",
+            "event": "accidental sensitive data exposure",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 204,
+                    "capec_title": "Lifting Sensitive Data Embedded in Cache"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 20,
+                    "cwe_title": "Improper Input Validation"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "ssh-compromise-developer-machine",
+            "title": "SSH compromise via stolen credentials from developer machine",
+            "description": "An attacker compromises a developer machine to steal SSH keys, impersonate users, or escalate privileges.",
+            "threat_persona": "michiko",
+            "event": "bastion compromise via SSH",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 555,
+                    "capec_title": "Remote Services with Stolen Credentials"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 522,
+                    "cwe_title": "Insufficiently Protected Credentials"
+                }
+            ]
+        },
+        {
+            "symbolic_name": "ssh-compromise-vulnerability",
+            "title": "SSH compromise via open port vulnerability",
+            "description": "An attacker exploits an open SSH port to escalate privileges or impersonate authorized users.",
+            "threat_persona": "ratimir",
+            "event": "bastion compromise via SSH",
+            "sources": ["adversary"],
+            "attack_mechanisms": [
+                {
+                    "capec_id": 300,
+                    "capec_title": "Port Scanning"
+                }
+            ],
+            "weaknesses": [
+                {
+                    "cwe_id": 200,
+                    "cwe_title": "Exposure of Sensitive Information to an Unauthorized Actor"
+                }
+            ]
+        }
+    ],        
+    "controls": [
+        {
+            "symbolic_name": "sandboxing-for-image-processing",
+            "title": "Implement sandboxing for image processing",
+            "description": "Run image processing in isolated environment to limit impact of exploitation",
+            "threats": ["buffer-overflow-image-processing"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "medium"
+        },
+        {
+            "symbolic_name": "owasp-file-upload-guidelines",
+            "title": "Follow OWASP Cheat Sheet for File Upload",
+            "description": "Run image processing in isolated environment to limit impact of exploitation",
+            "threats": ["buffer-overflow-image-processing"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "validate-tls-certificate-checks",
+            "title": "Validate TLS usage and certificate checks are in place",
+            "description": "Validate TLS usage and certificate checks are in place.",
+            "threats": ["supply-chain-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "sca-and-patching-for-third-party-libraries",
+            "title": "SCA scanning and patching",
+            "description": "Regularly scan third-party dependencies for vulnerabilities and malicious packages, fix any critical or high vulnerabilities",
+            "threats": ["supply-chain-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "experimental-zone",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "access-control-for-azure-blobs",
+            "title": "Ensure appropriate access control and authorization for any Azure Blob storage",
+            "description": "Use ABAC, rbac, and other access control methods to ensure only authorized individuals can access the images.",
+            "threats": ["image-tampering", "model-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "active",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "access-logging-for-azure-blob",
+            "title": "Have access logging in place for Azure Blob storage",
+            "description": "Turn on access logging for the Azure Blob and push logs to a SIEM for monitoring.",
+            "threats": ["image-tampering", "model-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "backup-for-azure-blob-storage",
+            "title": "Ensure backups for Azure Blob storage with different credentials",
+            "description": "Ensure images have a backup stored securely and cannot be accessed with the same credentials as the production storage.",
+            "threats": ["image-tampering", "model-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "store-and-check-hashes",
+            "title": "Store hashes and validate integrity of images, jupyter notebooks and the machine learning models",
+            "description": "Protect Jupyter Notebooks and the machine learning models from tampering by using stored hashes and validating them.",
+            "threats": ["image-tampering", "model-tampering","notebook-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "experimental-zone"
+            },
+            "status": "suggested",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "jupyter-notebooks-access-control",
+            "title": "Ensure appropriate access control and authorization in place for the Jupyter Notebooks",
+            "description": "Use ABAC, rbac and other access control methods to ensure only people who are authorised can access Jupyter Notebooks.",
+            "threats": ["notebook-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "experimental-zone"
+            },
+            "status": "active",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "api-rate-limiting",
+            "title": "Rate Limiting",
+            "description": "Prevent brute force by restricting the number of requests an API client can make in a time frame.",
+            "threats": ["perturbation-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "adversarial-training",
+            "title": "Adversarial Training",
+            "description": "Train the model with adversarial examples to improve robustness against perturbation attacks.",
+            "threats": ["perturbation-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "medium"
+        },
+        {
+            "symbolic_name": "input-filtering",
+            "title": "Input Filtering",
+            "description": "Detect and block adversarial inputs through preprocessing or anomaly detection.",
+            "threats": ["perturbation-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "confidence-thresholding",
+            "title": "Confidence Thresholding",
+            "description": "Set thresholds to avoid over-reliance on high-confidence but incorrect predictions.",
+            "threats": ["perturbation-attack"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "medium"
+        },
+        {
+            "symbolic_name": "in-memory-image-storage",
+            "title": "The uploaded images are saved in memory - difficult to access",
+            "description": "The fact that images are not inherently sensitive and stored in memory mitigates this threat to an acceptable level.",
+            "threats": ["sensitive-image-exposure"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "active",
+            "priority": "medium"
+        },
+        {
+            "symbolic_name": "memory-access-restrictions",
+            "title": "Memory access restrictions",
+            "description": "Implement strict memory access restrictions to ensure only authorized processes or users can access the in-memory or cached data. This includes using mechanisms like process isolation and restricting debug or system tools that could read memory.",
+            "threats": ["sensitive-image-exposure"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "low"
+        },
+        {
+            "symbolic_name": "secure-cache-handling",
+            "title": "Secure cache-handling",
+            "description": "Use secure caching mechanisms that encrypt data stored in memory (e.g., using libraries like Redis with in-memory encryption) and ensure the cache has strict eviction policies to avoid prolonged data retention.",
+            "threats": ["sensitive-image-exposure"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "low"
+        },
+        {
+            "symbolic_name": "in-memory-data-lifecycle-management",
+            "title": "In-memory data lifecycle management",
+            "description": "Implement a strict lifecycle management policy to securely clear in-memory data immediately after use. For example, overwrite memory regions containing sensitive data and enforce short caching lifespans.",
+            "threats": ["sensitive-image-exposure"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "low"
+        },
+        {
+            "symbolic_name": "network-acl-ssh-restrictions",
+            "title": "Use network-level access control lists (acls) to limit SSH access to specific IP ranges",
+            "description": "Whitelist SSH ports to allow access only from specific IPs.",
+            "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "complex-ssh-passphrases",
+            "title": "Require passphrases for SSH private keys to be complex",
+            "description": "Passphrases for SSH keys should have high complexity (minimum 12 characters and one type of complexity).",
+            "threats": ["ssh-compromise-developer-machine"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "medium"
+        },
+        {
+            "symbolic_name": "developer-machine-security",
+            "title": "Developer machine endpoint security - EDR and posture management",
+            "description": "Ensure developer machines are patched, have an up-to-date OS, and EDR in place.",
+            "threats": ["ssh-compromise-developer-machine", "image-tampering", "model-tampering","notebook-tampering"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        },
+        {
+            "symbolic_name": "ssh-access-logging",
+            "title": "Configure logging for all SSH access attempts",
+            "description": "Log all access attempts - including successes and failures, and implement alerting for suspicious activities such as repeated login failures, new keys, or logins from unexpected locations.",
+            "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "active",
+            "priority": "high"
+        },
+        {
+            "symbolic_name": "bastion-host-patching-hardening",
+            "title": "Ensure the Bastion host is patched and hardened",
+            "description": "Have strict patching SLAs for the Bastion host.",
+            "threats": ["ssh-compromise-vulnerability"],
+            "trust_boundary": {
+                "trust_zone_a": "public",
+                "trust_zone_b": "prod-zone"
+            },
+            "status": "suggested",
+            "priority": "critical"
+        }
+    ],
+    "risks": [
+        {
+            "symbolic_name": "adversarial-attack-on-huskyai",
+            "title": "Adversarial attacks on the HuskyAI model",
+            "description": "Attackers could manipulate the HuskyAI model through perturbation techniques or tampering with the training and testing sets, leading to incorrect predictions and erosion of trust in the system.",
+            "threats": ["image-tampering", "model-tampering","notebook-tampering", "perturbation-attack"],
+            "likelihood": "unlikely",
+            "impact": "major",
+            "impact_description": "Operational issues and loss of user confidence - reputational damage.",
+            "score": 8,
+            "level": "medium"
+        },
+        {
+            "symbolic_name": "web-attacks",
+            "title": "Web Attacks",
+            "description": "An attacker could launch web based attacks by sending crafted requests, leading to outages and reputational damage.",
+            "threats": ["supply-chain-attack", "buffer-overflow-image-processing"],
+            "likelihood": "possible",
+            "impact": "moderate",
+            "impact_description": "Operational disruptions could arise from endpoint flooding or configuration tampering, leading to downtime and reputational damage.",
+            "score": 9,
+            "level": "high"
+        },
+        {
+            "symbolic_name": "unauthorized-ssh-access",
+            "title": "Unauthorized SSH access via stolen or compromised keys",
+            "description": "An attacker could gain unauthorized access to sensitive systems via stolen or compromised SSH keys, or by attacking the SSH port directly - leading to privilege escalation, information disclosure, reputational damage and potential operational disruption.",
+            "threats": ["ssh-compromise-developer-machine", "ssh-compromise-vulnerability"],
+            "likelihood": "possible",
+            "impact": "severe",
+            "impact_description": "Operational disruption requiring moderate to high recovery efforts with potentially reputational damage.",
+            "score": 15,
+            "level": "high"
+        }
+    ]
+}

--- a/td.vue/src/service/demo/index.js
+++ b/td.vue/src/service/demo/index.js
@@ -6,10 +6,12 @@ import onlineGame from './online-game';
 import iotDevice from './iot-device';
 import genericCms from './generic-cms';
 import cryptoWallet from './cryptocurrency-wallet';
+import huskyAi from './huskyai.tmbom';
 import v2DemoThreatModel from './v2-threat-model';
 
 const models = [
     { name: 'Demo Threat Model', model: v2DemoThreatModel },
+    { name: 'Husky AI', model: huskyAi },
     { name: 'Cryptocurrency Wallet', model: cryptoWallet },
     { name: 'Generic CMS', model: genericCms },
     { name: 'IoT Device', model: iotDevice },

--- a/td.vue/src/service/migration/tmBom/diagrams/boxes.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/boxes.js
@@ -30,11 +30,11 @@ const findDimensions = (model, symbolic_name, nodeSize) => {
     }
 
     // a 'typical' node is width 160 and height 80
-    // the nodes are placed around the edges of the trust boundary box
-    // so that 0 or 1 component is side of 1, 2 to 4 is side of 2
-    // 5 to 8 is side of 3, 9 to 12 is side of 4, 13 to 16 is side of 5 and so on
+    // the nodes are placed around the top and lhs edges of the trust boundary box
+    // so that 0 or 1 component is side of 1, 2 & 3 is side of 2
+    // 4 & 5 is side of 3, 6 & 7 is side of 4, 8 & 9 is side of 5 and so on
     if (nodes > 1) {
-        nodesPerSide = Math.floor((nodes + 7) / 4);
+        nodesPerSide = Math.floor((nodes + 2) / 2);
     }
 
     return { 'width': nodesPerSide * nodeSize.width, 'height': nodesPerSide * nodeSize.height };

--- a/td.vue/src/service/migration/tmBom/diagrams/nodes.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/nodes.js
@@ -1,7 +1,7 @@
 import defaultProperties from '@/service/entity/default-properties.js';
 import boxes from './boxes';
 
-const padding = 100;
+const padding = 125;
 const nodeSize = { width: 160 + padding, height: 80 + padding };
 
 const read = (model) => {

--- a/td.vue/src/service/migration/tmBom/diagrams/threats/risks.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/threats/risks.js
@@ -4,7 +4,6 @@ const merge = (model, tdThreats) => {
         for (const risk of model.risks) {
             // risks have a threats array, else the model would not pass the schema test
             for (const threat of risk.threats) {
-                console.debug(JSON.stringify(threat));
                 for (let tdThreat of tdThreats) {
                     if (tdThreat.id === threat) {
                         tdThreat.description += '\nRisk Identified: ' + risk.title;

--- a/td.vue/src/service/migration/tmBom/threat-model.schema.json
+++ b/td.vue/src/service/migration/tmBom/threat-model.schema.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://github.com/OWASP/www-project-threat-model-library/blob/v1.0.1/threat-model.schema.json",
-    "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below.",
+    "$comment": "When updating the schema `$id`, also update the value of the constant `$schema` property below. See <https://owasp.org/www-project-threat-model-library/#div-specification>.",
     "title": "OWASP Threat Model Library Schema",
 
     "$defs": {
@@ -74,6 +74,9 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 25
+        },
+        "risk-level-band": {
+            "enum": ["very_low", "low", "medium", "high", "very_high", "critical"]
         },
         "tier": {
             "enum": ["mission_critical", "business_critical", "important", "non_critical"]
@@ -324,6 +327,10 @@
                 "permissions": {
                     "title": "Free-form description of permissions typically available to the actor",
                     "type": "string"
+                },
+                "trust_zone": {
+                    "title": "Trust zone in which the actor operates",
+                    "$ref": "#/$defs/symbolic-name"
                 }
             }
         },
@@ -333,8 +340,7 @@
             "required": [
                 "symbolic_name",
                 "title",
-                "description",
-                "trust_zone"
+                "description"
             ],
             "additionalProperties": false,
             "properties": {
@@ -399,6 +405,10 @@
                 "product": {
                     "title": "Product implementing the data store",
                     "type": "string"
+                },
+                "trust_zone": {
+                    "title": "Trust zone where the data store resides",
+                    "$ref": "#/$defs/symbolic-name"
                 }
             }
         },
@@ -738,13 +748,13 @@
                 },
                 "score": {
                     "title": "Risk score based on likelihood and impact",
-                    "$comment": "http://go/threat-modeling-risk-score",
+                    "$comment": "https://owasp.org/www-project-threat-model-library/#div-specification",
                     "$ref": "#/$defs/risk-score"
                 },
                 "level": {
                     "title": "Risk level band",
-                    "$comment": "http://go/threat-modeling-risk-score",
-                    "type": "string"
+                    "$comment": "https://owasp.org/www-project-threat-model-library/#div-specification",
+                    "$ref": "#/$defs/risk-level-band"
                 }
             }
         },

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -61,6 +61,7 @@ import { getProviderType } from '@/service/provider/providers.js';
 import TdFormButton from '@/components/FormButton.vue';
 import tmActions from '@/store/actions/threatmodel.js';
 import schema from '@/service/schema/ajv';
+import tmBom from '@/service/migration/tmBom/tmBom';
 
 // only search for text files
 const pickerFileOptions = {
@@ -150,9 +151,12 @@ export default {
                     console.warn('Version 1.x file will be translated to V2 format');
                     this.$toast.warning(this.$t('threatmodel.warnings.v1Translate'), { timeout: false });
                 } else if (schema.isTmBom(jsonModel)) {
-                    console.error('Convert TM-BOM to internal TD format not yet supported');
-                    this.$toast.error(this.$t('threatmodel.warnings.tmUnsupported'), { timeout: false });
-                    return;
+                    console.warn('Convert TM-BOM to internal TD format');
+                    this.$toast.warning(this.$t('threatmodel.warnings.tmUnsupported'), { timeout: false });
+                    jsonModel = tmBom.read(jsonModel);
+                    console.debug('Force selection of file name for TM-BOM');
+                    fileName = '';
+                    this.$store.dispatch(tmActions.update, { fileName: fileName });
                 } else if (schema.isOtm(jsonModel)) {
                     console.error('Convert OTM to internal TD format not yet supported');
                     this.$toast.error(this.$t('threatmodel.warnings.otmUnsupported'), { timeout: false });

--- a/td.vue/src/views/demo/SelectDemoModel.vue
+++ b/td.vue/src/views/demo/SelectDemoModel.vue
@@ -29,6 +29,8 @@
 import demo from '@/service/demo/index.js';
 import isElectron from 'is-electron';
 import tmActions from '@/store/actions/threatmodel.js';
+import schema from '@/service/schema/ajv';
+import tmBom from '@/service/migration/tmBom/tmBom';
 
 export default {
     name: 'SelectDemoModel',
@@ -43,7 +45,11 @@ export default {
     },
     methods: {
         onModelClick(model) {
-            this.$store.dispatch(tmActions.selected, model.model);
+            if (schema.isTmBom(model.model)) {
+                this.$store.dispatch(tmActions.selected, tmBom.read(model.model));
+            } else {
+                this.$store.dispatch(tmActions.selected, model.model);
+            }
             if (isElectron()) {
                 // tell any electron server that the model has changed
                 window.electronAPI.modelOpened(model.name);

--- a/td.vue/tests/unit/service/demo/index.spec.js
+++ b/td.vue/tests/unit/service/demo/index.spec.js
@@ -1,0 +1,10 @@
+import demo from '@/service/demo/index.js';
+
+describe('service/demo/index.js', () => {
+    describe('models', () => {
+        it('gets all models', () => {
+            let models = demo.models;
+            expect(models).toHaveLength(10);
+        });
+    });
+});

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/nodes.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/nodes.spec.js
@@ -79,10 +79,10 @@ describe('service/migration/tmBom/diagrams/nodes.js', () => {
         });
 
         it('positions components along edge', () => {
-            expect(components[0].position).toStrictEqual({ x: 100, y: 150 });
-            expect(components[1].position).toStrictEqual({ x: 100, y: 330 });
-            expect(components[2].position).toStrictEqual({ x: 360, y: 150 });
-            expect(components[3].position).toStrictEqual({ x: 100, y: 510 });
+            expect(components[0].position).toStrictEqual({ x: 112.5, y: 162.5 });
+            expect(components[1].position).toStrictEqual({ x: 112.5, y: 367.5 });
+            expect(components[2].position).toStrictEqual({ x: 397.5, y: 162.5 });
+            expect(components[3].position).toStrictEqual({ x: 112.5, y: 572.5 });
         });
     });
 
@@ -102,9 +102,9 @@ describe('service/migration/tmBom/diagrams/nodes.js', () => {
         });
 
         it('positions components within zone', () => {
-            expect(components[0].position).toStrictEqual({ x: 400, y: 300 });
-            expect(components[1].position).toStrictEqual({ x: 400, y: 480 });
-            expect(components[2].position).toStrictEqual({ x: 660, y: 300 });
+            expect(components[0].position).toStrictEqual({ x: 412.5, y: 312.5 });
+            expect(components[1].position).toStrictEqual({ x: 412.5, y: 517.5 });
+            expect(components[2].position).toStrictEqual({ x: 697.5, y: 312.5 });
         });
     });
 });

--- a/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
+++ b/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
@@ -42,84 +42,93 @@ describe('views/demo/SelectDemoModel.vue', () => {
     });
 
     it('displays the Demo Threat Model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Demo Threat Model')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Demo Threat Model')
+                .at(0)
+                .exists()
+        ).toEqual(true);
+    });
+
+    it('displays the HuskyAI demo model', () => {
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Husky AI')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Cryptocurrency Wallet demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Cryptocurrency Wallet')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Cryptocurrency Wallet')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Generic CMS demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Generic CMS')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Generic CMS')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the IoT Device demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'IoT Device')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'IoT Device')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Online Game demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Online Game')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Online Game')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Payments Processing Platform demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Payments Processing Platform')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Payments Processing Platform')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Renting Car Startup demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Renting Car Startup')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Renting Car Startup')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the Three Tier Web Application demo model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'Three Tier Web Application')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'Three Tier Web Application')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('displays the New Blank Model', () => {
-	    expect(
-	        wrapper.findAllComponents(BListGroupItem)
-	            .filter(x => x.text() === 'New Blank Model')
-	            .at(0)
-	            .exists()
-	    ).toEqual(true);
+        expect(
+            wrapper.findAllComponents(BListGroupItem)
+                .filter(x => x.text() === 'New Blank Model')
+                .at(0)
+                .exists()
+        ).toEqual(true);
     });
 
     it('clears the threatmodels', () => {


### PR DESCRIPTION
**Summary**:
Allow Threat Dragon to import TM-BOM schema files. Export to follow later in 2025
Adds a sample TM-BOM into the demos as Husky AI

**Description for the changelog**:
enable TM-BOM import

**Declaration**:

- [x] appropriate unit tests have been created / modified
- [x] functional tests created / modified for changes in functionality
- [x] any use of AI has been declared in this pull request

**Other info**:
task for issue #850 
