### PR TITLE
Fix saving with keyboard shortcut so that it actually saves new data

### DIFF
--- a/td.vue/src/service/x6/graph/keys.js
+++ b/td.vue/src/service/x6/graph/keys.js
@@ -5,7 +5,7 @@
 
 import store from '@/store/index.js';
 
-import { THREATMODEL_SAVE } from '@/store/actions/threatmodel.js';
+import {THREATMODEL_DIAGRAM_APPLIED, THREATMODEL_SAVE} from '@/store/actions/threatmodel.js';
 
 
 const del = (graph) => () => graph.removeCells(graph.getSelectedCells());
@@ -43,6 +43,7 @@ const paste = (graph) => () => {
 
 const save = () => (evt) => {
     evt?.preventDefault();
+    store.get().dispatch(THREATMODEL_DIAGRAM_APPLIED);
     store.get().dispatch(THREATMODEL_SAVE);
 };
 


### PR DESCRIPTION
**Summary**:
Saving via keyboard shortcut doesn't apply the current diagram to the threatmodel state, so when the model saves, it saves whatever was already in it, which is what's currently on the disk. This is probably the cause of https://github.com/OWASP/threat-dragon/issues/1254. Saving via the File menu or the Save icon work correctly by applying the diagram to the threatmodel state first, so just replicate that.

**Description for the changelog**:
Dispatch `THREATMODEL_DIAGRAM_APPLIED` before dispatching `THREATMODEL_SAVE` when saving via keyboard shortcut.

**Declaration**:

- [ ] appropriate unit tests have been created / modified
- [ ] functional tests created / modified for changes in functionality
- [x] any use of AI has been declared in this pull request

**Other info**:
Steps to reproduce:

1. Open a diagram.
2. Make a trivial change (add a new process).
3. Save via ctrl+s.

Expected:
Output json file contains expected changes.

Actual:
Output json file is identical to what was already on the disk.

I don't know what unit or functional tests would be added for this since the existing tests clearly didn't catch it and I'm not familiar with this code base enough to confidently write any.
