### PR TITLE
Fix threat severity and status icons

### DIFF
--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -16,9 +16,14 @@
                 <b-col>
                     <font-awesome-icon 
                         icon="check"
+                        class="threat-icon gray-icon"
+                        :title="status"
+                        v-if="status === 'NotApplicable'" />
+                    <font-awesome-icon 
+                        icon="check"
                         class="threat-icon green-icon"
                         :title="status"
-                        v-if="status !== 'Open'" />
+                        v-if="status === 'Mitigated'" />
                     <font-awesome-icon 
                         icon="exclamation-triangle"
                         class="threat-icon red-icon"
@@ -28,7 +33,7 @@
                         icon="circle"
                         class="threat-icon red-icon"
                         :title="severity"
-                        v-if="severity === 'High'" />
+                        v-if="severity === 'High' || severity === 'Critical'" />
                     <font-awesome-icon 
                         icon="circle"
                         class="threat-icon yellow-icon"
@@ -39,6 +44,11 @@
                         class="threat-icon green-icon"
                         :title="severity"
                         v-if="severity === 'Low'" />
+                    <font-awesome-icon 
+                        icon="circle"
+                        class="threat-icon gray-icon"
+                        :title="severity"
+                        v-if="severity === 'TBD'" />
                 </b-col>
                 <b-col align-h="end">
                     <b-badge :v-if="!!modelType">{{ modelType }}</b-badge>
@@ -71,6 +81,10 @@
 
 .yellow-icon {
     color: $yellow;
+}
+
+.gray-icon {
+    color: $gray;
 }
 
 </style>

--- a/td.vue/tests/unit/components/graphThreats.spec.js
+++ b/td.vue/tests/unit/components/graphThreats.spec.js
@@ -88,13 +88,24 @@ describe('components/GraphThreats.vue', () => {
             expect(icon.exists()).toEqual(true);
         });
 
-        it('displays a green check for not applicable', () => {
+        it('displays a gray check for not applicable', () => {
             const propsData = getDefaultPropsData();
             propsData.status = 'NotApplicable';
             wrapper = getWrapper(propsData);
             const icon = wrapper.findAllComponents(FontAwesomeIcon)
                 .filter(x => x.attributes('icon') === 'check')
-                .filter(x => x.classes('green-icon'))
+                .filter(x => x.classes('gray-icon'))
+                .at(0);
+            expect(icon.exists()).toEqual(true);
+        });
+
+        it('displays a red circle for critical severity', () => {
+            const propsData = getDefaultPropsData();
+            propsData.severity = 'Critical';
+            wrapper = getWrapper(propsData);
+            const icon = wrapper.findAllComponents(FontAwesomeIcon)
+                .filter(x => x.attributes('icon') === 'circle')
+                .filter(x => x.classes('red-icon'))
                 .at(0);
             expect(icon.exists()).toEqual(true);
         });
@@ -128,6 +139,17 @@ describe('components/GraphThreats.vue', () => {
             const icon = wrapper.findAllComponents(FontAwesomeIcon)
                 .filter(x => x.attributes('icon') === 'circle')
                 .filter(x => x.classes('green-icon'))
+                .at(0);
+            expect(icon.exists()).toEqual(true);
+        });
+
+        it('displays a gray circle for TBD severity', () => {
+            const propsData = getDefaultPropsData();
+            propsData.severity = 'TBD';
+            wrapper = getWrapper(propsData);
+            const icon = wrapper.findAllComponents(FontAwesomeIcon)
+                .filter(x => x.attributes('icon') === 'circle')
+                .filter(x => x.classes('gray-icon'))
                 .at(0);
             expect(icon.exists()).toEqual(true);
         });


### PR DESCRIPTION
**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Use appropriate icons for N/A status and TBD, Critical severities. Closes #1338

**Description for the changelog**:
<!-- A short (one line) summary that describes the changes in this pull request for inclusion in the change log -->
- use gray check icon for not applicable threats
- use gray circle for TBD severity threats
- use red circle for critical severity threats

**Declaration**:

- [x] appropriate unit tests have been created / modified

<img width="1888" height="720" alt="изображение" src="https://github.com/user-attachments/assets/617937d8-2a6e-47ba-9611-579e4a97c00e" />
