### PR TITLE
Fix typo in README regarding repository registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The web application variant of Threat Dragon requires some environment variables
 follow [the documentation][config] on how to set these variables.
 
 If access to external repositories is required, such as Bitbucket / GitHub  / GitLab,
-then you need to go to your to the repository account and register the application.
+then you need to go to your repository account and register the application.
 There are step by step guides on how to do this for [Bitbucket][bitbucket], [GitHub][github] and [GitLab][gitlab].
 
 ### Run the application


### PR DESCRIPTION
Hi there,

I found a  small typos in the README.md file while reading through the documentation. This PR corrects them.

Changes:
Removes a duplicated "to the" in the "Environment variables" section.

This is just a minor documentation fix. Thanks for this great project!