### PR TITLE
fix(github): Resolve branch name issue for protected branches

### DIFF
--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -86,10 +86,9 @@ export default {
             this.$router.push({ name: `${this.providerType}Repository` });
         },
         onBranchClick(branch) {
-            this.$store.dispatch(branchActions.selected, branch);
-            const params = Object.assign({}, this.$route.params, {
-                branch
-            });
+            const branchName = typeof branch === 'object' ? branch.value : branch;
+            this.$store.dispatch(branchActions.selected, branchName);
+            const params = Object.assign({}, this.$route.params, { branch: branchName });
 
             const routeName = `${this.providerType}${this.$route.query.action === 'create' ? 'NewThreatModel' : 'ThreatModelSelect'}`;
 

--- a/td.vue/tests/unit/views/branchAccess.spec.js
+++ b/td.vue/tests/unit/views/branchAccess.spec.js
@@ -188,6 +188,35 @@ describe('views/BranchAccess.vue', () => {
         });
     });
 
+    describe('onBranchClick - protected branch object', () => {
+        const protectedBranch = {
+            value: 'protectedBranchName',
+            icon: 'lock',
+            iconTooltip: 'branch.protectedBranch'
+        };
+        let routeParams;
+        beforeEach(() => {
+            routeParams = {
+                provider: mockStore.state.provider.selected,
+                repository: mockStore.state.repo.selected
+            };
+            getLocalVue({
+                params: routeParams,
+                query: {}
+            });
+            wrapper.vm.onBranchClick(protectedBranch);
+        });
+
+        it('extracts the branch name from the object', () => {
+            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_SELECTED, 'protectedBranchName');
+        });
+
+        it('navigates with the correct branch name', () => {
+            routeParams.branch = 'protectedBranchName';
+            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitThreatModelSelect', params: routeParams });
+        });
+    });
+
     describe('open add branch dialog', () => {
         beforeEach(() => {
             getLocalVue({


### PR DESCRIPTION
**Summary**:
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Resolves #1417

Currently it's not possible to perform any api action on protected branches using the Github integration. The branch name is not determined correctly as the logic assumes the `branch` to be a simple string when it's actually an object.

**Description for the changelog**:
<!-- A short (one line) summary that describes the changes in this pull request for inclusion in the change log -->
Check if the branch parameter is an object to access the `value` field for the branch name, otherwise use the parameter as the `branch` name.

**Declaration**:

- [x] appropriate unit tests have been created / modified
- [ ] functional tests created / modified for changes in functionality (Not sure if this applies, due to the github scope)
- [x] any use of AI has been declared in this pull request

**Other info**:
❌ 