### PR TITLE
Fix SVG/PNG export to exclude selection decorations

### DIFF
--- a/td.vue/src/components/GraphButtons.vue
+++ b/td.vue/src/components/GraphButtons.vue
@@ -150,22 +150,21 @@ export default {
             });
         },
         async withSelectionCleared(fn) {
-            // Store currently selected cells
+            
             const selectedCells = this.graph.getSelectedCells();
             
-            // Clear the selection to remove visual highlights
-            this.graph.cleanSelection();
-            
-            // Wait for next tick and a small delay to ensure rendering completes
-            await this.$nextTick();
-            await new Promise(resolve => setTimeout(resolve, 100));
             
             try {
-                // Perform the export
+                this.graph.cleanSelection();
+
+                //Rendering is not immediate. Without this pause the export may include
+                //the previous selection highlight.
+                await new Promise(resolve => setTimeout(resolve, 100));
+                
                 fn();
             } finally {
-                // Restore the selection after a brief delay
-                await new Promise(resolve => setTimeout(resolve, 50));
+                
+                
                 if (selectedCells.length > 0) {
                     this.graph.select(selectedCells);
                 }


### PR DESCRIPTION
**Summary**:  

Fixes an issue where selected diagram elements were included in exported SVG and PNG files.
Closes #1318.

**Description for the changelog**:  

Remove selection highlights from exported SVG and PNG diagrams.

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created / modified
- [ ] functional tests created / modified for changes in functionality
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] any [use of AI](../blob/main/contributing.md#use-of-ai) has been declared in this pull request

**Other info**:  

<!-- Add here any other information that may be of help to the reviewer -->
