### PR TITLE
fix: clear selection before PNG/SVG diagram export

### DIFF
--- a/td.vue/src/components/GraphButtons.vue
+++ b/td.vue/src/components/GraphButtons.vue
@@ -62,13 +62,11 @@
             :onBtnClick="save"
             icon="save"
             :text="$t('forms.save')" />
-
     </b-btn-group>
 </template>
 
 <script>
 import { mapState } from 'vuex';
-
 import TdFormButton from '@/components/FormButton.vue';
 
 export default {
@@ -137,15 +135,44 @@ export default {
                 this.gridShowing = true;
             }
         },
-        exportPNG() {
-            this.graph.exportPNG(`${this.diagram.title}.png`, {
-                padding: 50
+
+        /*UPDATED EXPORT METHODS */
+
+        async exportPNG() {
+            await this.withSelectionCleared(() => {
+                this.graph.exportPNG(`${this.diagram.title}.png`, {
+                    padding: 50
+                });
             });
         },
-        exportSVG() {
-            this.graph.exportSVG(`${this.diagram.title}.svg`);
+
+        async exportSVG() {
+            await this.withSelectionCleared(() => {
+                this.graph.exportSVG(`${this.diagram.title}.svg`);
+            });
+        },
+
+        async withSelectionCleared(fn) {
+            // Store currently selected cells
+            const selectedCells = this.graph.getSelectedCells();
+
+            // Clear selection to remove visual decorations
+            this.graph.cleanSelection();
+
+            // Wait for DOM/rendering to settle
+            await this.$nextTick();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            try {
+                fn();
+            } finally {
+                // Restore selection after export
+                await new Promise(resolve => setTimeout(resolve, 50));
+                if (selectedCells.length > 0) {
+                    this.graph.select(selectedCells);
+                }
+            }
         }
     }
 };
-
 </script>


### PR DESCRIPTION
Updated export methods to handle selections properly.Added proper comments to changes

**Summary**:  
Fixes an issue where selected diagram elements were exported with editor-only visual decorations (such as selection outlines and delete controls) in PNG and SVG exports.

This change ensures exported diagrams are clean and reflect the intended final view rather than the current editing state.

<!--

What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->Closes #1318 

**Description for the changelog**:  
 Clean up diagram exports by excluding selection highlights and editor controls from PNG and SVG output.
<!--

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created / modified
- [ ] functional tests created / modified for changes in functionality
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] any [use of AI](../blob/main/contributing.md#use-of-ai) has been declared in this pull request

**Other info**:  

<!-- Add here any other information that may be of help to the reviewer -->
