### PR TITLE
Fix image export affected by zoom level

### DIFF
--- a/td.vue/src/components/GraphButtons.vue
+++ b/td.vue/src/components/GraphButtons.vue
@@ -139,14 +139,26 @@ export default {
         },
         async exportPNG() {
             await this.withSelectionCleared(() => {
-                this.graph.exportPNG(`${this.diagram.title}.png`, {
-                    padding: 50
-                });
+                const currentZoom = this.graph.zoom();
+                try {
+                    this.graph.zoomTo(1);
+                    this.graph.exportPNG(`${this.diagram.title}.png`, {
+                        padding: 50
+                    });
+                }finally{
+                    this.graph.zoomTo(currentZoom);
+                }
             });
         },
         async exportSVG() {
             await this.withSelectionCleared(() => {
-                this.graph.exportSVG(`${this.diagram.title}.svg`);
+                const currentZoom = this.graph.zoom();
+                try{
+                    this.graph.zoomTo(1);
+                    this.graph.exportSVG(`${this.diagram.title}.svg`);
+                }finally{
+                    this.graph.zoomTo(currentZoom);
+                }
             });
         },
         async withSelectionCleared(fn) {


### PR DESCRIPTION
**Summary**:  

Fixes an issue where exported SVG and PNG files were impacted by the diagram’s zoom level.
Closes #1317 

**Description for the changelog**:  
Makes sure SVG and PNG exports aren’t affected by the zoom level.

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [ ] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] you have declared whether any [use of AI](../blob/main/contributing.md#use-of-ai) has (or has not) been used in this pull request

**Other info**:  
The final implementation and validation were performed manually and Generative AI was not used.
