### PR TITLE
Fix possible loss of diagram changes when using Save/Save As in  desktop menu

### DIFF
--- a/td.vue/public/preload.js
+++ b/td.vue/public/preload.js
@@ -24,5 +24,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     onPrintModelConfirmed: (callback) => ipcRenderer.on('print-model-confirmed', callback),
     onSaveModelRequest: (callback) => ipcRenderer.on('save-model-request', callback),
     onSaveModelConfirmed: (callback) => ipcRenderer.on('save-model-confirmed', callback),
-    onSaveModelFailed: (callback) => ipcRenderer.on('save-model-failed', callback)
+    onSaveModelFailed: (callback) => ipcRenderer.on('save-model-failed', callback),
+    onApplyDiagramRequest: (callback) => ipcRenderer.on('apply-diagram-request', callback)
 });

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -79,6 +79,18 @@ export default {
     },
     async mounted() {
         this.init();
+        if (window.electronAPI?.onApplyDiagramRequest) {
+            window.electronAPI.onApplyDiagramRequest(() => {
+                if (!this.graph) return;
+
+                const updated = Object.assign({}, this.diagram);
+                updated.cells = this.graph.toJSON().cells;
+
+                this.$store.dispatch(tmActions.diagramSaved, updated);
+                this.$store.dispatch(tmActions.notModified);
+            });
+
+        }
     },
     methods: {
         init() {

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -255,6 +255,8 @@ function saveModel () {
         mainWindow.webContents.send('save-model-failed', '', messages[language].threatmodel.warnings.noModelOpen);
         return;
     }
+    mainWindow.webContents.send('apply-diagram-request');
+
     logger.log.debug(messages[language].desktop.file.save + ': ' + 'prompt renderer for model data');
     mainWindow.webContents.send('save-model-request', path.basename(model.filePath));
 }
@@ -266,6 +268,8 @@ function saveModelAs () {
         mainWindow.webContents.send('save-model-failed', '', messages[language].threatmodel.warnings.noModelOpen);
         return;
     }
+    mainWindow.webContents.send('apply-diagram-request');
+    
     logger.log.debug(messages[language].desktop.file.saveAs + ': ' + 'clear location, prompt renderer for model data');
     // clear any existing filename to force a SaveAs
     model.filePath = '';

--- a/td.vue/src/store/modules/threatmodel.js
+++ b/td.vue/src/store/modules/threatmodel.js
@@ -123,6 +123,10 @@ const actions = {
         console.debug('Save threat model action');
         if (getProviderType(rootState.provider.selected) === providerTypes.desktop) {
             // desktop responds later with its own STASH and NOT_MODIFIED
+            if (Object.keys(state.selectedDiagram).length !== 0) {
+                commit(THREATMODEL_DIAGRAM_SAVED, state.selectedDiagram);
+            }
+
             window.electronAPI.modelSave(state.data, state.fileName);
         } else {
             let result = false;


### PR DESCRIPTION
**Summary**:  
Fixes an issue where diagram changes weren’t saved when using Save/Save As in the desktop menu bar.
Closes #1360 

**Description for the changelog**:  
Ensures that the Save and Save As options from the desktop menu save the latest diagram changes.

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [ ] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  
