### PR TITLE
Fix link formatting in vulnerability reporting section

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -51,7 +51,7 @@ Note that you **must** follow the rules for any [use of AI](#use-of-ai-for-issue
 ## Found a Vulnerability?
 
 If you think you have found a vulnerability in Threat Dragon then please report it
-to our [leaders / collaborators]([leaders].
+to our [leaders / collaborators][leaders].
 
 We are always very grateful to researchers who report vulnerabilities responsibly and are very happy
 to give all credit for the valuable assistance they provide.


### PR DESCRIPTION
**Summary**:  
There is invalid formatting for a link the maintainers / contributors page in the contributing.md file 

**Description for the changelog**:  
Fix broken link in contributing.md

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified (N/A)
- [ ] you have considered any changes required for the functional tests (N/A)
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  
No AI to disclose, just a quick typo fix! :) 