### PR TITLE
Fixed a bug in desktop app introduced in pr #1444

### DIFF
--- a/td.vue/src/views/demo/SelectDemoModel.vue
+++ b/td.vue/src/views/demo/SelectDemoModel.vue
@@ -61,7 +61,7 @@ export default {
                 // tell any electron server that the model has changed
                 window.electronAPI.modelOpened(model.name);
                 const params = Object.assign({}, this.$route.params, { threatmodel: model.name });
-                this.$router.push({ name: 'localThreatModel' , params });
+                this.$router.push({ name: 'desktopThreatModel' , params });
                 return;
             }
             if (this.providerType === providerTypes.local) {


### PR DESCRIPTION
**Summary**:  

Fixes a bug introduced in PR #1444 where desktop (Electron) users could no longer open demo models.

In SelectDemoModel.vue, a ternary expression was added to route git providers to repository selection and Google Drive to folder selection. The if statement only checked for providerTypes.local, but desktop does not fall under local  so desktop users hit the ternary, which constructed a desktopFolder route that doesn't exist. So for the fix i added routing to 'desktopThreatModel' route within the isElectron check so the desktop routing is now handled correctly.

<img width="865" height="146" alt="image" src="https://github.com/user-attachments/assets/55d3e6ab-9127-48f6-aa41-44724945891b" />



**Description for the changelog**:  

Fix desktop (Electron) demo model routing broken by provider-type handling in PR #1444

