### PR TITLE
Fix: Broken link in model select page

### DIFF
--- a/td.server/src/providers/bitbucket.js
+++ b/td.server/src/providers/bitbucket.js
@@ -88,5 +88,6 @@ export default {
     getOauthReturnUrl,
     getOauthRedirectUrl,
     isConfigured,
+    getBitbucketUrl,
     name
 };

--- a/td.server/src/providers/github.js
+++ b/td.server/src/providers/github.js
@@ -112,5 +112,6 @@ export default {
     getOauthReturnUrl,
     getOauthRedirectUrl,
     isConfigured,
+    getGithubUrl,
     name
 };

--- a/td.server/src/providers/gitlab.js
+++ b/td.server/src/providers/gitlab.js
@@ -88,5 +88,6 @@ export default {
     getOauthReturnUrl,
     getOauthRedirectUrl,
     isConfigured,
+    getGitlabUrl,
     name
 };

--- a/td.vue/src/service/api/threatmodelApi.js
+++ b/td.vue/src/service/api/threatmodelApi.js
@@ -16,7 +16,7 @@ const encodeUrlComponents = (... uriComponents) => {
  * Gets the organisation data configured for the express server
  * @returns {Promise}
  */
-const organisationAsync = () => api.getAsync(`${resource}/organisation`);
+const organisationAsync = (providerName) => api.getAsync(`${resource}/organisation`, { params: { provider: providerName } });
 
 /**
  * Gets the repos for the given user

--- a/td.vue/src/store/modules/provider.js
+++ b/td.vue/src/store/modules/provider.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import isElectron from 'is-electron';
 
-import {
+import{
     PROVIDER_CLEAR,
     PROVIDER_FETCH,
     PROVIDER_SELECTED
@@ -36,7 +36,7 @@ const actions = {
         } else if (providerName === 'local') {
             commit(PROVIDER_SELECTED, { 'providerName': 'local', 'providerUri': 'threat-dragon-local' });
         } else {
-            const resp = await threatmodelApi.organisationAsync();
+            const resp = await threatmodelApi.organisationAsync(providerName);
             const providerUri = `${resp.protocol}://${resp.hostname}${resp.port ? ':' + resp.port : ''}`;
             commit(PROVIDER_SELECTED, { 'providerName': providerName, 'providerUri': providerUri });
         }

--- a/td.vue/tests/unit/service/api/threatmodelApi.spec.js
+++ b/td.vue/tests/unit/service/api/threatmodelApi.spec.js
@@ -8,12 +8,13 @@ describe('service/threatmodelApi.js', () => {
     });
 
     describe('organisationAsync', () => {
+        const providerName = 'github';
         beforeEach(async () => {
-            await threatmodelApi.organisationAsync();
+            await threatmodelApi.organisationAsync(providerName);
         });
 
         it('calls the organisation endpoint', () => {
-            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/organisation');
+            expect(api.getAsync).toHaveBeenCalledWith('/api/threatmodel/organisation', { 'params': { 'provider': providerName } });
         });
     });
 


### PR DESCRIPTION
**Summary**:  

The link in the threat model select page heading was hardcoded to always point to GitHub, even if the user was authenticated with GitLab or Bitbucket. This meant users were sent to the wrong provider URL when clicking the repo link.

This fix involves using pre-existing provider modules  (github.js, gitlab.js, bitbucket.js) that  already had functions to return the correct base URL, so we can call those from the `organisation` endpoint instead of hardcoding GitHub config. The frontend then uses the response to build the right link for whichever provider the user is authenticated with. This fix closes issue #1445 

**Description for the changelog**:  

fixed repo link on threat model select page now correctly points to the authenticated provider(gitlab,bitbucket or github) instead of always assuming GitHub

<img width="1336" height="420" alt="image" src="https://github.com/user-attachments/assets/b2c0d141-304f-4275-bcc3-4f6500b91691" />

The image above shows how the url is always harcoded to have github's base url regardless of the origin of the repo.


<img width="703" height="535" alt="image" src="https://github.com/user-attachments/assets/00c0fda0-b427-49d2-8bf8-e828abc2266f" />

The image above shows the same end point with the fix applied. The URL is now dynamically set based on the provider used for authentication .The frontend sends the provider name to the backend, which uses it to build the appropriate URL and return it to the frontend.

