### PR TITLE
updated the link so that the unit test passes

### DIFF
--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -206,7 +206,7 @@ describe('components/ThreatEditDialog.vue', () => {
             await wrapper.vm.$nextTick();
             const link=wrapper.find('a');
             expect(link.exists()).toBe(true);
-            // expect(link.attributes('href')).toContain('https://cornucopia.owasp.org/card');
+            expect(link.attributes('href')).toContain('https://cornucopia.owasp.org/edition/webapp/');
             expect(link.text()).toContain('VE2');
         });
 


### PR DESCRIPTION
The test case expects the "cardUrl" in the threatEditDialog to point to an outdated base url, so made a quick fix to the updated link so all frontend tests pass.

closes #1451 