### PR TITLE
provide example minimal production env-vars

### DIFF
--- a/docs/configure/bitbucket.md
+++ b/docs/configure/bitbucket.md
@@ -222,6 +222,25 @@ or if using Windows:
 | `BITBUCKET_ENTERPRISE_PROTOCOL` | Optional if your Bitbucket enterprise instance uses a nonstandard protocol | `https` |
 | `BITBUCKET_REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in a Bitbucket repo | |
 
+### Example production Bitbucket environment
+
+Important: this example file contains test values, do not use these values for anything other than short-term tests.
+
+```text
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY: 00112233445566778899aabbccddeeff
+ENCRYPTION_JWT_SIGNING_KEY: deadbeef112233445566778899aabbcc
+ENCRYPTION_KEYS: [{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef"}]
+BITBUCKET_CLIENT_ID: deadbeef0123456789ab
+BITBUCKET_CLIENT_SECRET: deadbeef0123456789abcdef01234567deadbeef
+BITBUCKET_WORKSPACE: threat-dragon
+BITBUCKET_SCOPE: repository:write
+NODE_ENV: production
+PROTOCOL: https
+SERVER_API_PROTOCOL: https
+```
+
+Note the use of HTTPS in production deployments in this _minimal_ environment.
+
 ----
 
 Threat Dragon: _making threat modeling less threatening_

--- a/docs/configure/configure.md
+++ b/docs/configure/configure.md
@@ -206,7 +206,7 @@ for example `http://localhost:3000/`, but not in 'production' mode.
 __Note__ : the JWT refresh signing key should be different from the JWT signing key as they are different tokens.
 A JWT is used as the refresh token because it is tamper resistant and provides user context.
 
-### Remote environments
+### Remote repository environments
 
 Refer to the step by step guide pages for setting the environment variables specific for these technologies:
 

--- a/docs/configure/github.md
+++ b/docs/configure/github.md
@@ -249,6 +249,24 @@ templates/
 | `GITHUB_REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in a Github repo | |
 | `GITHUB_CONTENT_REPO` | Optional GitHub repository for organization-wide templates (e.g., `org/templates-repo`) | |
 
+### Example production github environment
+
+Important: this example file contains test values, do not use these values for anything other than short-term tests.
+
+```text
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY: 00112233445566778899aabbccddeeff
+ENCRYPTION_JWT_SIGNING_KEY: deadbeef112233445566778899aabbcc
+ENCRYPTION_KEYS: [{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef"}]
+GITHUB_CLIENT_ID: deadbeef0123456789ab
+GITHUB_CLIENT_SECRET: deadbeef0123456789abcdef01234567deadbeef
+GITHUB_SCOPE: repo
+NODE_ENV: production
+PROTOCOL: https
+SERVER_API_PROTOCOL: https
+```
+
+Note the use of HTTPS in production deployments in this _minimal_ environment.
+
 ----
 
 Threat Dragon: _making threat modeling less threatening_

--- a/docs/configure/gitlab.md
+++ b/docs/configure/gitlab.md
@@ -85,6 +85,25 @@ a similar example of setting up Github step by step.
 | `GITLAB_REDIRECT_URI` | The redirect provided to the GitLab OAuth app | |
 | `GITLAB_REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in a GitLab repo | |
 
+### Example production GitLab environment
+
+Important: this example file contains test values, do not use these values for anything other than short-term tests.
+
+```text
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY: 00112233445566778899aabbccddeeff
+ENCRYPTION_JWT_SIGNING_KEY: deadbeef112233445566778899aabbcc
+ENCRYPTION_KEYS: [{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef"}]
+GITLAB_CLIENT_ID: 00112233445566778899aabbccddeeff
+GITLAB_CLIENT_SECRET: gloas-deadbeef0123456789abcdefdeadbeef
+GITLAB_SCOPE: read_user read_repository write_repository profile read_api api
+GITLAB_HOST: https://secure-gitlab-instance
+NODE_ENV: production
+PROTOCOL: https
+SERVER_API_PROTOCOL: https
+```
+
+Note the use of HTTPS in production deployments in this _minimal_ environment.
+
 ----
 
 Threat Dragon: _making threat modeling less threatening_

--- a/docs/configure/google.md
+++ b/docs/configure/google.md
@@ -178,6 +178,25 @@ Ensure that Threat Dragon is running on `http://localhost:8080/#/` as expected, 
 | `GOOGLE_SCOPE` | Optional authorization scopes | `openid email profile` |
 | `GOOGLE_REDIRECT_URI` | Required URL following successful authorization | |
 
+### Example production Google environment
+
+Important: this example file contains test values, do not use these values for anything other than short-term tests.
+
+```text
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY: 00112233445566778899aabbccddeeff
+ENCRYPTION_JWT_SIGNING_KEY: deadbeef112233445566778899aabbcc
+ENCRYPTION_KEYS: [{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef"}]
+GOOGLE_CLIENT_ID: 01234567890123456789
+GOOGLE_CLIENT_SECRET: 0123456789abcdef0123456789abcdef0123456
+GOOGLE_SCOPE: openid email profile
+GOOGLE_REDIRECT_URI: https://secure-google-instance:3000/api/oauth/return
+NODE_ENV: production
+PROTOCOL: https
+SERVER_API_PROTOCOL: https
+```
+
+Note the use of HTTPS in production deployments in this _minimal_ environment.
+
 ----
 
 Threat Dragon: _making threat modeling less threatening_

--- a/docs/configure/local.md
+++ b/docs/configure/local.md
@@ -127,6 +127,21 @@ or if using Windows:
 
 - `docker run -d -p 8080:3000 -v %CD%/test.env:/app/.env owasp/threat-dragon:stable`
 
+### Example production local environment
+
+Important: this example file contains test values, do not use these values for anything other than short-term tests.
+
+```text
+ENCRYPTION_JWT_REFRESH_SIGNING_KEY: 00112233445566778899aabbccddeeff
+ENCRYPTION_JWT_SIGNING_KEY: deadbeef112233445566778899aabbcc
+ENCRYPTION_KEYS: [{"isPrimary": true, "id": 0, "value": "0123456789abcdef0123456789abcdef"}]
+NODE_ENV: production
+PROTOCOL: https
+SERVER_API_PROTOCOL: https
+```
+
+Note the use of HTTPS in production environments.
+
 ----
 
 Threat Dragon: _making threat modeling less threatening_


### PR DESCRIPTION
**Summary**:  

This provides a set of examples in the documentation that sets out a minimal production set of web-app environment variables. For:

- local
- github
- gitlab
- bitbucket
- google

No environment variables applicable to desktop version

**Description for the changelog**:  

provide example minimal production env-vars

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

closes #1370 
