### PR TITLE
Dockerfile Refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ FROM        node:$NODE_VERSION-alpine AS base-node
 RUN         apk -U upgrade
 WORKDIR     /app
 RUN         npm i -g npm@latest
-RUN         mkdir -p td.server td.vue
-RUN         mkdir -p td.vue/src/service/schema/api_json
 RUN         chown -R node:node /app
 USER        node
 
@@ -14,7 +12,7 @@ USER        node
 # Build the front and back-end.  This needs devDependencies which do not
 # need to be included in the final image
 FROM        base-node AS build
-RUN         mkdir boms
+RUN         mkdir -p boms td.server td.vue td.vue/src/service/schema/api_json
 
 COPY        package-lock.json package.json /app/
 COPY        ./td.server/package-lock.json ./td.server/package.json ./td.server/
@@ -37,7 +35,7 @@ RUN         cp td.server/sbom.json        boms/threat-dragon-server-bom.json && 
             cp td.vue/dist/.sbom/bom.xml  boms/threat-dragon-site-bom.xml
 
 
-FROM        ruby:3.2-slim-bullseye AS build-docs
+FROM        ruby:4.0-slim-bookworm AS build-docs
 RUN         apt-get update \
             && apt-get install -y --no-install-recommends \
             build-essential \
@@ -52,14 +50,14 @@ RUN         bundle exec jekyll build -b docs/
 
 # Build the final, production image.
 FROM        base-node
-COPY        --from=build-docs /td.docs/_site /app/docs
-COPY        --from=build /app/boms /app/boms
+COPY        --chown=node:node --from=build-docs /td.docs/_site /app/docs
+COPY        --chown=node:node --from=build /app/boms /app/boms
 
-COPY        ./td.server/package-lock.json ./td.server/package.json ./td.server/
+COPY        --chown=node:node ./td.server/package-lock.json ./td.server/package.json ./td.server/
 RUN         cd td.server && npm clean-install --omit dev --ignore-scripts
-COPY        --from=build /app/td.server/dist ./td.server/dist
-COPY        --from=build /app/td.vue/dist ./dist
-COPY        ./td.server/index.js ./td.server/index.js
+COPY        --chown=node:node --from=build /app/td.server/dist ./td.server/dist
+COPY        --chown=node:node --from=build /app/td.vue/dist ./dist
+COPY        --chown=node:node ./td.server/index.js ./td.server/index.js
 
 HEALTHCHECK --interval=10s --timeout=2s --start-period=2s CMD ["/nodejs/bin/node", "./td.server/dist/healthcheck.js"]
 CMD         ["td.server/index.js"]


### PR DESCRIPTION
**Summary**:  

Closes #1474 
Closes #1472 

Previously, some files in the final docker image were owned by root.  While not a security vulnerability in and of itself, we specify that the container's user is node, and we should have all the files in `/app` owned by `node:node`.

We recently updated the documentation to use ruby 4+, so we should be using 4+ to build the documentation in the docker image as well.  See #1471 

**Description for the changelog**:  

All files in the docker image under `/app` are now owned by the node user.  

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

N/A