### PR TITLE
Add Threat Dragon AI Tool documentation and integrations section

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -57,6 +57,8 @@ nav:
       groups:
         - name: Modeling
           fa_class: fas fa-pencil-alt
+        - name: Integrations
+          fa_class: fas fa-plug
     - name: Open Source
       groups:
         - name: Development

--- a/docs/integrations/threat-dragon-ai-tool.md
+++ b/docs/integrations/threat-dragon-ai-tool.md
@@ -1,0 +1,33 @@
+---
+title: Threat Dragon AI Tool
+---
+
+# Threat Dragon AI Tool
+
+The Threat Dragon AI Tool integrates AI assistance into the OWASP Threat Dragon threat modeling workflow.
+
+It helps generate potential threats and mitigations automatically based on system architecture and inputs.
+
+## Repository
+
+The source code and documentation for the project are available on GitHub:
+
+[Threat-Dragon-AI-Tool_Github_](https://github.com/InfosecOTB/threat-dragon-ai-tool)
+
+
+## AI-Powered Threat Modeling Research
+
+The development of this tool is based on research described in Piotr's blog series on AI-powered threat modeling. 
+The series explores how large language models and automation techniques can assist security professionals in identifying and analyzing threats.
+
+You can read the full series here:
+
+- [Piotr's blog series](https://infosecotb.com/category/security-architecture/)
+
+## Use Cases
+
+Possible use cases for this integration include:
+
+- assisting developers during early threat modeling sessions
+- automatically suggesting potential threats based on system descriptions
+- exploring how AI tools can augment secure development workflows


### PR DESCRIPTION
**Summary**:  
Adds documentation for the Threat Dragon AI Tool integration.

Closes #1493 

This PR introduces a new Integrations section under the Usage documentation and adds a page describing the Threat Dragon AI Tool project.

**Description for the changelog**:  
Add documentation page for Threat Dragon AI Tool integration.

**Declaration**:  
Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [ ] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

This change adds:

docs/integrations/threat-dragon-ai-tool.md

a new Integrations group in the documentation navigation via docs/_config.yml

The documentation includes:

a high-level overview of the Threat Dragon AI Tool

a link to the GitHub repository

references to Piotr's AI-powered threat modeling blog series.