### PR TITLE
Fix Desktop e2e Menu Test to Use Latest Release

### DIFF
--- a/td.vue/tests/e2e/desktop/support/menu.js
+++ b/td.vue/tests/e2e/desktop/support/menu.js
@@ -100,7 +100,7 @@ helpMenu.links = [
     },
     { label: helpMenu.labels.github, url: 'https://github.com/owasp/threat-dragon/' },
     { label: helpMenu.labels.submit, url: 'https://github.com/owasp/threat-dragon/issues/new/choose/' },
-    { label: helpMenu.labels.check, url: 'https://github.com/OWASP/threat-dragon/releases/' }
+    { label: helpMenu.labels.check, url: 'https://github.com/OWASP/threat-dragon/releases/latest/' }
 ];
 
 const waitForToast = async (text) => {


### PR DESCRIPTION
**Summary**:  

Fixes #1517 
I already broke the desktop e2e tests! :disappointed: 
There's a test that checks all the links in the menu.  In #1497 we updated the menu to point to the latest release.
I reviewed and approved the PR, but I didn't think to update #1494 :sweat_smile: 

**Description for the changelog**:  

Fix for desktop e2e test

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:
  
Whoops!

If we decide that these tests are too flaky in the future, I'm happy to revisit!  We could even reel it in to use a startsWith type matcher.  I think for now my preference would be to keep this as is, so it is immediately obvious in future PRs if we are changing any of the external links.