### PR TITLE
Pinning Trivy GH Action to commit hash for v0.35.0

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -62,7 +62,8 @@ jobs:
           ref: main
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        # Pinned to commit for v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: '${{ env.IMAGE_NAME }}'
           format: 'template'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -462,7 +462,8 @@ jobs:
           docker load --input /tmp/${{ env.IMAGE_NAME }}.tar
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        # Pinned to commit for v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: '${{ env.IMAGE_NAME }}'
           format: 'table'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -488,7 +488,8 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        # Pinned to commit for v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: '${{ env.IMAGE_NAME }}'
           format: 'template'


### PR DESCRIPTION
**Summary**:  

Relates to #1518 

Updates all Trivy GH Actions to v0.35.0 - but **using the commit hash instead of a version tag**.

Our Trivy actions are failing because the tags they reference are no longer available.  All tags were removed as part of the containment effort by AcquaSecurity (the makers of Trivy) related to a recent compromise.  

Unlike tags, commit hashes are immutable.  Even if the git history is rewritten, the commit becomes orphaned rather than overwritten.

**Description for the changelog**:  

Pin Trivy GitHub action to specific commit

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [ ] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

This is the exact recommendation from AquaSecurity: https://www.aquasec.com/blog/autonomous-runtime-security-turning-runtime-intelligence-into-agentic-response-2/

I think there needs to be a larger discussion around GH Actions / dependency pinning.  Aggressive pinning like this does increase maintenance overhead, and it is also less readable than a tag which is usually a semantic version.  However, due to the immutable nature of commit hashes, this is significantly more secure from a dependency management / supply chain hardening perspective. 