### PR TITLE
notify contributors that signed commits are mandatory

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -129,6 +129,7 @@ schemas
 snapcraft
 sudo
 Suomi
+SHA
 SVG
 SY
 TBC

--- a/contributing.md
+++ b/contributing.md
@@ -19,6 +19,7 @@ and actually work, you will then get a better response.
 * ensure that [unit tests][unit] have been extended or created for any code changes
 * if the contribution changes the functionality then ensure that the [functional tests][e2e] are created or modified
 * the use of generative AI is not prohibited but must be declared in the [pull request](#use-of-ai-for-coding)
+* the main repository only accepts [signed commits][signed-commits], otherwise the contribution will be rejected
 
 ### Contributor etiquette
 
@@ -151,4 +152,5 @@ Threat Dragon: _making threat modeling less threatening_
 [project]: https://owasp.org/www-project-threat-dragon/
 [raise]: https://github.com/OWASP/threat-dragon/issues/new?assignees=&labels=bug&template=bug_report.md&title=
 [request]: https://github.com/OWASP/threat-dragon/issues/new/choose
+[signed-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
 [unit]: https://www.threatdragon.com/docs/testing/unit.html

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -15,6 +15,10 @@ We are trying to keep the test coverage relatively high, so please try to update
 There are some [developer notes]({{ '/development/development.html' | relative_url }})
 to help you get started with this project.
 
+The Threat Dragon main branch only accepts signed commits, otherwise the contribution will be rejected.
+Signed commits help to filter out malicious activity,
+see the Github documentation on [commit signature verification][signed-commits].
+
 ### Quick start
 
 Clone and install the Threat Dragon repo:
@@ -41,3 +45,5 @@ For secure disclosure, please see the [security policy](https://github.com/OWASP
 ----
 
 Threat Dragon: _making threat modeling less threatening_
+
+[signed-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -50,6 +50,10 @@ for example the dropping of 'unnecessary' semicolons is not to be adopted.
 
 Indents are generally set to 4, but this may change and it might go to a 2 space indentation sometime in the future.
 
+To contribute to the Threat Dragon main branch you must provide signed commits, otherwise they will be rejected.
+Signed commits help to filter out malicious activity,
+see the Github documentation on [commit signature verification][signed-commits].
+
 ### Running Locally
 
 The local environment is split into different parts: `td.server` and `td.vue`.
@@ -112,3 +116,5 @@ The notarization status of the MacOS `.app` file can be checked with command:
 ----
 
 Threat Dragon: _making threat modeling less threatening_
+
+[signed-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification

--- a/docs/trust/trust.md
+++ b/docs/trust/trust.md
@@ -8,6 +8,13 @@ group: Trust
 
 ## Trust
 
+The Threat Dragon development team build security into the application and the supply chain.
+Some examples of this are:
+
+* the code repository enforces signed commits which helps filter out malicious activity
+* the supply chain actions are identified using a full-length SHA
+* the desktop installer releases are signed and notarized where possible
+
 ### Continual testing
 
 The automated security scans of Threat Dragon are run on every commit:


### PR DESCRIPTION
**Summary**:  

This documents that signed commits are mandatory and notifies contributors

**Description for the changelog**:  

document mandatory signed commits

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- N/A appropriate unit tests have been created and/or modified
- N/A you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Closes #1525 
