### PR TITLE
Sync i18n files to have same keys

### DIFF
--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -509,7 +509,7 @@ const ara = {
             openMedium: 'مفتوح / أولوية متوسطة',
             openLow: 'مفتوح / أولوية منخفضة',
             openTbd: 'مفتوح / الأولوية في TBD',
-            openunknown: 'مفتوح / أولوية غير معروفة'
+            openUnknown: 'مفتوح / أولوية غير معروفة'
         }
     },
     upgrade: {

--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -4,7 +4,8 @@ const ara = {
     },
     nav: {
         loggedInAs: 'تم تسجيل الدخول كـ ',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const ara = {
             openExisting: 'فتح نموذج تهديد موجود',
             createNew: 'إنشاء نموذج تهديد جديد فارغ',
             readDemo: 'استكشاف نموذج تهديد تجريبي',
-            importExisting: 'استيراد نموذج التهديد بصيغة  JSON'
+            importExisting: 'استيراد نموذج التهديد بصيغة  JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const ara = {
         repo: 'مستودع',
         newThreatModel: 'إنشاء نموذج تهديد جديد'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'المساهمون',
         contributorsPlaceholder: 'ابدأ الكتابة لإضافة مساهم',
@@ -168,6 +232,7 @@ const ara = {
             onlyJsonAllowed: 'الملفات التي يمكن التعامل معها هي التي تنتهي بامتداد .json فقط.',
             open: 'حدث خطأ في فتح نموذج التهديد. تحقق من الـ console الخاص بالمطور (developer console) للحصول على مزيد من المعلومات',
             save: 'حدث خطأ في حفظ نموذج التهديد. تحقق من الـ console الخاص بالمطور (developer console) للحصول على مزيد من المعلومات',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const ara = {
         saveModelAs: 'حفظ النموذج كـ',
         search: 'بحث',
         next: 'التالي',
-        previous: 'السابق'
+        previous: 'السابق',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'تفاصيل البطاقة',
@@ -360,6 +427,16 @@ const ara = {
                 informationDisclosure: 'Information disclosure كشف المعلومات',
                 denialOfService: 'Denial of service إنكار الخدمة',
                 elevationOfPrivilege: 'Elevation of privilege تسلق الامتياز'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding',
+                authentication: 'Authentication',
+                sessionManagement: 'Session Management',
+                authorization: 'Authorization',
+                cryptography: 'Cryptography',
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -4,7 +4,8 @@ const deu = {
     },
     nav: {
         loggedInAs: 'Angemeldet als',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const deu = {
             openExisting: 'Ein bestehendes Bedrohungsmodell öffnen',
             createNew: 'Ein neues, leeres, Bedrohungsmodell erstellen',
             readDemo: 'Erkunden Sie ein Bespiel Bedrohungsmodell',
-            importExisting: 'Ein Bedrohungsmodell als JSON importieren'
+            importExisting: 'Ein Bedrohungsmodell als JSON importieren',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const deu = {
         repo: 'Repository',
         newThreatModel: 'Ein neues Bedrohungsmodell erstellen'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Mitwirkende',
         contributorsPlaceholder: 'Tippen Sie, um Mitwirkende hinzuzufügen',
@@ -157,8 +221,7 @@ const deu = {
                 defaultTitle: 'Neues EoP-Spielediagramm',
                 defaultDescription: 'Beschreibung des neuen EoP-Spielediagramms',
                 select: 'EoP-Spiele'
-            }
-            
+            }            
         },
         threats: 'Bedrohungen',
         errors: {
@@ -168,7 +231,8 @@ const deu = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Nur Datein mit .json Endung werden unterstützt.',
             open: 'Fehler beim Öffnen des Bedrohungsmodells. Prüfen Sie die Developer Konsole für mehr Informationen',
-            save: 'Fehler beim Speichern des Bedrohungsmodells. Prüfen Sie die Developer Konsole für mehr Informationen'
+            save: 'Fehler beim Speichern des Bedrohungsmodells. Prüfen Sie die Developer Konsole für mehr Informationen',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -304,7 +368,9 @@ const deu = {
         saveModelAs: 'Modell speichern als',
         search: 'Suchen',
         next: 'nächste',
-        previous: 'vorherige'
+        previous: 'vorherige',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Kartendetails',
@@ -361,6 +427,16 @@ const deu = {
                 informationDisclosure: 'Veröffentlichung von Informationen',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Erhöhung von Rechten'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -4,7 +4,8 @@ const ell = {
     },
     nav: {
         loggedInAs: 'Σύνδεση ως',
-        logOut: 'Αποσύνδεση'
+        logOut: 'Αποσύνδεση',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const ell = {
             openExisting: 'Άνοιγμα ενός υφιστάμενου μοντέλου απειλών',
             createNew: 'Δημιουργήστε ένα νέο, κενό μοντέλο απειλών',
             readDemo: 'Εξερευνήστε ένα δείγμα μοντέλου απειλών',
-            importExisting: 'Εισάγετε ένα μοντέλο απειλών σε μορφή JSON'
+            importExisting: 'Εισάγετε ένα μοντέλο απειλών σε μορφή JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const ell = {
         repo: 'αποθετήριο',
         newThreatModel: 'Δημιουργήστε ένα νέο μοντέλο απειλών'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Συνεισφέροντες',
         contributorsPlaceholder: 'Προσθήκη ενός νέου συνεισφέροντος',
@@ -167,7 +231,8 @@ const ell = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Υποστηρίζονται μόνο αρχεία με κατάληξη .json.',
             open: 'Σφάλμα κατά το άνοιγμα αυτού του μοντέλου απειλών. Ελέγξτε την κονσόλα του προγραμματιστή για περισσότερες πληροφορίες',
-            save: 'Σφάλμα κατά την αποθήκευση του μοντέλου απειλών. Παρακαλούμε ελέγξτε την κονσόλα για περαιτέρω πληροφορίες'
+            save: 'Σφάλμα κατά την αποθήκευση του μοντέλου απειλών. Παρακαλούμε ελέγξτε την κονσόλα για περαιτέρω πληροφορίες',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const ell = {
         saveModelAs: 'Αποθήκευση Μοντέλου ως',
         search: 'Αναζήτηση',
         next: 'Επόμενο',
-        previous: 'προηγούμενος'
+        previous: 'προηγούμενος',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Λεπτομέρειες κάρτας',
@@ -360,6 +427,16 @@ const ell = {
                 informationDisclosure: 'Αποκάλυψη Πληροφοριών (Information Disclosure)',
                 denialOfService: 'Άρνηση εκτέλεσης υπηρεσίας (Denial of service)',
                 elevationOfPrivilege: 'Αναβάθμιση προνομίων (Elevation of Priviledge)'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -151,7 +151,6 @@ const eng = {
             templateDownloading: 'Downloading template'
         },
         repo: {
-            
             notInitialized: {
                 title: 'Template Repository Not Initialized',
                 userMessage: 'The template repository has not been initialized. Please contact your administrator.',
@@ -172,8 +171,6 @@ const eng = {
                 action: 'Initialize',
                 success: 'Template repository successfully initialized.',
                 error: 'Could not initialize the template repository. Check the developer console for more information.'
-
-
             }
         },
     },
@@ -373,7 +370,6 @@ const eng = {
         next:'Next',
         previous:'Previous',
         manage : 'Manage...',
-
         exportTemplate: 'Export As Template',
     },
     cards: {
@@ -431,6 +427,16 @@ const eng = {
                 informationDisclosure: 'Information disclosure',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Elevation of privilege'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -4,7 +4,8 @@ const spa = {
     },
     nav: {
         loggedInAs: 'Conectado como',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const spa = {
             openExisting: 'Abrir un modelo de amenazas (threat model) existente',
             createNew: 'Crear un nuevo modelo de amenazas (threat model) desde cero',
             readDemo: 'Descargar y explorar un ejemplo de modelo de amenazas (threat model)',
-            importExisting: 'Importar un modelo de amenazas (threat model) de JSON'
+            importExisting: 'Importar un modelo de amenazas (threat model) de JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const spa = {
         repo: 'repositorio',
         newThreatModel: 'Crear un nuevo modelo de amenazas (threat model)'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Colaboradores',
         contributorsPlaceholder: 'Agregar un nuevo colaborador',
@@ -167,7 +231,8 @@ const spa = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Solamente archivos con extensión .json son soportados.',
             open: 'Error al abrir el modelo de amenazas. Consulte la consola de desarrollador para obtener más información.',
-            save: 'Error al guardar el modelo de amenazas. Consulte la consola de desarrollador para obtener más información.'
+            save: 'Error al guardar el modelo de amenazas. Consulte la consola de desarrollador para obtener más información.',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const spa = {
         saveModelAs: 'Guardar modelo como',
         search: 'Buscar',
         next: 'próximo',
-        previous: 'Previo'
+        previous: 'Previo',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Detalles de la carta',
@@ -380,7 +447,6 @@ const spa = {
             plot4ai: 'Nueva amenaza PLOT4ai',
             stride: 'Nueva amenaza STRIDE',
             eop: 'Nueva amenaza EoP'
-
         },
         edit: 'Editar amenaza',
         confirmDeleteTitle: 'Confirmación de eliminación',

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -4,7 +4,8 @@ const fin = {
     },
     nav: {
         loggedInAs: 'Kirjautunut käyttäjänä',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const fin = {
             openExisting: 'Avaa olemassa oleva uhkamalli',
             createNew: 'Tee uusi tyhjä uhkamalli',
             readDemo: 'Tutki esimerkkejä',
-            importExisting: 'Tuo uhkamalli JSON-tiedostosta'
+            importExisting: 'Tuo uhkamalli JSON-tiedostosta',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const fin = {
         repo: 'arkisto',
         newThreatModel: 'Tee uusi uhkamalli'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Osallistujat',
         contributorsPlaceholder: 'Kirjoita lisätäksesi uuden osallistujan',
@@ -167,7 +231,8 @@ const fin = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Sovellus tukee vain .json -päätteisiä tiedostoja.',
             open: 'Virhe uhkamallin lukemisessa. Yksityiskohtaisemmat tiedot virheestä löytyvät kehittäjän konsolista.',
-            save: 'Virhe uhkamallin tallentamisessa. Yksityiskohtaisemmat tiedot virheestä löytyvät kehittäjän konsolista.'
+            save: 'Virhe uhkamallin tallentamisessa. Yksityiskohtaisemmat tiedot virheestä löytyvät kehittäjän konsolista.',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const fin = {
         saveModelAs: 'Tallenna Uhkamalli Nimellä',
         search: 'Etsi',
         next: 'Seuraava',
-        previous: 'Edellinen'
+        previous: 'Edellinen',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Kortin tiedot',
@@ -360,6 +427,16 @@ const fin = {
                 informationDisclosure: 'Information disclosure',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Elevation of privilege'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -4,7 +4,8 @@ const fra = {
     },
     nav: {
         loggedInAs: 'Connecté en tant que',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const fra = {
             openExisting: 'Ouvrir un modèle de menace existant',
             createNew: 'Créer un nouveau modèle de menace',
             readDemo: 'Explorez un exemple de modèle de menace',
-            importExisting: 'Importer un modèle de menace via JSON'
+            importExisting: 'Importer un modèle de menace via JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const fra = {
         repo: 'projet',
         newThreatModel: 'Créer un nouveau modèle de menace'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Contributeurs',
         contributorsPlaceholder: 'Ajouter un nouveau contributeur',
@@ -167,7 +231,8 @@ const fra = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Only files that end with .json are supported.',
             open: 'Erreur lors de l\'ouverture de ce modèle de menace. Vérifiez la console de développement pour plus d\'informations',
-            save: 'Erreur lors de la sauvegarde de ce modèle de menace. Vérifiez la console de développement pour plus d\'informations'
+            save: 'Erreur lors de la sauvegarde de ce modèle de menace. Vérifiez la console de développement pour plus d\'informations',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const fra = {
         saveModelAs: 'Sauvergarder le modèle en tant que',
         search: 'Rechercher',
         next: 'suivant',
-        previous: 'précédent'
+        previous: 'précédent',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Détails de la carte',
@@ -360,6 +427,16 @@ const fra = {
                 informationDisclosure: 'Divulgation d\'information',
                 denialOfService: 'Déni de service',
                 elevationOfPrivilege: 'Élévation de privilège'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -4,7 +4,8 @@ const hin = {
     },
     nav: {
         loggedInAs: 'लॉग-इन किया गया है भूमिका में',
-        logOut: 'लॉगआउट'
+        logOut: 'लॉगआउट',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP थ्रेट ड्रैगन',
@@ -46,7 +47,8 @@ const hin = {
             openExisting: 'एक मौजूदा थ्रेट मॉडल खोलें',
             createNew: 'एक नया, खाली थ्रेट मॉडल बनाएँ',
             readDemo: 'एक नमूना थ्रेट मॉडल का अन्वेषण करें',
-            importExisting: 'JSON के माध्यम से एक थ्रेट मॉडल आयात करें'
+            importExisting: 'JSON के माध्यम से एक थ्रेट मॉडल आयात करें',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const hin = {
         repo: 'रेपो',
         newThreatModel: 'एक नया थ्रेट मॉडल बनाएं'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'योगदानकर्ता',
         contributorsPlaceholder: 'योगदानकर्ता जोड़ने के लिए टाइप करना प्रारंभ करें',
@@ -167,7 +231,8 @@ const hin = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'केवल .json के साथ समाप्त होने वाली फ़ाइलें समर्थित हैं।',
             open: 'इस थ्रेट मॉडल को खोलने में त्रुटि। अधिक जानकारी के लिए डेवलपर कंसोल की जाँच करें',
-            save: 'खतरे के मॉडल को सहेजने में त्रुटि। अधिक जानकारी के लिए डेवलपर कंसोल की जाँच करें'
+            save: 'खतरे के मॉडल को सहेजने में त्रुटि। अधिक जानकारी के लिए डेवलपर कंसोल की जाँच करें',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const hin = {
         saveModelAs: 'मॉडल को इस रूप में सहेजें',
         search: 'खोज',
         next: 'अगला',
-        previous: 'पहले का'
+        previous: 'पहले का',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'कार्ड विवरण',
@@ -360,6 +427,16 @@ const hin = {
                 informationDisclosure: 'सूचना प्रकटीकरण',
                 denialOfService: 'सेवा से इनकार',
                 elevationOfPrivilege: 'विशेषाधिकार का उन्नयन'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -4,7 +4,8 @@ const ind = {
     },
     nav: {
         loggedInAs: 'Masuk sebagai',
-        logOut: 'Keluar'
+        logOut: 'Keluar',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const ind = {
             openExisting: 'Buka model ancaman yang ada',
             createNew: 'Buat model ancaman kosong baru',
             readDemo: 'Jelajahi model ancaman sampel',
-            importExisting: 'Impor model ancaman melalui JSON'
+            importExisting: 'Impor model ancaman melalui JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const ind = {
         repo: 'repo',
         newThreatModel: 'Buat Model Ancaman Baru'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Kontributor',
         contributorsPlaceholder: 'Mulai mengetik untuk menambahkan kontributor',
@@ -167,7 +231,8 @@ const ind = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Hanya file yang berakhir dengan .json yang didukung.',
             open: 'Kesalahan membuka Model Ancaman ini. Periksa konsol pengembang untuk informasi lebih lanjut',
-            save: 'Kesalahan menyimpan Model Ancaman. Periksa konsol pengembang untuk informasi lebih lanjut'
+            save: 'Kesalahan menyimpan Model Ancaman. Periksa konsol pengembang untuk informasi lebih lanjut',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const ind = {
         saveModelAs: 'Simpan Model Sebagai',
         search: 'Cari',
         next: 'Berikutnya',
-        previous: 'sebelumnya'
+        previous: 'sebelumnya',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Detail kartu',
@@ -360,6 +427,16 @@ const ind = {
                 informationDisclosure: 'Information disclosure',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Elevation of privilege'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -4,7 +4,8 @@ const jpn = {
     },
     nav: {
         loggedInAs: 'ユーザー名',
-        logOut: 'ログアウト'
+        logOut: 'ログアウト',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const jpn = {
             openExisting: '既存の脅威モデルを開く',
             createNew: '新しい脅威モデルを作る',
             readDemo: '脅威モデルの一例を見る',
-            importExisting: '脅威モデルをJSONからインポートする'
+            importExisting: '脅威モデルをJSONからインポートする',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const jpn = {
         repo: 'リポジトリに切り替える',
         newThreatModel: '新しい脅威モデルを作成する'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: '貢献者',
         contributorsPlaceholder: '貢献した方の名前',
@@ -167,7 +231,8 @@ const jpn = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: '拡張子.jsonのファイルのみに対応しています。',
             open: '脅威モデルを開く時にエラーが発生しました。開発者コンソールを確認してください。',
-            save: '脅威モデルを保存時にエラーが発生しました。開発者コンソールを確認してください。'
+            save: '脅威モデルを保存時にエラーが発生しました。開発者コンソールを確認してください。',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const jpn = {
         saveModelAs: '名前を付けてモデルを保存',
         search: '検索',
         next: '次',
-        previous: '前の'
+        previous: '前の',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'カードの詳細',
@@ -360,6 +427,16 @@ const jpn = {
                 informationDisclosure: '情報漏洩',
                 denialOfService: 'サービス拒否',
                 elevationOfPrivilege: '特権の昇格'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {
@@ -370,7 +447,6 @@ const jpn = {
             plot4ai: 'PLOT4ai脅威を追加',
             stride: 'STRIDE脅威を追加',
             eop: 'EoPゲーム脅威を追加',
-
         },
         edit: '脅威を編集',
         confirmDeleteTitle: '削除の確認',

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -4,7 +4,8 @@ const msa = {
     },
     nav: {
         loggedInAs: 'Log masuk sebagai',
-        logOut: 'Log keluar'
+        logOut: 'Log keluar',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const msa = {
             openExisting: 'Buka model ancaman sedia ada',
             createNew: 'Cipta model ancaman baru yang kosong',
             readDemo: 'Teroka model ancaman contoh',
-            importExisting: 'Import model ancaman melalui JSON'
+            importExisting: 'Import model ancaman melalui JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const msa = {
         repo: 'repo',
         newThreatModel: 'Cipta Model Ancaman Baharu'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Penyumbang',
         contributorsPlaceholder: 'Mulakan menaip untuk menambah penyumbang',
@@ -158,7 +222,6 @@ const msa = {
                 defaultDescription: 'Penerangan gambarajah EoP permainan baru',
                 select: 'EoP permainan'
             }
-
         },
         threats: 'Ancaman',
         errors: {
@@ -168,7 +231,8 @@ const msa = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Hanya fail yang berakhir dengan .json yang disokong.',
             open: 'Ralat membuka Model Ancaman ini. Semak konsol pembangun untuk maklumat lanjut',
-            save: 'Ralat menyimpan Model Ancaman ini. Semak konsol pembangun untuk maklumat lanjut'
+            save: 'Ralat menyimpan Model Ancaman ini. Semak konsol pembangun untuk maklumat lanjut',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -304,7 +368,9 @@ const msa = {
         saveModelAs: 'Simpan Model Sebagai',
         search: 'Carian',
         next: 'seterusnya',
-        previous: 'sebelumnya'
+        previous: 'sebelumnya',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Butiran kad',
@@ -361,6 +427,16 @@ const msa = {
                 informationDisclosure: 'Pendedahan maklumat',
                 denialOfService: 'Penafian Perkhidmatan',
                 elevationOfPrivilege: 'Kenaikan Hak'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -97,7 +97,7 @@ const msa = {
         refBranch: 'Cawangan Rujukan',
         add: 'tambah cawangan',
         cancel: 'Batal',
-        nama: 'nama cawangan',
+        name: 'nama cawangan',
     },
     folder: {
         select: 'Select a',
@@ -430,11 +430,11 @@ const msa = {
             },
             eop: {
                 header: '--- EoP ---',
-                dataValidationAndEncoding: 'Data Validation & Encoding', 
-                authentication: 'Authentication', 
-                sessionManagement: 'Session Management', 
-                authorization: 'Authorization', 
-                cryptography: 'Cryptography', 
+                dataValidationAndEncoding: 'Data Validation & Encoding',
+                authentication: 'Authentication',
+                sessionManagement: 'Session Management',
+                authorization: 'Authorization',
+                cryptography: 'Cryptography',
                 cornucopia: 'Cornucopia',
                 wildCard: 'Wild Card'
             }

--- a/td.vue/src/i18n/pt-br.js
+++ b/td.vue/src/i18n/pt-br.js
@@ -427,6 +427,16 @@ const bra = {
                 informationDisclosure: 'Divulgação de informações',
                 denialOfService: 'Negação de serviço',
                 elevationOfPrivilege: 'Elevação de privilégio'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/pt-br.js
+++ b/td.vue/src/i18n/pt-br.js
@@ -430,19 +430,19 @@ const bra = {
             },
             eop: {
                 header: '--- EoP ---',
-                dataValidationAndEncoding: 'Data Validation & Encoding', 
-                authentication: 'Authentication', 
-                sessionManagement: 'Session Management', 
-                authorization: 'Authorization', 
-                cryptography: 'Cryptography', 
+                dataValidationAndEncoding: 'Data Validation & Encoding',
+                authentication: 'Authentication',
+                sessionManagement: 'Session Management',
+                authorization: 'Authorization',
+                cryptography: 'Cryptography',
                 cornucopia: 'Cornucopia',
                 wildCard: 'Wild Card'
             }
         },
         generic: {
-            dafault: 'Nova ameaça genérica',
+            default: 'Nova ameaça genérica',
             cia : 'Nova ameaça CIA',
-            die : 'Nova ameaça CIA-DIE',
+            ciadie : 'Nova ameaça CIA-DIE',
             linddun : 'Nova ameaça LINDDUN',
             plot4ai : 'Nova ameaça PLOT4ai',
             stride: 'Nova ameaça STRIDE',

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -427,6 +427,16 @@ const por = {
                 informationDisclosure: 'Divulgação de informações',
                 denialOfService: 'Negação de serviço',
                 elevationOfPrivilege: 'Elevação de privilégio'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -4,7 +4,8 @@ const rus = {
     },
     nav: {
         loggedInAs: 'Logged in as',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const rus = {
             openExisting: 'Open an existing threat model',
             createNew: 'Create a new, empty threat model',
             readDemo: 'Explore a sample threat model',
-            importExisting: 'Import a threat model via JSON'
+            importExisting: 'Import a threat model via JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const rus = {
         repo: 'repo',
         newThreatModel: 'Create a New Threat Model'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Contributors',
         contributorsPlaceholder: 'Start typing to add a contributor',
@@ -167,7 +231,8 @@ const rus = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Only files that end with .json are supported.',
             open: 'Error opening this Threat Model. Check the developer console for more information',
-            save: 'Error saving the Threat Model. Check the developer console for more information'
+            save: 'Error saving the Threat Model. Check the developer console for more information',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const rus = {
         saveModelAs: 'Save Model As',
         search: 'Search',
         next: 'Next',
-        previous: 'Previous'
+        previous: 'Previous',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Данные карты',
@@ -360,6 +427,16 @@ const rus = {
                 informationDisclosure: 'Information disclosure',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Elevation of privilege'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -4,7 +4,8 @@ const ukr = {
     },
     nav: {
         loggedInAs: 'Logged in as',
-        logOut: 'Log out'
+        logOut: 'Log out',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const ukr = {
             openExisting: 'Open an existing threat model',
             createNew: 'Create a new, empty threat model',
             readDemo: 'Explore a sample threat model',
-            importExisting: 'Import a threat model via JSON'
+            importExisting: 'Import a threat model via JSON',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const ukr = {
         repo: 'repo',
         newThreatModel: 'Create a New Threat Model'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: 'Contributors',
         contributorsPlaceholder: 'Start typing to add a contributor',
@@ -167,7 +231,8 @@ const ukr = {
             invalidModel: 'The threat model file does not validate correctly. Please check your model and try again',
             onlyJsonAllowed: 'Only files that end with .json are supported.',
             open: 'Error opening this Threat Model. Check the developer console for more information',
-            save: 'Error saving the Threat Model. Check the developer console for more information'
+            save: 'Error saving the Threat Model. Check the developer console for more information',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: 'Could not export the Threat Model. Check the developer console for more information',
@@ -303,7 +368,9 @@ const ukr = {
         saveModelAs: 'Save Model As',
         search: 'Search',
         next:'Next',
-        previous:'Previous'
+        previous:'Previous',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: 'Деталі картки',
@@ -360,6 +427,16 @@ const ukr = {
                 informationDisclosure: 'Information disclosure',
                 denialOfService: 'Denial of service',
                 elevationOfPrivilege: 'Elevation of privilege'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -4,7 +4,8 @@ const zho = {
     },
     nav: {
         loggedInAs: '登录身份为',
-        logOut: '登出'
+        logOut: '登出',
+        contentManagement: 'Content Management'
     },
     home: {
         title: 'OWASP Threat Dragon',
@@ -46,7 +47,8 @@ const zho = {
             openExisting: '打开现有的威胁模型',
             createNew: '创建一个新的、空的威胁模型',
             readDemo: '打开示例威胁模型',
-            importExisting: '通过 JSON 导入威胁模型'
+            importExisting: '通过 JSON 导入威胁模型',
+            createFromTemplate: 'Create model from a Template'
         }
     },
     demo: {
@@ -110,6 +112,68 @@ const zho = {
         repo: '源',
         newThreatModel: '创建新的威胁模型'
     },
+    template:{
+        startFromLocalTemplate: 'Start from a Local Template',
+        select: 'Select a Template from the list below',
+        selectDescription: 'Templates provide a starting point for new threat models, pre-populated with relevant components and threats.',
+        noTemplates: 'No templates found',
+        templatesLocalSession: 'Remote templates are not available for local sessions.',
+        search: 'Search templates...',
+        exportTemplate: 'Export as Template',
+        tags: 'Tags',
+        name: 'Template Name',
+        description: 'Template Description',
+        saveTemplate: 'Save Template',
+        addNew: 'Add New Template',
+        manage: 'Manage Templates',
+        manageDescription: 'Import, export, and manage your threat model templates here.',
+        editTemplate: 'Edit Template',
+        addTagsPlaceholder: 'Add tags...',
+        updateSuccess: 'Template updated successfully',
+        importSuccess: 'Template imported successfully',
+        deleteSuccess: 'Template deleted successfully',
+        deleteTitle: 'Confirm Delete',
+        deleteConfirm: 'Are you sure you want to delete "{name}"?',
+        errors: {
+            invalidJson: 'Invalid JSON. Please check your template file and try again',
+            invalidTemplate: 'Invalid template format. Please check your template file and try again',
+            loadFailed: 'Failed to load templates. Please try again',
+            duplicateTemplate: 'A template with this name already exists. Please use a different name',
+            updateFailed: 'Failed to update template',
+            deleteFailed: 'Failed to delete template'
+        },
+        warnings: {
+            templateSave: 'Could not save the template. Check the developer console for more information',
+            invalidSchema: 'Template does not strictly match schema. Details in the developer console'
+        },
+        prompts: {
+            templateSaved: 'Template successfully saved',
+            templateDownloading: 'Downloading template'
+        },
+        repo: {
+            notInitialized: {
+                title: 'Template Repository Not Initialized',
+                userMessage: 'The template repository has not been initialized. Please contact your administrator.',
+                adminMessage: 'Please go to the Manage Templates page to initialize the template repository.'
+            },
+            notConfigured: {
+                title: 'Template Repository Not Configured',
+                userMessage: 'The template repository is not configured. Please set up the repository to access templates.'
+            },
+            notFound: {
+                title: 'Template Repository Not Found',
+                userMessage: 'The repository {repoName} is not a valid repository. Please check your configuration.'
+            },
+            bootstrap:{
+                bootstrapping:'Initializing..',
+                title: 'Initialize Template Repository',
+                description: 'This will create the necessary folder structure within the repository if it does not already exist.',
+                action: 'Initialize',
+                success: 'Template repository successfully initialized.',
+                error: 'Could not initialize the template repository. Check the developer console for more information.'
+            }
+        },
+    },
     threatmodel: {
         contributors: '贡献者',
         contributorsPlaceholder: '添加新的贡献者',
@@ -167,7 +231,8 @@ const zho = {
             invalidModel: '威胁模型验证不正确。请检查你的模型并重试',
             onlyJsonAllowed: '只支持以.json结尾的文件。',
             open: '打开此威胁模型出错。检查开发者控制台以了解更多信息',
-            save: '保存此威胁模型出错。检查开发者控制台以了解更多信息'
+            save: '保存此威胁模型出错。检查开发者控制台以了解更多信息',
+            createConflict: 'A threat model with this name already exists. Please use a different name.'
         },
         warnings: {
             export: '无法导出威胁模型。检查开发者控制台查阅更多信息',
@@ -303,7 +368,9 @@ const zho = {
         saveModelAs: '模型另存为',
         search: '搜索',
         next: '下一个',
-        previous: '上一个'
+        previous: '上一个',
+        manage : 'Manage...',
+        exportTemplate: 'Export As Template',
     },
     cards: {
         details: '卡片详情',
@@ -360,6 +427,16 @@ const zho = {
                 informationDisclosure: '信息泄露',
                 denialOfService: '拒绝服务',
                 elevationOfPrivilege: '权限提升'
+            },
+            eop: {
+                header: '--- EoP ---',
+                dataValidationAndEncoding: 'Data Validation & Encoding', 
+                authentication: 'Authentication', 
+                sessionManagement: 'Session Management', 
+                authorization: 'Authorization', 
+                cryptography: 'Cryptography', 
+                cornucopia: 'Cornucopia',
+                wildCard: 'Wild Card'
             }
         },
         generic: {


### PR DESCRIPTION
**Summary**:  

Ensures that all the i18n translation files have same keys
Note that many of these new key:values need translation as they are in default of English

**Description for the changelog**:  

ensure all i18n files have same keys

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Closes #1286 
