### PR TITLE
Dependabot Policy Changes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,3 +21,81 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 10
+    groups:
+      root-npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      root-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/td.server"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 10
+    groups:
+      server-npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      server-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/td.vue"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 10
+    groups:
+      vue-npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      vue-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
**Summary**:  

Updates Dependabot's configuration so PRs are scoped by directory instead of being grouped across the entire repo.

Currently, the PRs are too large and touch too many  things to be useful.  We close more of the PRs than we accept.
This is an attempt to make the PRs smaller, better scoped, and reduce the likelihood of breaking changes.
For example, #1566 groups the root package.json, td.vue/package.json, and td.server/package.json - but importantly, it introduces a breaking change by trying to upgrade the major version of Electron.  If Dependabot knows not to increment major versions, I think these PRs will become higher value and safer to merge.

The rules:
- runs weekly
- 10-day [cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)
- groups patch/minor version in the directory
- groups patch/minor security in the directory
- ignores npm major version updates for automatic version-update PRs

Major dependency upgrades should be handled in dedicated PRs because they often need focused testing and migration review.

**Description for the changelog**:  

Dependabot configuration updates

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai in this pull request has been disclosed below:
  - AI Tools: `OpenAI Codex`
  - LLMs and versions: `GPT-5`
  - Prompts: `Investigate the Dependabot configuration, compare it with a large generated Dependabot PR, propose a config change to split npm updates by app directory, suppress major version updates`

**Other info**:  

It will still be our responsibility to monitor for major version changes and pay attention to CVEs (this is why we have Trivy!).  The reality is that major version upgrades often imply breaking changes.

I think we can find a lot more value from Dependabot if we use it in a way where we can actually start to trust the PRs it opens, and have more confidence in merging them after our quality gates pass.