### PR TITLE
Bugfix: desktop dirty-state confirmations do not show

### DIFF
--- a/td.vue/src/main.desktop.js
+++ b/td.vue/src/main.desktop.js
@@ -211,5 +211,4 @@ app.use(BootstrapVue);
 app.use(Toast, toastOptions);
 installToastGlobalProperties(app, toastOptions);
 app.component('font-awesome-icon', FontAwesomeIcon);
-app.mount('#app');
-appProxy = app.config.globalProperties;
+appProxy = app.mount('#app');

--- a/td.vue/tests/e2e/desktop/specs/menu.spec.js
+++ b/td.vue/tests/e2e/desktop/specs/menu.spec.js
@@ -21,6 +21,7 @@ const {
     exportModelAsHtml,
     exportModelAsPdf,
     closeModel,
+    closeDirtyModel,
     openHelpMenuLink,
     openAboutDialog
 } = require('../support/menu');
@@ -145,6 +146,21 @@ describe('Desktop menu integration tests', function () {
 
             await openModel(modelPath);
             await closeModel();
+
+            assert.equal(await browser.getPageSource().then((source) => source.includes(appContent.welcomeMessage)), true);
+            assert.equal(await browser.getUrl(), appContent.dashboardUrl);
+        });
+    });
+
+    it('confirms before closing a dirty model through File > Close Model', async () => {
+        const browser = getBrowser();
+
+        await withMenuWorkspace(async ({ copyModelFixture }) => {
+            const modelPath = copyModelFixture('close-dirty-model.json');
+
+            await openModel(modelPath);
+            await setThreatModelTitle('Unsaved Desktop Menu Change');
+            await closeDirtyModel();
 
             assert.equal(await browser.getPageSource().then((source) => source.includes(appContent.welcomeMessage)), true);
             assert.equal(await browser.getUrl(), appContent.dashboardUrl);

--- a/td.vue/tests/e2e/desktop/support/diagram.js
+++ b/td.vue/tests/e2e/desktop/support/diagram.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const { getBrowser } = require('./session');
-const { openModel, saveModel, saveModelAs, closeModel } = require('./menu');
+const { openModel, saveModel, saveModelAs, closeModel, waitForToast } = require('./menu');
 const { waitFor } = require('./utils');
 
 const UI_WAIT_TIMEOUT_MS = 10000;
+const THREAT_MODEL_SAVED_TOAST = 'Threat model successfully saved';
 
 const diagramView = {
     selectors: {
@@ -96,6 +97,7 @@ const saveDiagramWithCtrlS = async () => {
     await graphCanvas.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
     await graphCanvas.click();
     await browser.keys(['Control', 's']);
+    await waitForToast(THREAT_MODEL_SAVED_TOAST);
 };
 
 const closeDiagram = async () => {

--- a/td.vue/tests/e2e/desktop/support/menu.js
+++ b/td.vue/tests/e2e/desktop/support/menu.js
@@ -24,6 +24,7 @@ const THREAT_MODEL_EXPORTED_TOAST = 'Threat model exported';
 const appContent = {
     dashboardUrl: 'app://./index.html#/dashboard',
     demoModelTitle: 'Demo Threat Model',
+    discardMessage: 'Are you sure you want to discard your changes?',
     exportMarker: 'Threat Dragon export',
     newModelEditRoute: /#\/desktop\/New%20Threat%20Model\/edit/,
     nonEmptyFileSizeBytes: 0,
@@ -270,6 +271,19 @@ const closeModel = async () => {
     await waitForDashboard();
 };
 
+const closeDirtyModel = async () => {
+    const browser = getBrowser();
+    await clickFileMenuItem(fileMenu.labels.closeModel);
+    await browser.waitUntil(
+        async () => browser.execute((message) => document.body.innerText.includes(message), appContent.discardMessage),
+        { timeout: UI_WAIT_TIMEOUT_MS, timeoutMsg: 'Timed out waiting for discard confirmation' }
+    );
+    const okButton = await browser.$('//button[normalize-space()="OK"]');
+    await okButton.waitForClickable({ timeout: UI_WAIT_TIMEOUT_MS });
+    await okButton.click();
+    await waitForDashboard();
+};
+
 const openHelpMenuLink = async (label) => {
     await clickHelpMenuItem(label);
 };
@@ -292,6 +306,7 @@ module.exports = {
     openModel,
     createNewModel,
     waitForModelEditor,
+    waitForToast,
     setThreatModelTitle,
     waitForThreatModelTitle,
     saveModel,
@@ -299,6 +314,7 @@ module.exports = {
     exportModelAsHtml,
     exportModelAsPdf,
     closeModel,
+    closeDirtyModel,
     openHelpMenuLink,
     openAboutDialog
 };


### PR DESCRIPTION
**Summary**:  

The vue3-compat PR introduced a bug that prevents the desktop client from showing the model dirty / discard changes confirmation modal. 

Closes #1572 

**Description for the changelog**:  

bugfix: desktop discard changes confirmation not showing

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `OpenAI Codex`
  - LLMs and versions: `gpt-5.4 medium`
  - Prompts: `Investigate the flaky tests reported in https://github.com/OWASP/threat-dragon/issues/1572 - put an emphases on vue3-compat flows, and you must reproduce the issue locally before suggesting a fix`

**Other info**:  

1 test feels flaky and I think we can address it with a more targeted wait.
There is a real bug here though with how the desktop handles the confirmation modal.  I've added a targeted e2e regression test to capture this and hopefully prevent regressions.

I was able to reproduce the modal bug locally, steps to reproduce are included in the related issue.