### PR TITLE
chore(td.vue): incremental vue-i18n migration prep (v10)

### DIFF
--- a/td.vue/package-lock.json
+++ b/td.vue/package-lock.json
@@ -38,7 +38,7 @@
         "passive-events-support": "^1.1.0",
         "uuid": "11.1.0",
         "vue": "^3.4.21",
-        "vue-i18n": "^9.14.1",
+        "vue-i18n": "^10.0.8",
         "vue-router": "^4.4.5",
         "vue-toastification": "^2.0.0-rc.5",
         "vuex": "^4.1.0"
@@ -2979,13 +2979,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.14.5",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
-      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
-      "license": "MIT",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.8.tgz",
+      "integrity": "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==",
       "dependencies": {
-        "@intlify/message-compiler": "9.14.5",
-        "@intlify/shared": "9.14.5"
+        "@intlify/message-compiler": "10.0.8",
+        "@intlify/shared": "10.0.8"
       },
       "engines": {
         "node": ">= 16"
@@ -2995,12 +2994,11 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.14.5",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
-      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
-      "license": "MIT",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.8.tgz",
+      "integrity": "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==",
       "dependencies": {
-        "@intlify/shared": "9.14.5",
+        "@intlify/shared": "10.0.8",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -3011,10 +3009,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.14.5",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
-      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
-      "license": "MIT",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.8.tgz",
+      "integrity": "sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==",
       "engines": {
         "node": ">= 16"
       },
@@ -38161,14 +38158,13 @@
       "license": "MIT"
     },
     "node_modules/vue-i18n": {
-      "version": "9.14.5",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
-      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.8.tgz",
+      "integrity": "sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==",
       "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
-      "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "9.14.5",
-        "@intlify/shared": "9.14.5",
+        "@intlify/core-base": "10.0.8",
+        "@intlify/shared": "10.0.8",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -90,7 +90,7 @@
     "passive-events-support": "^1.1.0",
     "uuid": "11.1.0",
     "vue": "^3.4.21",
-    "vue-i18n": "^9.14.1",
+    "vue-i18n": "^10.0.8",
     "vue-router": "^4.4.5",
     "vue-toastification": "^2.0.0-rc.5",
     "vuex": "^4.1.0"

--- a/td.vue/src/i18n/index.js
+++ b/td.vue/src/i18n/index.js
@@ -45,7 +45,7 @@ const installLegacyCompat = (instance) => {
 const get = () => {
     if (i18nInstance === null) {
         i18nInstance = createI18n({
-            // Preserves Options API and get().global.tc() compatibility with vue-i18n v8
+            // Preserves Options API compatibility while migrating off deprecated tc/$tc.
             // Legacy mode is deprecated and will be removed in vue-i18n v12.
             // TODO: remove after refactoring i18n usage
             legacy: true,
@@ -62,7 +62,8 @@ const get = () => {
     return i18nInstance;
 };
 
-export const tc = (key) => get().global.tc(key);
+export const t = (...args) => get().global.t(...args);
+export const tc = (key, ...args) => t(key, ...args);
 
 export default {
     get

--- a/td.vue/tests/unit/components/localeSelect.spec.js
+++ b/td.vue/tests/unit/components/localeSelect.spec.js
@@ -1,40 +1,57 @@
 import { BDropdown, BDropdownItem, BootstrapVue } from 'bootstrap-vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import VueI18n from 'vue-i18n';
+import { createI18n } from 'vue-i18n';
 import Vuex from 'vuex';
 
 import LocaleSelect from '@/components/LocaleSelect.vue';
 import { LOCALE_SELECTED } from '@/store/actions/locale.js';
 
 describe('components/LocaleSelect.vue', () => {
-    let mockStore, wrapper;
+    let i18n, mockStore, wrapper, dispatchSpy;
+    const MESSAGES = {
+        eng: { hello: 'Hello World' },
+        deu: { hello: 'Hallo Welt' }
+    };
+    const LOCALE_LABELS = {
+        eng: 'English',
+        deu: 'Deutsch'
+    };
+    const mountComponent = (storeLocale = 'eng') => {
+        const localVue = createLocalVue();
+        i18n = createI18n({
+            locale: 'eng',
+            messages: MESSAGES
+        });
+
+        localVue.use(Vuex);
+        localVue.use(i18n);
+        localVue.use(BootstrapVue);
+
+        mockStore = new Vuex.Store({
+            state: { locale: { locale: storeLocale }},
+            actions: { [LOCALE_SELECTED]: () => {} },
+            dispatch: jest.fn()
+        });
+
+        wrapper = shallowMount(LocaleSelect, {
+            localVue,
+            i18n,
+            store: mockStore
+        });
+    };
+    const findLocaleItem = (label) => wrapper.findAllComponents(BDropdownItem).filter((c) => c.text() === label).at(0);
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        wrapper = null;
+        mockStore = null;
+        i18n = null;
+    });
+
 
     describe('default locale', () => {
         beforeEach(() => {
-            const localVue = createLocalVue();
-            localVue.use(Vuex);
-            localVue.use(VueI18n);
-            localVue.use(BootstrapVue);
-
-            const i18n = new VueI18n({
-                locale: 'eng',
-                messages: {
-                    eng: { hello: 'Hello World' },
-                    deu: { hello: 'Hallo Welt' }
-                }
-            });
-
-            mockStore = new Vuex.Store({
-                state: { locale: { locale: 'eng' }},
-                actions: { [LOCALE_SELECTED]: () => {} },
-                dispatch: () => {}
-            });
-
-            wrapper = shallowMount(LocaleSelect, {
-                localVue,
-                i18n,
-                store: mockStore
-            });
+            mountComponent();
         });
 
         it('renders the component', () => {
@@ -42,78 +59,47 @@ describe('components/LocaleSelect.vue', () => {
         });
 
         it('displays the current locale', () => {
-            expect(wrapper.findComponent(BDropdown).attributes('text')).toEqual('English');
+            expect(wrapper.findComponent(BDropdown).attributes('text')).toEqual(LOCALE_LABELS.eng);
         });
 
-        it('has an option for eng', () => {
-            expect(wrapper.findAllComponents(BDropdownItem)
-                .filter((c) => c.text() === 'English').exists()
-            ).toEqual(true);
+        it.each([
+            ['eng', LOCALE_LABELS.eng],
+            ['deu', LOCALE_LABELS.deu]
+        ])('has an option for %s', (_localeCode, localeLabel) => {
+            expect(findLocaleItem(localeLabel).exists()).toEqual(true);
         });
 
-        it('has an option for deu', () => {
-            expect(wrapper.findAllComponents(BDropdownItem)
-                .filter((c) => c.text() === 'Deutsch').exists()
-            ).toEqual(true);
-        });
 
         describe('updates', () => {
             beforeEach(() => {
-                mockStore.dispatch = jest.fn();
+                dispatchSpy = jest.spyOn(mockStore, 'dispatch');
             });
 
-            it('updates the locale to deu', async () => {
-                await wrapper.findAllComponents(BDropdownItem)
-                    .filter(c => c.text() === 'Deutsch')
-                    .at(0)
-                    .trigger('click');
+            it.each([
+                ['deu', LOCALE_LABELS.deu],
+                ['eng', LOCALE_LABELS.eng]
+            ])('updates the locale to %s', async (localeCode, localeLabel) => {
+                await findLocaleItem(localeLabel).trigger('click');
 
-                expect(mockStore.dispatch).toHaveBeenCalledWith(LOCALE_SELECTED, 'deu');
+                expect(dispatchSpy).toHaveBeenCalledTimes(1);
+                expect(dispatchSpy).toHaveBeenCalledWith(LOCALE_SELECTED, localeCode);
             });
-
-            it('updates the locale to eng', async () => {
-                await wrapper.findAllComponents(BDropdownItem)
-                    .filter(c => c.text() === 'English')
-                    .at(0)
-                    .trigger('click');
-
-                expect(mockStore.dispatch).toHaveBeenCalledWith(LOCALE_SELECTED, 'eng');
-            });
-
         });
+
     });
 
     describe('different locale', () => {
-        let i18n;
         beforeEach(() => {
-            const localVue = createLocalVue();
-            localVue.use(Vuex);
-            localVue.use(VueI18n);
-            localVue.use(BootstrapVue);
-
-            i18n = new VueI18n({
-                locale: 'eng',
-                messages: {
-                    eng: { hello: 'Hello World' },
-                    deu: { hello: 'Hallo Welt' }
-                }
-            });
-
-            mockStore = new Vuex.Store({
-                state: { locale: { locale: 'test' }},
-                actions: { [LOCALE_SELECTED]: () => {} },
-                dispatch: () => {}
-            });
-
-            wrapper = shallowMount(LocaleSelect, {
-                localVue,
-                i18n,
-                store: mockStore
-            });
+            mountComponent('test');
         });
 
         it('sets the locale based on the state', () => {
             expect(i18n.locale).toEqual('test');
         });
+
+        it('uses the locale code text for unknown locales', () => {
+            expect(wrapper.findComponent(BDropdown).attributes('text')).toEqual('test');
+        });
     });
+
 });


### PR DESCRIPTION
**Summary**:  

Incremental Vue i18n migration work to reduce risk ahead of the full v11+ move:
- upgrades `td.vue` from `vue-i18n` v9 to v10
- routes the local `tc` helper through `t` to avoid direct deprecated `global.tc` usage
- keeps current behavior stable while preparing for later legacy-mode removal

Refs #1558

**Description for the changelog**: 

Upgrade `td.vue` to `vue-i18n` v10 and refactor i18n helper usage to reduce migration risk.

**Declaration**:  
Thanks for submitting a pull request, please make sure:  
- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Cursor Agent`
  - LLMs and versions: `Codex 5.3`
  - Prompts: `Audit repo against vue-i18n v10/v11 migration guides; identify deprecated usages; apply minimal migration-safe changes; upgrade vue-i18n to v10; validate with unit tests;`
 
**Other info**:  
Validation performed:
- `npm install vue-i18n@^10` in `td.vue`
- `npm run test

Notes for reviewers:
- This PR is intentionally incremental and does **not** remove `legacy: true` yet.
- It should be considered a step toward #1558,