### PR TITLE
Feat/translation normalisation

### DIFF
--- a/docs/development/translations.md
+++ b/docs/development/translations.md
@@ -1,42 +1,85 @@
----
-layout: page
-title: Translations
-nav_order: 4
-path: /development/translations
-group: Development
----
-
 ## Translations
 
 Internationalization is enabled by [vue-i18n](https://kazupon.github.io/vue-i18n/).
 This feature enables our community members to translate Threat Dragon,
 increasing the diversity of the Threat Dragon community.
 
-The following translations are available:
+### Locale identifiers
 
-- العربية (ara-SY)
-- Deutsch (deu-DE)
-- English (eng-US)
-- Ελληνικά (ell-GR)
-- español (spa-ES)
-- Suomi; (fin-FI)
-- français (fra-CA)
-- मानक हिन्दी (hin-IN)
-- Bahasa Indonesia (ind-ID)
-- 日本語 (jpn)
-- Português (por-PT)
-- Português do Brazil (por-BR)
-- Malay (msa-MY)
-- 中文 (zho-CN)
+We follow **IETF BCP 47** language tags: `language`-`REGION` (case‑insensitive, but canonical form recommended).
 
-By default, if a translation key cannot be found, it will fall-back to the default locale (`eng-US`).
+- **Language**: ISO 639‑1 two‑letter code (lowercase) – e.g., `en`, `pt`, `zh`
+- **Region** (optional): ISO 3166‑1 alpha‑2 country code (uppercase) – e.g., `BR`, `US`, `GB`
 
-To add a new language:
+**Example:** `pt-BR` (Brazilian Portuguese). For a language without a region variant, use only the language code (e.g. `es`).
 
-- Add a new file with the ISO 639-2 code as the name (eg "deu" or "eng") in the `td.vue/src/i18n` directory
-- Copy the contents of the `en.js` file to the new file and translate the application messages
-- Import the file to `td.vue/src/i18n/index.js` and add it to the `messages` object in the `get` method
-- Choose the new locale from the dropdown to test your translations
+> **Why uppercase region?** BCP 47 is case‑insensitive, but the canonical form (e.g., `pt-BR`) matches browser APIs 
+(`navigator.language`) and is the convention used in `vue-i18n` examples. Our code uses the canonical form for the `messages`
+object keys.
+
+### Available translations
+
+All translation files are located in `td.vue/src/i18n/`. Each file exports a single JavaScript object with the same nested 
+structure as `en.js`.
+
+| Language                      | BCP 47  | Filename    | Status                                                      |
+|-------------------------------|---------|-------------|-------------------------------------------------------------|
+| العربية (Arabic)              | `ar`    | `ar.js`     | All keys present, some values are in English (untranslated) |
+| Deutsch (German)              | `de`    | `de.js`     | All keys present, some values are in English (untranslated) |
+| Ελληνικά (Greek)              | `el`    | `el.js`     | All keys present, some values are in English (untranslated) |
+| English                       | `en`    | `en.js`     |                                                             |
+| Español (Spanish)             | `es`    | `es.js`     | All keys present, some values are in English (untranslated) |
+| Suomi (Finnish)               | `fi`    | `fi.js`     | All keys present, some values are in English (untranslated) |
+| Français (French)             | `fr`    | `fr.js`     | All keys present, some values are in English (untranslated) |
+| मानक हिन्दी (Hindi)           | `hi`    | `hi.js`     | All keys present, some values are in English (untranslated) |
+| Bahasa Indonesia (Indonesian) | `id`    | `id.js`     | All keys present, some values are in English (untranslated) |
+| 日本語 (Japanese)              | `ja`    | `ja.js`     | All keys present, some values are in English (untranslated) |
+| Bahasa Malaysia (Malay)       | `ms`    | `ms.js`     | All keys present, some values are in English (untranslated) |
+| Português (European)          | `pt`    | `pt.js`     | All keys present, very few English values (untranslated)    |
+| Português do Brasil (Brazil)  | `pt-br` | `pt-br.js`  | All keys present, some values are in English (untranslated) |
+| Русский (Russian)             | `ru`    | `ru.js`     | All keys present, some values are in English (untranslated) |
+| Українська (Ukrainian)        | `uk`    | `uk.js`     | All keys present, some values are in English (untranslated) |
+| 中文 (Chinese)                 | `zh`    | `zh.js`     | All keys present, some values are in English (untranslated) |
+
+
+**Fallback behaviour**  
+If a translation key is missing in the selected locale, the application falls back according to the `fallbackLocale` 
+configuration in `td.vue/src/i18n/index.js`.  
+
+Currently:
+- European Portuguese (`pt`) falls back to Brazilian Portuguese (`pt-BR`)
+- All other locales fall back to English (`en`)
+
+> **Note:** The fallback is **one‑way** (`pt-BR` → `pt`). Portuguese does not fall back to Brazilian Portuguese (you need to 
+configure it).
+
+### Adding a new language
+
+1. **Create a new file** in `td.vue/src/i18n` using the **IETF language tag** as the filename (e.g., `pt-br.js`, `en-gb.js`, 
+`zh-cn.js`).
+    - For a language without a region variant, use the two‑letter ISO 639‑1 code (e.g., `de.js`).
+    - For region‑specific variants, append `-` and the two‑letter ISO 3166‑1 alpha‑2 country code (lowercase) to the base
+     language.
+
+2. **Default contents** – Copy the structure from `en.js` and translate the values.
+
+3. **Import the new file** in `td.vue/src/i18n/index.js` and add it to the `messages` object, using the IETF tag as the key.
+
+4. **Configure fallback relationships** – in `td.vue/src/i18n/index.js`, if the new language should fall back to another 
+(e.g., a regional variant to its base language), add the appropriate entry to the `fallbackLocale` object in `index.js`.
+The syntax is:
+   ```javascript
+   fallbackLocale: {
+       'new_locale': ['fallback1', 'fallback2'],
+       'default': 'en'
+   }
+   ```
+
+4. **Test your translations** by selecting the new locale from the dropdown menu.
+    - **For bonus points**, test the fallback configuration: temporarily remove a specific translation key from your new 
+    locale file. When you reload the application with that locale selected, the fallback language (as configured in 
+    `fallbackLocale` in `index.js`) should display the missing key. This confirms that the fallback chain works correctly and
+     that users will always see a meaningful translation even if your file is incomplete.
 
 ----
 

--- a/td.vue/src/components/LocaleSelect.vue
+++ b/td.vue/src/components/LocaleSelect.vue
@@ -85,33 +85,33 @@ export default {
         },
         getLanguageName(locale) {
             switch (locale) {
-            case 'ara':
+            case 'ar':
                 return 'العربية'; // Arabic
-            case 'deu':
+            case 'de':
                 return 'Deutsch'; // German
-            case 'ell':
+            case 'el':
                 return 'Ελληνικά'; // Greek
-            case 'eng':
+            case 'en':
                 return 'English';
-            case 'spa':
+            case 'es':
                 return 'Español'; // Spanish
-            case 'fin':
+            case 'fi':
                 return 'Suomi'; // Finnish
-            case 'fra':
+            case 'fr':
                 return 'Français'; // French
-            case 'hin':
+            case 'hi':
                 return 'हिंदी'; // Hindi
-            case 'ind':
+            case 'id':
                 return 'Bahasa Indonesia'; // Indonesia
-            case 'jpn':
+            case 'ja':
                 return '日本語'; // Japanese
-            case 'msa':
+            case 'ms':
                 return 'Malay'; // Malay
-            case 'por':
+            case 'pt':
                 return 'Português'; // Portuguese
-            case 'bra':
+            case 'pt-BR':
                 return 'Português (Brasil)'; // Brazilian Portuguese
-            case 'zho':
+            case 'zh':
                 return '中文'; // Chinese
             default:
                 return locale;

--- a/td.vue/src/desktop/menu.js
+++ b/td.vue/src/desktop/menu.js
@@ -13,23 +13,23 @@ const buildVersion = require('../../package.json').version;
 var mainWindow;
 
 // access the i18n message strings
-import ara from '@/i18n/ar.js';
-import deu from '@/i18n/de.js';
-import ell from '@/i18n/el.js';
-import eng from '@/i18n/en.js';
-import fin from '@/i18n/fi.js';
-import fra from '@/i18n/fr.js';
-import hin from '@/i18n/hi.js';
-import ind from '@/i18n/id.js';
-import jpn from '@/i18n/ja.js';
-import msa from '@/i18n/ms.js';
-import por from '@/i18n/pt.js';
-import bra from '@/i18n/pt-br.js';
-import spa from '@/i18n/es.js';
-import zho from '@/i18n/zh.js';
+import ar from '@/i18n/ar.js';
+import de from '@/i18n/de.js';
+import el from '@/i18n/el.js';
+import en from '@/i18n/en.js';
+import es from '@/i18n/es.js';
+import fi from '@/i18n/fi.js';
+import fr from '@/i18n/fr.js';
+import hi from '@/i18n/hi.js';
+import id from '@/i18n/id.js';
+import ja from '@/i18n/ja.js';
+import ms from '@/i18n/ms.js';
+import pt from '@/i18n/pt.js';
+import ptBr from '@/i18n/pt-br.js';
+import zh from '@/i18n/zh.js';
 
-const messages = { ara, deu, ell, eng, fin, fra, hin, ind, jpn, msa, por, bra, spa, zho };
-const defaultLanguage = 'eng';
+const messages = { ar, de, el, en, es, fi, fr, hi, id, ja, ms, pt, 'pt-BR': ptBr, zh };
+const defaultLanguage = 'en';
 var language = defaultLanguage;
 
 export const model = {
@@ -467,7 +467,7 @@ export const modelSave = (modelData, fileName) => {
 
 // the renderer has changed the language
 export const setLocale = (locale) => {
-    const languages = [ 'ara', 'deu', 'ell', 'eng', 'fin', 'fra', 'hin', 'ind', 'jpn', 'msa', 'por', 'bra', 'spa', 'zho' ];
+    const languages = [ 'ar', 'de', 'el', 'en', 'es', 'fi', 'fr', 'hi', 'id', 'ja', 'ms', 'pt', 'pt-BR', 'zh' ];
     language = languages.includes(locale) ? locale : defaultLanguage;
 };
 

--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -1,4 +1,4 @@
-const ara = {
+const messages = {
     auth: {
         sessionExpired: 'انتهت صلاحية جلستك. يرجى تسجيل الدخول مرة أخرى للمتابعة.'
     },
@@ -524,4 +524,4 @@ const ara = {
     }
 };
 
-export default ara;
+export default messages;

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -1,4 +1,4 @@
-const deu = {
+const messages = {
     auth: {
         sessionExpired: 'Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.'
     },
@@ -524,4 +524,4 @@ const deu = {
     }
 };
 
-export default deu;
+export default messages;

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -1,4 +1,4 @@
-const ell = {
+const messages = {
     auth: {
         sessionExpired: 'Η συνεδρία σας έχει λήξει.  Παρακαλούμε συνδεθείτε εκ νέου για να συνεχίσετε.'
     },
@@ -524,4 +524,4 @@ const ell = {
     }
 };
 
-export default ell;
+export default messages;

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -1,4 +1,4 @@
-const eng = {
+const messages = {
     auth: {
         sessionExpired: 'Your session has expired. Please log in again to continue.'
     },
@@ -524,4 +524,4 @@ const eng = {
     }
 };
 
-export default eng;
+export default messages;

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -1,4 +1,4 @@
-const spa = {
+const messages = {
     auth: {
         sessionExpired: 'Su sesión ha expirado. Por favor inicie una nueva sesión para continuar.'
     },
@@ -524,4 +524,4 @@ const spa = {
     }
 };
 
-export default spa;
+export default messages;

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -1,4 +1,4 @@
-const fin = {
+const messages = {
     auth: {
         sessionExpired: 'Istuntosi on vanhentunut. Ole hyvä ja kirjaudu sisään uudelleen jatkaaksesi.'
     },
@@ -524,4 +524,4 @@ const fin = {
     }
 };
 
-export default fin;
+export default messages;

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -1,4 +1,4 @@
-const fra = {
+const messages = {
     auth: {
         sessionExpired: 'Votre session est expirée. Veuillez vous reconnecter pour continuer.'
     },
@@ -524,4 +524,4 @@ const fra = {
     }
 };
 
-export default fra;
+export default messages;

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -1,4 +1,4 @@
-const hin = {
+const messages = {
     auth: {
         sessionExpired: 'आपका सत्र समाप्त हो गया है। कृपया जारी रखने के लिए फिर से लॉग इन करें।'
     },
@@ -524,4 +524,4 @@ const hin = {
     }
 };
 
-export default hin;
+export default messages;

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -1,4 +1,4 @@
-const ind = {
+const messages = {
     auth: {
         sessionExpired: 'Sesi Anda telah berakhir. Silakan masuk kembali untuk melanjutkan.'
     },
@@ -524,4 +524,4 @@ const ind = {
     }
 };
 
-export default ind;
+export default messages;

--- a/td.vue/src/i18n/index.js
+++ b/td.vue/src/i18n/index.js
@@ -2,24 +2,24 @@ import { createI18n } from 'vue-i18n';
 
 // the language codes follow
 // Internet Engineering Task Force (IETF) Best Current Practice (BCP) 47
-// using codes from ISO 639-2
+// ISO 639-1 language codes
 
-import ara from './ar.js';
-import deu from './de.js';
-import ell from './el.js';
-import eng from './en.js';
-import fin from './fi.js';
-import fra from './fr.js';
-import hin from './hi.js';
-import ind from './id.js';
-import jpn from './ja.js';
-import msa from './ms.js';
-import por from './pt.js';
-import bra from './pt-br.js';
+import ar from './ar.js';
+import de from './de.js';
+import el from './el.js';
+import en from './en.js';
+import es from './es.js';
+import fi from './fi.js';
+import fr from './fr.js';
+import hi from './hi.js';
+import id from './id.js';
+import ja from './ja.js';
+import ms from './ms.js';
+import pt from './pt.js';
+import ptBr from './pt-br.js';
 // hide RUS & UKR for now: import rus from './ru.js';
-import spa from './es.js';
 // hide RUS & UKR for now: import ukr from './uk.js';
-import zho from './zh.js';
+import zh from './zh.js';
 
 let i18nInstance = null;
 
@@ -51,11 +51,10 @@ const get = () => {
             legacy: true,
             locale: 'eng',
             fallbackLocale: {
-                'por': ['bra'],
-                'bra': ['por'],
-                'default':  'eng'
+                pt: ['pt-BR'],
+                default:  'en'
             },
-            messages: { ara, deu, ell, eng, spa, fin, fra, hin, ind, jpn, msa, por, bra, zho }
+            messages: { ar, de, el, en, es, fi, fr, hi, id, ja, ms, pt, 'pt-BR': ptBr, zh }
         });
         installLegacyCompat(i18nInstance);
     }

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -1,4 +1,4 @@
-const jpn = {
+const messages = {
     auth: {
         sessionExpired: 'セッションの有効期限が切れました。再ログインしてください。'
     },
@@ -524,4 +524,4 @@ const jpn = {
     }
 };
 
-export default jpn;
+export default messages;

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -1,4 +1,4 @@
-const msa = {
+const messages = {
     auth: {
         sessionExpired: 'Sesi anda telah tamat. Sila log masuk semula untuk meneruskan.'
     },
@@ -524,4 +524,4 @@ const msa = {
     }
 };
 
-export default msa;
+export default messages;

--- a/td.vue/src/i18n/pt-br.js
+++ b/td.vue/src/i18n/pt-br.js
@@ -1,4 +1,4 @@
-const bra = {
+const messages = {
     auth: {
         sessionExpired: 'Sua sessão está expirada. Por favor, faça login novamente.'
     },
@@ -524,4 +524,4 @@ const bra = {
     }
 };
 
-export default bra;
+export default messages;

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -1,4 +1,4 @@
-const por = {
+const messages = {
     auth: {
         sessionExpired: 'A sua sessão expirou. Por favor, inicie sessão novamente para continuar.'
     },
@@ -524,4 +524,4 @@ const por = {
     }
 };
 
-export default por;
+export default messages;

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -1,4 +1,4 @@
-const rus = {
+const messages = {
     auth: {
         sessionExpired: 'Your session has expired. Please log in again to continue.'
     },
@@ -524,4 +524,4 @@ const rus = {
     }
 };
 
-export default rus;
+export default messages;

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -1,4 +1,4 @@
-const ukr = {
+const messages = {
     auth: {
         sessionExpired: 'Your session has expired. Please log in again to continue.'
     },
@@ -524,4 +524,4 @@ const ukr = {
     }
 };
 
-export default ukr;
+export default messages;

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -1,4 +1,4 @@
-const zho = {
+const messages = {
     auth: {
         sessionExpired: '会话登录已过期，请重新登录。'
     },
@@ -524,4 +524,4 @@ const zho = {
     }
 };
 
-export default zho;
+export default messages;

--- a/td.vue/src/plugins/vue-test-utils-compat.js
+++ b/td.vue/src/plugins/vue-test-utils-compat.js
@@ -41,8 +41,8 @@ const renderNamedSlot = (slots, name) => {
 };
 
 const defaultI18n = {
-    locale: 'eng',
-    availableLocales: ['eng', 'deu'],
+    locale: 'en',
+    availableLocales: ['en', 'de'],
     t: (key) => key,
     tc: (key) => key
 };
@@ -611,7 +611,7 @@ const normalizeMountOptions = (options = {}) => {
 
     if (store) {
         if (store.state && !store.state.locale) {
-            store.state.locale = { locale: 'eng' };
+            store.state.locale = { locale: 'en' };
         }
 
         if (store.state && !Object.prototype.hasOwnProperty.call(store.state, 'packageBuildVersion')) {

--- a/td.vue/src/service/threats/models/eop/cornucopia.js
+++ b/td.vue/src/service/threats/models/eop/cornucopia.js
@@ -11,13 +11,13 @@ export default {
 
     getData() {
         switch (i18n.get().locale) {
-        case 'spa':
+        case 'es':
             return cornucopiaES;
-        case 'fra':
+        case 'fr':
             return cornucopiaFR;
-        case 'rus':
+        case 'ru':
             return cornucopiaRU;
-        case 'eng':
+        case 'en':
         default:
             return cornucopiaEN;
         }

--- a/td.vue/src/store/modules/locale.js
+++ b/td.vue/src/store/modules/locale.js
@@ -1,7 +1,7 @@
 import { LOCALE_SELECTED } from '../actions/locale';
 
 const state = {
-    locale: 'eng'
+    locale: 'en'
 };
 
 const actions = {

--- a/td.vue/tests/unit/components/graph.spec.js
+++ b/td.vue/tests/unit/components/graph.spec.js
@@ -30,7 +30,7 @@ describe('components/GraphButtons.vue', () => {
                     selected: provider
                 },
                 locale: {
-                    locale: 'eng'
+                    locale: 'en'
                 },
                 threatmodel: {
                     selectedDiagram: {

--- a/td.vue/tests/unit/components/localeSelect.spec.js
+++ b/td.vue/tests/unit/components/localeSelect.spec.js
@@ -9,17 +9,17 @@ import { LOCALE_SELECTED } from '@/store/actions/locale.js';
 describe('components/LocaleSelect.vue', () => {
     let i18n, mockStore, wrapper, dispatchSpy;
     const MESSAGES = {
-        eng: { hello: 'Hello World' },
-        deu: { hello: 'Hallo Welt' }
+        en: { hello: 'Hello World' },
+        de: { hello: 'Hallo Welt' }
     };
     const LOCALE_LABELS = {
-        eng: 'English',
-        deu: 'Deutsch'
+        en: 'English',
+        de: 'Deutsch'
     };
-    const mountComponent = (storeLocale = 'eng') => {
+    const mountComponent = (storeLocale = 'en') => {
         const localVue = createLocalVue();
         i18n = createI18n({
-            locale: 'eng',
+            locale: 'en',
             messages: MESSAGES
         });
 
@@ -59,12 +59,12 @@ describe('components/LocaleSelect.vue', () => {
         });
 
         it('displays the current locale', () => {
-            expect(wrapper.findComponent(BDropdown).attributes('text')).toEqual(LOCALE_LABELS.eng);
+            expect(wrapper.findComponent(BDropdown).attributes('text')).toEqual(LOCALE_LABELS.en);
         });
 
         it.each([
-            ['eng', LOCALE_LABELS.eng],
-            ['deu', LOCALE_LABELS.deu]
+            ['en', LOCALE_LABELS.en],
+            ['de', LOCALE_LABELS.de]
         ])('has an option for %s', (_localeCode, localeLabel) => {
             expect(findLocaleItem(localeLabel).exists()).toEqual(true);
         });
@@ -76,8 +76,8 @@ describe('components/LocaleSelect.vue', () => {
             });
 
             it.each([
-                ['deu', LOCALE_LABELS.deu],
-                ['eng', LOCALE_LABELS.eng]
+                ['de', LOCALE_LABELS.de],
+                ['en', LOCALE_LABELS.en]
             ])('updates the locale to %s', async (localeCode, localeLabel) => {
                 await findLocaleItem(localeLabel).trigger('click');
 

--- a/td.vue/tests/unit/desktop/desktop.spec.js
+++ b/td.vue/tests/unit/desktop/desktop.spec.js
@@ -470,24 +470,24 @@ describe('desktop/desktop.js', () => {
 
         describe('handleUpdateMenu', () => {
             it('logs re-labeling menu for locale', () => {
-                ipcHandlers['update-menu'](null, 'fra');
-                expect(mockLogger.log.debug).toHaveBeenCalledWith(expect.stringContaining('fra'));
+                ipcHandlers['update-menu'](null, 'fr');
+                expect(mockLogger.log.debug).toHaveBeenCalledWith(expect.stringContaining('fr'));
             });
 
             it('calls menu.setLocale with locale', () => {
-                ipcHandlers['update-menu'](null, 'fra');
-                expect(mockMenu.setLocale).toHaveBeenCalledWith('fra');
+                ipcHandlers['update-menu'](null, 'fr');
+                expect(mockMenu.setLocale).toHaveBeenCalledWith('fr');
             });
 
             it('calls menu.getMenuTemplate after setLocale', () => {
                 mockMenu.getMenuTemplate.mockClear();
-                ipcHandlers['update-menu'](null, 'fra');
+                ipcHandlers['update-menu'](null, 'fr');
                 expect(mockMenu.getMenuTemplate).toHaveBeenCalled();
             });
 
             it('calls Menu.setApplicationMenu when update-menu is triggered', () => {
                 mockDeps.Menu.setApplicationMenu.mockClear();
-                ipcHandlers['update-menu'](null, 'fra');
+                ipcHandlers['update-menu'](null, 'fr');
                 expect(mockDeps.Menu.setApplicationMenu).toHaveBeenCalled();
             });
         });

--- a/td.vue/tests/unit/desktop/menu.spec.js
+++ b/td.vue/tests/unit/desktop/menu.spec.js
@@ -597,6 +597,24 @@ describe('desktop/menu.js', () => {
         });
 
         describe('Locale selection', () => {
+            const locales = [
+                { code: 'ar', label: ar.desktop.help.heading, name: 'Arabic' },
+                { code: 'de', label: de.desktop.help.heading, name: 'German' },
+                { code: 'el', label: el.desktop.help.heading, name: 'Greek (Modern)' },
+                { code: 'en', label: en.desktop.help.heading, name: 'English' },
+                { code: 'es', label: es.desktop.help.heading, name: 'Spanish (Castilian)' },
+                { code: 'fi', label: fi.desktop.help.heading, name: 'Finnish' },
+                { code: 'fr', label: fr.desktop.help.heading, name: 'French' },
+                { code: 'hi', label: hi.desktop.help.heading, name: 'Hindi' },
+                { code: 'id', label: id.desktop.help.heading, name: 'Bahasa Indonesia' },
+                { code: 'ja', label: ja.desktop.help.heading, name: 'Japanese' },
+                { code: 'ms', label: ms.desktop.help.heading, name: 'Malay' },
+                { code: 'pt', label: pt.desktop.help.heading, name: 'Portuguese' },
+                { code: 'pt-BR', label: ptBr.desktop.help.heading, name: 'Brazilian Portuguese' },
+                { code: 'ru', label: ru.desktop.help.heading, name: 'Russian' },
+                { code: 'uk', label: uk.desktop.help.heading, name: 'Ukrainian' },
+                { code: 'zh', label: zh.desktop.help.heading, name: 'Chinese' }
+            ];
 
             afterAll(() => {
                 menu.setLocale('default');
@@ -613,104 +631,12 @@ describe('desktop/menu.js', () => {
                 expect(helpItems).toBeDefined();
             });
 
-            it('should provide translation for Arabic', () => {
-                menu.setLocale('ar');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ar.desktop.help.heading);
+            it.each(locales)('should provide translation for $name ($code)', ({ code, label }) => {
+                menu.setLocale(code);
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === label);
                 expect(helpItems).toBeDefined();
             });
-
-            it('should provide translation for German', () => {
-                menu.setLocale('de');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === de.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Greek (Modern)', () => {
-                menu.setLocale('el');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === el.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for English', () => {
-                menu.setLocale('en');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === en.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Spanish (Castilian)', () => {
-                menu.setLocale('es');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === es.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for French', () => {
-                menu.setLocale('fr');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === fr.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Finnish', () => {
-                menu.setLocale('fi');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === fi.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Hindi', () => {
-                menu.setLocale('hi');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === hi.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Bahasa Indonesia', () => {
-                menu.setLocale('id');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === id.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Japanese', () => {
-                menu.setLocale('ja');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ja.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Malay', () => {
-                menu.setLocale('ms');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ms.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Portuguese', () => {
-                menu.setLocale('pt');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === pt.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Brazilian Portuguese', () => {
-                menu.setLocale('pt-BR');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ptBr.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Russian', () => {
-                menu.setLocale('ru');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ru.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Ukrainian', () => {
-                menu.setLocale('uk');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === uk.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Chinese', () => {
-                menu.setLocale('zh');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === zh.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
         });
-
     });
 
 });

--- a/td.vue/tests/unit/desktop/menu.spec.js
+++ b/td.vue/tests/unit/desktop/menu.spec.js
@@ -5,21 +5,22 @@ jest.mock('fs', () => require('./helpers/mockFs'));
 
 import { utils } from './helpers/mockUtils.js';
 import menu, { model } from '@/desktop/menu.js';
-import ara from '@/i18n/ar.js';
-import deu from '@/i18n/de.js';
-import ell from '@/i18n/el.js';
-import eng from '@/i18n/en.js';
-import fin from '@/i18n/fi.js';
-import fra from '@/i18n/fr.js';
-import hin from '@/i18n/hi.js';
-import ind from '@/i18n/id.js';
-import msa from '@/i18n/ms.js';
-import por from '@/i18n/pt.js';
-import bra from '@/i18n/pt-br.js';
-import rus from '@/i18n/ru.js';
-import spa from '@/i18n/es.js';
-import ukr from '@/i18n/uk.js';
-import zho from '@/i18n/zh.js';
+import ar from '@/i18n/ar.js';
+import de from '@/i18n/de.js';
+import el from '@/i18n/el.js';
+import en from '@/i18n/en.js';
+import es from '@/i18n/es.js';
+import fi from '@/i18n/fi.js';
+import fr from '@/i18n/fr.js';
+import hi from '@/i18n/hi.js';
+import id from '@/i18n/id.js';
+import ja from '@/i18n/ja.js';
+import ms from '@/i18n/ms.js';
+import pt from '@/i18n/pt.js';
+import ptBr from '@/i18n/pt-br.js';
+import ru from '@/i18n/ru.js';
+import uk from '@/i18n/uk.js';
+import zh from '@/i18n/zh.js';
 
 describe('desktop/menu.js', () => {
 
@@ -608,97 +609,103 @@ describe('desktop/menu.js', () => {
 
             it('should provide default translation for unrecognised locale', () => {
                 menu.setLocale('unrecognised');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === eng.desktop.help.heading);
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === en.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for Arabic', () => {
-                menu.setLocale('ara');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ara.desktop.help.heading);
+                menu.setLocale('ar');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === ar.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for German', () => {
-                menu.setLocale('deu');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === deu.desktop.help.heading);
+                menu.setLocale('de');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === de.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for Greek (Modern)', () => {
-                menu.setLocale('ell');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ell.desktop.help.heading);
+                menu.setLocale('el');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === el.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for English', () => {
-                menu.setLocale('eng');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === eng.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Bahasa Indonesia', () => {
-                menu.setLocale('ind');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ind.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Malay', () => {
-                menu.setLocale('msa');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === msa.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Finnish', () => {
-                menu.setLocale('fin');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === fin.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for French', () => {
-                menu.setLocale('fra');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === fra.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Hindi', () => {
-                menu.setLocale('hin');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === hin.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Portuguese', () => {
-                menu.setLocale('por');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === por.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Brazilian Portuguese', () => {
-                menu.setLocale('bra');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === bra.desktop.help.heading);
-                expect(helpItems).toBeDefined();
-            });
-
-            it('should provide translation for Russian', () => {
-                menu.setLocale('rus');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === rus.desktop.help.heading);
+                menu.setLocale('en');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === en.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for Spanish (Castilian)', () => {
-                menu.setLocale('spa');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === spa.desktop.help.heading);
+                menu.setLocale('es');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === es.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for French', () => {
+                menu.setLocale('fr');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === fr.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Finnish', () => {
+                menu.setLocale('fi');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === fi.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Hindi', () => {
+                menu.setLocale('hi');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === hi.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Bahasa Indonesia', () => {
+                menu.setLocale('id');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === id.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Japanese', () => {
+                menu.setLocale('ja');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === ja.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Malay', () => {
+                menu.setLocale('ms');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === ms.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Portuguese', () => {
+                menu.setLocale('pt');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === pt.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Brazilian Portuguese', () => {
+                menu.setLocale('pt-BR');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === ptBr.desktop.help.heading);
+                expect(helpItems).toBeDefined();
+            });
+
+            it('should provide translation for Russian', () => {
+                menu.setLocale('ru');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === ru.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for Ukrainian', () => {
-                menu.setLocale('ukr');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === ukr.desktop.help.heading);
+                menu.setLocale('uk');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === uk.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 
             it('should provide translation for Chinese', () => {
-                menu.setLocale('zho');
-                const helpItems = menu.getMenuTemplate().find((item) => item.label === zho.desktop.help.heading);
+                menu.setLocale('zh');
+                const helpItems = menu.getMenuTemplate().find((item) => item.label === zh.desktop.help.heading);
                 expect(helpItems).toBeDefined();
             });
 


### PR DESCRIPTION
**Summary**:  

This pull request normalises to **IETF BCP 47** standard (ISO 639‑1 language + optional ISO 3166‑1 region). It replaces the old three‑letter ISO 639‑2 codes (`ara`, `deu`, `eng`, …) with two‑letter codes (`ar`, `de`, `en`, …) and adopts canonical `pt-BR` for Brazilian Portuguese. This improves interoperability with browser APIs and aligns with vue-i18n v10 best practices.

Refs #1558, #1495
Closes #1502, #1503

**Description for the changelog**:  

refactor(i18n): normalise locale codes to BCP 47 / ISO 639-1

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[DeepSeek Chat]`
  - LLMs and versions: `[DeepSeek (current version as of April 2026)]`
  - Prompts: `[Assist with comparing translation keys, updating translation documentation, and drafting pull request template]`

**Other info**:  
