### PR TITLE
Setting least priv permissions for workflows

### DIFF
--- a/.github/workflows/browserstack.yaml
+++ b/.github/workflows/browserstack.yaml
@@ -6,6 +6,9 @@ on:
     - cron: '40 8 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # for security reasons the github actions are pinned to specific SHAs
 jobs:
   browserstack_e2e:

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -78,34 +78,6 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
 
-  codeql:
-    name: Analyze with codeql
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: main
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          languages: 'javascript'
-          config-file: ./.github/codeql/codeql-config.yml
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-      - name: CodeQL autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-
-      - name: Perform vulnerability analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
   link_checker:
     name: Link checker
     runs-on: ubuntu-24.04

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '45 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: threatdragon/owasp-threat-dragon:latest
 
@@ -53,7 +56,7 @@ jobs:
     name: Scan with Trivy
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       security-events: write
     steps:
       - name: Checkout repository
@@ -79,6 +82,7 @@ jobs:
     name: Analyze with codeql
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       security-events: write
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -187,35 +187,6 @@ jobs:
       - name: Run unit tests
         run: npm run test:desktop
 
-  codeql:
-    name: Analyze with codeql
-    runs-on: ubuntu-24.04
-    needs: [server_unit_tests, site_unit_tests, desktop_unit_tests]
-    permissions:
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          languages: 'javascript'
-          config-file: ./.github/codeql/codeql-config.yml
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-      - name: CodeQL autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-
-      - name: Perform vulnerability analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
   e2e_smokes:
     name: Local site e2e smokes
     runs-on: ubuntu-24.04

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,6 +5,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: "pr-${{ github.event.number }}"
   ZAP_FILE: "zap-scan-pr-${{ github.event.number }}"
@@ -189,6 +192,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [server_unit_tests, site_unit_tests, desktop_unit_tests]
     permissions:
+      contents: read
       security-events: write
 
     strategy:
@@ -446,7 +450,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build_docker_image
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   HEROKU_APP: threatdragon-v2
   HEROKU_EMAIL: jon.gadsden@owasp.org
@@ -133,6 +136,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [server_unit_tests, site_unit_tests]
     permissions:
+      contents: read
       security-events: write
 
     strategy:
@@ -480,7 +484,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build_docker_image
     permissions:
-      contents: write
+      contents: read
       security-events: write
 
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -131,35 +131,6 @@ jobs:
       - name: Unit test
         run: npm run test:desktop
 
-  codeql:
-    name: Analyze with codeql
-    runs-on: ubuntu-24.04
-    needs: [server_unit_tests, site_unit_tests]
-    permissions:
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          languages: 'javascript'
-          config-file: ./.github/codeql/codeql-config.yml
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-      - name: CodeQL autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-
-      - name: Perform vulnerability analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
   build_docker_image:
     name: Build latest docker
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -3,6 +3,9 @@ name: Release Linux
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 # for security reasons the github actions are pinned to specific SHAs
 jobs:
   desktop_linux:

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -3,6 +3,9 @@ name: Release MacOS
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 # for security reasons the github actions are pinned to specific SHAs
 jobs:
   desktop_macos:

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -3,6 +3,9 @@ name: Release to Snap
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # for security reasons the github actions are pinned to specific SHAs
 jobs:
   desktop_linux_snap:

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -3,6 +3,9 @@ name: Windows release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 # for security reasons the github actions are pinned to specific SHAs
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
       - v2.?.*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   # threatdragon is the working area on docker hub so use this area
   # owasp/threat-dragon is the final release area so DO NOT use that
@@ -131,6 +134,8 @@ jobs:
     name: Windows installer
     runs-on: windows-latest
     needs: [desktop_unit_tests, site_unit_tests]
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: td.vue
@@ -177,6 +182,8 @@ jobs:
     name: MacOS installer
     runs-on: macos-latest
     needs: [desktop_unit_tests, site_unit_tests]
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # MacOS signing: certificate and password, see electron.build/code-signing
@@ -238,6 +245,8 @@ jobs:
     name: Linux installers
     runs-on: ubuntu-24.04
     needs: [desktop_unit_tests, site_unit_tests]
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: td.vue
@@ -472,6 +481,8 @@ jobs:
       - desktop_linux
       - desktop_windows
       - sbom_combiner
+    permissions:
+      contents: write
 
     steps:
       - name: Check out


### PR DESCRIPTION
**Summary**:  

CodeQL has correctly warned us that:
> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

**Description for the changelog**:  

chore: set GH actions permissions

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I did my best to reason about each action and what permissions they'd need, but there's no guarantee that I caught everything! :sweat_smile: 