### PR TITLE
Dependabot Config Updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,7 @@ updates:
     directory: ".github/workflows"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 10
     groups:
@@ -18,14 +19,16 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
         update-types:
-          - "patch"
-          - "minor"
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 10
     groups:
@@ -40,9 +43,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - "patch"
-          - "minor"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -52,6 +52,7 @@ updates:
     directory: "/td.server"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 10
     groups:
@@ -66,9 +67,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - "patch"
-          - "minor"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -78,6 +76,7 @@ updates:
     directory: "/td.vue"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 10
     groups:
@@ -92,9 +91,30 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "bundler"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 10
+    groups:
+      docs-bundler-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "patch"
           - "minor"
+      docs-bundler-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
**Summary**:  

I previously took a swing at making the dependabot updates more meaningful.  What has happened instead is that we are getting swamped with PRs that are still lower fidelity.  This PR attempts to group updates better, with one caveat: security updates do not allow a cooldown configuration.  We will still need to mark those as draft and wait.

By having all of the apps covered with groupings and security configs (`td.vue`, `td.server`, `docs`, `root`), we can disable the repo setting of "Grouped Security Updates", as I _believe_ that is what was interfering with the existing config.

I've constrained the max PRs to 1 per group.  I'd rather roll slow and steady than drown in PRs that we aren't confident merging. :smile: 

**Description for the changelog**:  

chore: dependabot config update

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I'm still learning, so I cannot promise this will make life better - open to suggestions as well!