### PR TITLE
Skip visual regression tests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -277,6 +277,8 @@ jobs:
     name: Site visual regression
     runs-on: ubuntu-24.04
     needs: site_unit_tests
+    # TODO: https://github.com/OWASP/threat-dragon/issues/1613
+    if: false
     defaults:
       run:
         working-directory: td.vue


### PR DESCRIPTION
**Summary**:  

Relates to #1613 
Visual regression tests are flaky.  Until stabilized, we should skip them.

**Description for the changelog**:  

chore: skips flaky visual regression tests pending

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I'll take my time a bit more with #1613 and make sure it works locally for contributors, the drifts are maintainable, and they aren't flaky in the way they are today.  

I'm not _quite_ ready to give up on the idea, but in its current state it's just noise.
