### PR TITLE
Harden TM-BOM import / merge 

### DIFF
--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'نماذج التهديد الإصدار 2.0 غير متوافقة مع الإصدارات السابقة مع نماذج Threat Dragon للإصدار x.1 من ستتم ترقية نماذج الإصدار x.1 المستوردة إلى مخطط الإصدار 2.0،'
         },
         prompts: {

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Importierte Version 1.x Modelle werden auf das Version 2.0 Schema gehoben' //in line with wording of BSI Leitfaden zur Entwicklung sicherer Webanwendungen
         },
         prompts: {

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Τα εισαχθέντα μοντέλα της έκδοσης 1.x models θα αναβαθμιστούν στο σχήμα της έκδοσης 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Imported version 1.x model has been upgraded to the version 2.x format'
         },
         prompts: {

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Los modelos importados de la versión 1.x serán actualizados acorde al esquema de la versión 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Version 1.x mallit päivitetään automaattisesti version 2.0 uhkamalleiksi.'
         },
         prompts: {

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Imported version 1.x model has been upgraded to the version 2.x format'
         },
         prompts: {

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Imported version 1.x model has been upgraded to the version 2.x format'
         },
         prompts: {

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Model versi 1.x yang diimpor akan ditingkatkan ke skema versi 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'バージョン1.xのモデルは、インポート時にバージョン2.0のフォーマットに変換されます。'
         },
         prompts: {

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Model versi 1.x yang diimport akan dinaik tarafkan ke skema versi 2.0'
         },
         prompts: {

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Imported version 1.x model has been upgraded to the version 2.x format'
         },
         prompts: {

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -240,7 +240,7 @@ const messages = {
             noModelOpen: 'No model open',
             otmUnsupported: 'Import of Open Threat Model file format not yet supported',
             save: 'Could not save the Threat Model. Check the developer console for more information',
-            tmUnsupported: 'Import of TM-BOM file format is experimental and subject to change that may break models',
+            tmUnsupported: 'Import of TM-BOM files converts the file format to Threat Dragon',
             v1Translate: 'Imported version 1.x model has been upgraded to the version 2.x format'
         },
         prompts: {

--- a/td.vue/src/main.desktop.js
+++ b/td.vue/src/main.desktop.js
@@ -203,7 +203,7 @@ const localAuth = () => {
 };
 
 const openTmBom = (jsonModel) => {
-    console.warn('Convert TM-BOM to internal TD format');
+    console.info('Convert TM-BOM to internal TD format');
     appProxy.$toast.warning(t('threatmodel.warnings.tmUnsupported'), { timeout: false });
     return importTmbom(jsonModel);
 };

--- a/td.vue/src/service/migration/tmBom/diagrams/assumptions.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/assumptions.js
@@ -18,16 +18,15 @@ const merge = (model, components) => {
     return components;
 };
 
+// the summary holds any assumptions that are not associated with a component
 const summary = (model) => {
     let summaryAssumptions = new Array();
 
-    if (model.assumptions) {
-        model.assumptions.forEach((assumption) => {
-            if (!assumption.topics) {
-                summaryAssumptions.push(assumption);
-            }
-        });
-    }
+    model.assumptions?.forEach((assumption) => {
+        if (!assumption.topics) {
+            summaryAssumptions.push(assumption);
+        }
+    });
 
     return summaryAssumptions;
 };

--- a/td.vue/src/service/migration/tmBom/diagrams/boxes.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/boxes.js
@@ -6,30 +6,26 @@ const nodeGeometry = {width: 160 + padding, height: 80 + padding, padding: paddi
 
 const countNodes = (model, trust_zone) => {
     let count = 0;
+    let zones = new Array();
+    model.trust_zones?.forEach((zone) => zones.push(zone.symbolic_name));
 
-    if (model.actors) {
-        model.actors.forEach((actor) => {
-            if (actor.trust_zone === trust_zone) {
-                count++;
-            }
-        });
-    }
+    model.actors?.forEach((actor) => {
+        if (actor.trust_zone === trust_zone || (!zones.includes(actor.trust_zone) && trust_zone === undefined)) {
+            count++;
+        }
+    });
 
-    if (model.components) {
-        model.components.forEach((component) => {
-            if (component.trust_zone === trust_zone) {
-                count++;
-            }
-        });
-    }
+    model.components?.forEach((component) => {
+        if (component.trust_zone === trust_zone || (!zones.includes(component.trust_zone) && trust_zone === undefined)) {
+            count++;
+        }
+    });
 
-    if (model.data_stores) {
-        model.data_stores.forEach((data_store) => {
-            if (data_store.trust_zone === trust_zone) {
-                count++;
-            }
-        });
-    }
+    model.data_stores?.forEach((data_store) => {
+        if (data_store.trust_zone === trust_zone || (!zones.includes(data_store.trust_zone) && trust_zone === undefined)) {
+            count++;
+        }
+    });
 
     return count;
 };

--- a/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
@@ -10,7 +10,11 @@ const assignThreats = (model, components) => {
         threat.components_affected?.forEach((componentAffected) => {
             components.forEach((component) => {
                 if (componentAffected === component.id) {
-                    component.data.threats.push(threat);
+                    if (component.data.threats) {
+                        component.data.threats.push(threat);
+                    } else {
+                        console.warn('Ignoring threat incorrectly associated with trust zone');
+                    }
                 }
             });
         });
@@ -33,12 +37,12 @@ const merge = (model, version) => {
     cells = assignThreats(model, cells);
 
     diagrams.push({
-	    version: version,
-	    title: model.scope.title,
-	    thumbnail: thumbnail,
-	    diagramType: 'TM-BOM',
-	    id: diagramId++,
-	    cells: cells
+        version: version,
+        title: model.scope.title,
+        thumbnail: thumbnail,
+        diagramType: 'TM-BOM',
+        id: diagramId++,
+        cells: cells
     });
 
     // add TM-BOM diagrams, which are supporting diagrams in arbitrary format

--- a/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
@@ -1,7 +1,7 @@
 import assumptions from './assumptions';
-import data_flows from './flows';
+import dataFlows from './flows';
 import nodes from './nodes';
-import data_sets from './sets';
+import dataSets from './sets';
 import threats from './threats/threats';
 
 const assignThreats = (model, components) => {
@@ -13,7 +13,7 @@ const assignThreats = (model, components) => {
                     if (component.data.threats) {
                         component.data.threats.push(threat);
                     } else {
-                        console.warn('Ignoring threat incorrectly associated with trust zone');
+                        console.warn('Ignoring threat ' + threat.id + ' incorrectly associated with trust zone ' + component.id);
                     }
                 }
             });
@@ -23,18 +23,38 @@ const assignThreats = (model, components) => {
     return components;
 };
 
+// antv/x6 drawing package throws an error if the source or target of a flow/edge are named but no cell exists of that name
+// so sift out early and warn on this easily-made error
+const checkEdges = (edges, nodes) => {
+    let ids = new Array();
+    for (let node of nodes) {
+        ids.push(node.id);
+    }
+    edges.forEach((edge) => {
+        if (!ids.includes(edge.source.cell)) {
+            console.warn('Source cell not found: ' + edge.source.cell);
+            edge.source.cell = '';
+        }
+        if (!ids.includes(edge.target.cell)) {
+            console.warn('Target cell not found: ' + edge.target.cell);
+            edge.target.cell = '';
+        }
+    });
+};
+
 const merge = (model, version) => {
     const thumbnail = './public/content/images/thumbnail.jpg';
     var diagrams = new Array();
     let diagramId = 0;
     const diagramNodes = nodes.merge(model);
-    const diagramEdges = data_flows.merge(model);
+    const diagramEdges = dataFlows.merge(model);
+    checkEdges(diagramEdges, diagramNodes);
     let cells = diagramNodes.concat(diagramEdges);
 
     // data sets and assumptions are merged into existing components
-    cells = data_sets.merge(model, cells);
-    cells = assumptions.merge(model, cells);
-    cells = assignThreats(model, cells);
+    dataSets.merge(model, cells);
+    assumptions.merge(model, cells);
+    assignThreats(model, cells);
 
     diagrams.push({
         version: version,
@@ -46,19 +66,16 @@ const merge = (model, version) => {
     });
 
     // add TM-BOM diagrams, which are supporting diagrams in arbitrary format
-    if (model.diagrams) {
-        let modelDiagrams = model.diagrams;
-        modelDiagrams.forEach((diagram) => {
-            diagrams.push({
-                version: version,
-                title: diagram.title,
-                thumbnail: thumbnail,
-                diagramType: diagram.type,
-                id: diagramId++,
-                cells: []
-            });
+    model.diagrams?.forEach((diagram) => {
+        diagrams.push({
+            version: version,
+            title: diagram.title,
+            thumbnail: thumbnail,
+            diagramType: diagram.type,
+            id: diagramId++,
+            cells: []
         });
-    }
+    });
 
     return diagrams;
 };

--- a/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/diagrams.js
@@ -13,7 +13,7 @@ const assignThreats = (model, components) => {
                     if (component.data.threats) {
                         component.data.threats.push(threat);
                     } else {
-                        console.warn('Ignoring threat ' + threat.id + ' incorrectly associated with trust zone ' + component.id);
+                        console.warn('Ignoring threat ' + threat.id + 'for trust zone : ' + component.id);
                     }
                 }
             });
@@ -30,6 +30,7 @@ const checkEdges = (edges, nodes) => {
     for (let node of nodes) {
         ids.push(node.id);
     }
+
     edges.forEach((edge) => {
         if (!ids.includes(edge.source.cell)) {
             console.warn('Source cell not found: ' + edge.source.cell);

--- a/td.vue/src/service/migration/tmBom/diagrams/flows.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/flows.js
@@ -1,34 +1,26 @@
 import defaultProperties from '@/service/entity/default-properties.js';
 
 const merge = (model) => {
-    const flows = placeFlows(model);
-
-    return flows;
-};
-
-const placeFlows = (model) => {
     let flows = new Array();
     let zIndex = 0;
 
     if (model.data_flows) {
-        let data_flows = model.data_flows;
-        data_flows.forEach((data_flow) => {
+        for (let dataFlow of model.data_flows) {
             let flow = defaultProperties.defaultEntity('tm.Flow');
-            flow.data.name = flow.labels[0].attrs.labelText.text = data_flow.title;
-            flow.data.description = data_flow.description;
-            flow.data.isEncrypted = data_flow.encrypted;
-            flow.id = data_flow.symbolic_name;
+            flow.data.name = flow.labels[0].attrs.labelText.text = dataFlow.title;
+            flow.data.description = dataFlow.description;
+            flow.data.isEncrypted = dataFlow.encrypted;
+            flow.id = dataFlow.symbolic_name;
             flow.zIndex = zIndex++;
-            flow.source.cell = data_flow.source.object;
-            flow.target.cell = data_flow.destination.object;
+            flow.source.cell = dataFlow.source.object;
+            flow.target.cell = dataFlow.destination.object;
             flows.push(flow);
-        });
+        }
     }
 
     return flows;
 };
 
 export default {
-    placeFlows,
     merge
 };

--- a/td.vue/src/service/migration/tmBom/diagrams/nodes.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/nodes.js
@@ -7,9 +7,11 @@ const nodeSize = { width: boxes.nodeGeometry.width, height: boxes.nodeGeometry.h
 export const createNodes = (model, zone) => {
     let nodes = new Array();
     let zIndex = 0;
+    let zones = new Array();
+    model.trust_zones?.forEach((zone) => zones.push(zone.symbolic_name));
 
     model.actors?.forEach((actor) => {
-        if ((actor.trust_zone === zone) || (!actor.trust_zone && zone === null)) {
+        if ((actor.trust_zone === zone) || (!zones.includes(actor.trust_zone) && zone === undefined)) {
             let node = defaultProperties.defaultEntity('tm.Actor');
             node.label = node.data.name = actor.title;
             node.data.description = actor.description;
@@ -20,7 +22,7 @@ export const createNodes = (model, zone) => {
     });
 
     model.components?.forEach((component) => {
-        if ((component.trust_zone === zone) || (!component.trust_zone && zone === null)) {
+        if ((component.trust_zone === zone) || (!zones.includes(component.trust_zone) && zone === undefined)) {
             let process = defaultProperties.defaultEntity('tm.Process');
             process.data.name = process.attrs.text.text = component.title;
             process.data.description = component.description;
@@ -31,7 +33,7 @@ export const createNodes = (model, zone) => {
     });
 
     model.data_stores?.forEach((data_store) => {
-        if ((data_store.trust_zone === zone) || (!data_store.trust_zone && zone === null)) {
+        if ((data_store.trust_zone === zone) || (!zones.includes(data_store.trust_zone) && zone === undefined)) {
             let store = defaultProperties.defaultEntity('tm.Store');
             store.data.name = store.attrs.text.text = data_store.title;
             store.data.description = data_store.description;
@@ -70,8 +72,9 @@ export const placeNodes = (nodes, position) => {
 export const merge = (model) => {
     let trustBoundaryBoxes = boxes.merge(model);
 
+    // public zone components are not in any trust boundary
+    let publicNodes = createNodes(model, undefined);
     // place public zone components around the edges of the diagram
-    let publicNodes = createNodes(model, undefined).concat(createNodes(model, ''));
     let nodes = placeNodes(publicNodes, { x: 0, y: 0 });
 
     // find and place the nodes for each trust zone / boundary box

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -159,7 +159,7 @@ export default {
                     fileName = '';
                     this.$store.dispatch(tmActions.update, { fileName: fileName });
                 } else if (schema.isTmBom(jsonModel)) {
-                    console.warn('Convert TM-BOM to internal TD format');
+                    console.info('Convert TM-BOM to internal TD format');
                     this.$toast.warning(this.$t('threatmodel.warnings.tmUnsupported'), { timeout: false });
                     jsonModel = importTmbom(jsonModel);
                     console.debug('Force selection of file name for TM-BOM');

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/diagrams.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/diagrams.spec.js
@@ -41,7 +41,7 @@ describe('service/migration/tmBom/diagrams/diagrams.js', () => {
         });
 
         it('creates main diagram', () => {
-	    expect(testDiagrams).toHaveLength(1);
+	        expect(testDiagrams).toHaveLength(1);
         });
 
     });

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/diagrams.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/diagrams.spec.js
@@ -37,11 +37,11 @@ describe('service/migration/tmBom/diagrams/diagrams.js', () => {
     describe('merge main diagram', () => {
         beforeEach(() => {
             delete(tmBomModel.diagrams);
-		    testDiagrams = diagrams.merge(tmBomModel, version);
+            testDiagrams = diagrams.merge(tmBomModel, version);
         });
 
         it('creates main diagram', () => {
-	        expect(testDiagrams).toHaveLength(1);
+            expect(testDiagrams).toHaveLength(1);
         });
 
     });

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/flows.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/flows.spec.js
@@ -1,42 +1,42 @@
-import data_flows from '@/service/migration/tmBom/diagrams/flows';
+import flows from '@/service/migration/tmBom/diagrams/flows';
 import tmBomModel from '../test-model';
 
 describe('service/migration/tmBom/diagrams/flows.js', () => {
 
     describe('finds the flows', () => {
         it('counts flows in model', () => {
-            expect(data_flows.merge(tmBomModel)).toHaveLength(tmBomModel.data_flows.length);
+            expect(flows.merge(tmBomModel)).toHaveLength(tmBomModel.data_flows.length);
         });
     });
 
     describe('configures the flows', () => {
         let dataFlows;
         beforeEach(() => {
-            dataFlows = data_flows.placeFlows(tmBomModel);
+            dataFlows = flows.merge(tmBomModel);
         });
 
         it('sets the name', () => {
-		    expect(dataFlows[0].data.name).toBe('Test title data-flow0');
-		    expect(dataFlows[2].data.name).toBe('Test title data-flow2');
-		    expect(dataFlows[4].data.name).toBe('Test title data-flow4');
+            expect(dataFlows[0].data.name).toBe('Test title data-flow0');
+            expect(dataFlows[2].data.name).toBe('Test title data-flow2');
+            expect(dataFlows[4].data.name).toBe('Test title data-flow4');
         });
 
         it('sets the zIndex', () => {
-		    expect(dataFlows[0].zIndex).toEqual(0);
-		    expect(dataFlows[2].zIndex).toEqual(2);
-		    expect(dataFlows[4].zIndex).toEqual(4);
+            expect(dataFlows[0].zIndex).toEqual(0);
+            expect(dataFlows[2].zIndex).toEqual(2);
+            expect(dataFlows[4].zIndex).toEqual(4);
         });
 
         it('sets the ID', () => {
-		    expect(dataFlows[0].id).toBe('data-flow0');
-		    expect(dataFlows[2].id).toBe('data-flow2');
-		    expect(dataFlows[4].id).toBe('data-flow4');
+            expect(dataFlows[0].id).toBe('data-flow0');
+            expect(dataFlows[2].id).toBe('data-flow2');
+            expect(dataFlows[4].id).toBe('data-flow4');
         });
 
         it('sets the source cell', () => {
-		    expect(dataFlows[0].source.cell).toBe('actor0');
-		    expect(dataFlows[2].source.cell).toBe('actor2');
-		    expect(dataFlows[4].source.cell).toBe('component4');
+            expect(dataFlows[0].source.cell).toBe('actor0');
+            expect(dataFlows[2].source.cell).toBe('actor2');
+            expect(dataFlows[4].source.cell).toBe('component4');
         });
 
         it('sets the target cell', () => {
@@ -59,12 +59,12 @@ describe('service/migration/tmBom/diagrams/flows.js', () => {
     });
 
     describe('handles model with no data flows', () => {
-	    let noDataFlowsModel = JSON.parse(JSON.stringify(tmBomModel));
-	    delete noDataFlowsModel.data_flows;
-        let dataFlows = data_flows.placeFlows(noDataFlowsModel);
+        let noDataFlowsModel = JSON.parse(JSON.stringify(tmBomModel));
+        delete noDataFlowsModel.data_flows;
+        let dataFlows = flows.merge(noDataFlowsModel);
 
-	    it('adds no data flows', () => {
-	        expect(dataFlows).toEqual([]);
-	    });
+        it('adds no data flows', () => {
+            expect(dataFlows).toEqual([]);
+        });
     });
 });

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/nodes.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/nodes.spec.js
@@ -49,7 +49,7 @@ describe('service/migration/tmBom/diagrams/nodes.js', () => {
 
     describe('create nodes in zones', () => {
         it('creates nodes in untrusted zone', () => {
-            let components = createNodes(tmBomModel, null);
+            let components = createNodes(tmBomModel);
             expect(components).toHaveLength(6);
         });
 
@@ -111,8 +111,10 @@ describe('service/migration/tmBom/diagrams/nodes.js', () => {
         delete(emptyZonesTmBom.trust_zones);
         let components = merge(emptyZonesTmBom);
 
-        it('merges only public nodes', () => {
-            expect(components).toHaveLength(6);
+        it('merges all nodes as public', () => {
+            expect(components).toHaveLength(tmBomModel.actors.length
+                + tmBomModel.components.length
+                + tmBomModel.data_stores.length);
         });
     });
 

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/sets.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/sets.spec.js
@@ -1,11 +1,11 @@
-import data_sets from '@/service/migration/tmBom/diagrams/sets';
+import dataSets from '@/service/migration/tmBom/diagrams/sets';
 import tmBomModel from '../test-model';
 import { components as nodes } from './mockTdComponents.json';
 
 describe('service/migration/tmBom/diagrams/sets.js', () => {
 
     describe('updates component descriptions', () => {
-        let components = data_sets.merge(tmBomModel, nodes);
+        let components = dataSets.merge(tmBomModel, nodes);
 
         it('adds the data set title', () => {
             expect(components[0].data.description).not.toContain('title data_set');
@@ -61,7 +61,7 @@ describe('service/migration/tmBom/diagrams/sets.js', () => {
         delete noDataSetModel.data_sets;
 
         it('preserves the components', () => {
-            let components = data_sets.merge(noDataSetModel, nodes);
+            let components = dataSets.merge(noDataSetModel, nodes);
             expect(components).toStrictEqual(nodes);
         });
     });

--- a/td.vue/tests/unit/service/migration/tmBom/test-model.json
+++ b/td.vue/tests/unit/service/migration/tmBom/test-model.json
@@ -534,7 +534,7 @@
             "symbolic_name": "threat3",
             "title": "Test title threat3",
             "description": "Test description threat3",
-            "components_affected": ["component5"],
+            "components_affected": ["trust-zone3"],
             "threat_persona": "threat-persona3",
             "event": "Test event threat0",
             "sources": ["events_beyond_org_control", "adversary"]

--- a/td.vue/tests/unit/service/migration/tmBom/test-model.json
+++ b/td.vue/tests/unit/service/migration/tmBom/test-model.json
@@ -390,6 +390,15 @@
             "destination": {"type": "data_store", "object": "data-store3"},
             "has_sensitive_data": true,
             "encrypted": false
+        },
+        {
+            "symbolic_name": "data-flow6",
+            "title": "Test title data-flow6",
+            "description": "Test description data-flow6",
+            "source": {"type": "actor", "object": "no-source"},
+            "destination": {"type": "data_store", "object": "no-destination"},
+            "has_sensitive_data": true,
+            "encrypted": false
         }
     ],
     "assumptions": [


### PR DESCRIPTION
**Summary**:  

This handles various faults that can be present in a TM-BOM but that the schema check does not pick up:

- component references a non-existent trust zone
- threats applied to a trust zone
- data flow target or source references a non-existent component

**Description for the changelog**:  

harden TM-BOM merge to avoid errors being thrown

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

closes #1625 
