### PR TITLE
Fix inconsistent state between cell data and name for component labels

### DIFF
--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -57,7 +57,7 @@
             <b-form-textarea
               id="name"
               v-model="cellRef.data.name"
-              @update="onChangeName()"
+              @update="onChangeName"
               :rows="cellRef.data.type === 'tm.Text' ? 7 : 2"
               graphPro
             ></b-form-textarea>
@@ -372,8 +372,8 @@ export default {
             // should not need to need to force an update
             this.$forceUpdate();
         },
-        onChangeName() {
-            dataChanged.updateName(this.cellRef);
+        onChangeName(name) {
+            dataChanged.updateName(this.cellRef, name);
             this.updateComponent();
         },
         onChangeBidirection() {

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -66,11 +66,15 @@ const updateStyleAttrs = (cell) => {
     }
 };
 
-const updateName = (cell) => {
+const updateName = (cell, name) => {
     if (!cell || !cell.setName || !cell.getData) {
         console.warn('No cell found to update name');
     } else {
-        cell.setName(cell.getData().name);
+        const cellData = cell.getData();
+        if (cellData && name !== undefined) {
+            cellData.name = name;
+        }
+        cell.setName(cellData.name);
     }
 };
 

--- a/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
+++ b/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
@@ -51,6 +51,14 @@ const selectGraphLabel = (labelPattern) => {
         .click({ force: true });
 };
 
+const assertSelectedGraphLabel = (expectedLabel) => {
+    cy.get('#graph-container .x6-cell.x6-node.x6-node-selected tspan')
+        .should(($labels) => {
+            const labelText = [...$labels].map((label) => label.textContent).join('');
+            expect(labelText).to.equal(expectedLabel);
+        });
+};
+
 const assertNoObservedError = (matcher) => {
     cy.window().its('__tdObservedErrors').should((messages) => {
         expect(messages, 'captured browser errors').to.satisfy((errors) =>
@@ -135,6 +143,20 @@ describe('Regressions discovered during vue3 migration', () => {
         });
 
         assertNoObservedError(expectedRuntimeError);
+    });
+
+    it('updates the selected component label on every name keystroke', () => {
+        openDemoModel('Demo Threat Model');
+        openDiagramEditor('Main Request Data Flow');
+        selectGraphLabel(/Database/);
+
+        cy.get('#name').clear();
+        cy.get('#name').type('D');
+        assertSelectedGraphLabel('D');
+        cy.get('#name').type('B');
+        assertSelectedGraphLabel('DB');
+        cy.get('#name').type('2');
+        assertSelectedGraphLabel('DB2');
     });
 
     it('does not render javascript: links in the exercised threat-model flows', () => {

--- a/td.vue/tests/unit/components/graphProperties.spec.js
+++ b/td.vue/tests/unit/components/graphProperties.spec.js
@@ -36,6 +36,7 @@ describe('components/GraphProperties.vue', () => {
 
     describe('with data', () => {
         let entityData;
+        let cellRef;
 
         beforeEach(() => {
             entityData = {
@@ -46,6 +47,14 @@ describe('components/GraphProperties.vue', () => {
                 isBidirectional: true,
                 reasonOutOfScope: 'someone thought so'
             };
+            cellRef = {
+                data: entityData,
+                getData: () => entityData,
+                updateStyle: jest.fn(),
+                isEdge: () => false,
+                setData: jest.fn(),
+                setName: jest.fn()
+            };
             const localVue = createLocalVue();
             localVue.use(Vuex);
             localVue.use(BootstrapVue);
@@ -53,13 +62,7 @@ describe('components/GraphProperties.vue', () => {
             const mockStore = new Vuex.Store({
                 state: {
                     cell: {
-                        ref: {
-                            data: entityData,
-                            getData: () => entityData,
-                            updateStyle: jest.fn(),
-                            isEdge: () => false,
-                            setData: jest.fn()
-                        }
+                        ref: cellRef
                     }
                 }
             });
@@ -84,6 +87,13 @@ describe('components/GraphProperties.vue', () => {
                 .filter(x => x.attributes('id') === 'name')
                 .at(0);
             expect(input.attributes('value')).toEqual(entityData.name);
+        });
+
+        it('updates the diagram label with the current textarea value', () => {
+            wrapper.vm.onChangeName('some flow updated');
+
+            expect(entityData.name).toEqual('some flow updated');
+            expect(cellRef.setName).toHaveBeenCalledWith('some flow updated');
         });
 
         it('shows the description', () => {

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -25,6 +25,31 @@ describe('service/x6/graph/data-changed.js', () => {
         });
     });
 
+    describe('updateName', () => {
+        let cellData;
+
+        beforeEach(() => {
+            cellData = { name: 'Original name' };
+            cell = {
+                getData: jest.fn(() => cellData),
+                setName: jest.fn()
+            };
+        });
+
+        it('uses the existing cell data name by default', () => {
+            dataChanged.updateName(cell);
+
+            expect(cell.setName).toHaveBeenCalledWith('Original name');
+        });
+
+        it('updates the cell data before setting the diagram label', () => {
+            dataChanged.updateName(cell, 'Updated name');
+
+            expect(cellData.name).toEqual('Updated name');
+            expect(cell.setName).toHaveBeenCalledWith('Updated name');
+        });
+    });
+
     describe('actor', () => {
         beforeEach(() => {
             cell = getCell();


### PR DESCRIPTION
**Summary**:  

The best I (and my robot minions) can tell is that this is a race condition introduced by the Vue3 compat runtime. I took a TDD approach, creating a failing test first then the fix.

The properties panel used BootstrapVue’s update event for the name field, but the handler ignored the emitted value for the input. Calling dataChanged.updateName(cell) reads cell.getData().name, but that read can happen before v-model has written back to cell.data.name. The result was cell.setName(...) receiving the previous value.

Closes #1627 

**Description for the changelog**:  

bugfix: component labels one keystroke behind

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT5.5`
  - Prompts: `Identify the bug in issue 1627, and create a failing unit test to prove it` `Fix the bug, ensure all tests pass, explain in detail the root cause`

**Other info**:  
