### PR TITLE
add vue key to graph properties to prevent stale cell references

### DIFF
--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -41,7 +41,10 @@
       </b-col>
     </b-row>
 
-    <b-form v-if="!!cellRef && cellRef.data">
+    <b-form
+      v-if="!!cellRef && cellRef.data"
+      :key="cellKey"
+    >
       <b-form-row>
         <b-col md="6">
           <b-form-group
@@ -364,9 +367,14 @@ import dataChanged from '@/service/x6/graph/data-changed.js';
 
 export default {
     name: 'TdGraphProperties',
-    computed: mapState({
-        cellRef: (state) => state.cell.ref
-    }),
+    computed: {
+        ...mapState({
+            cellRef: (state) => state.cell.ref
+        }),
+        cellKey() {
+            return this.cellRef?.id || this.cellRef?.data?.type || 'selected-cell';
+        }
+    },
     methods: {
         updateComponent() {
             // should not need to need to force an update

--- a/td.vue/src/components/GraphProperties.vue
+++ b/td.vue/src/components/GraphProperties.vue
@@ -372,7 +372,7 @@ export default {
             cellRef: (state) => state.cell.ref
         }),
         cellKey() {
-            return this.cellRef?.id || this.cellRef?.data?.type || 'selected-cell';
+            return this.cellRef?.id;
         }
     },
     methods: {

--- a/td.vue/tests/unit/components/graphProperties.spec.js
+++ b/td.vue/tests/unit/components/graphProperties.spec.js
@@ -1,4 +1,4 @@
-import { BootstrapVue, BFormTextarea, BFormGroup } from 'bootstrap-vue';
+import { BootstrapVue, BForm, BFormTextarea, BFormGroup } from 'bootstrap-vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
@@ -7,26 +7,37 @@ import TdGraphProperties from '@/components/GraphProperties.vue';
 describe('components/GraphProperties.vue', () => {
     let wrapper;
 
+    const mountComponent = (cellRef, mutations) => {
+        const localVue = createLocalVue();
+        localVue.use(Vuex);
+        localVue.use(BootstrapVue);
+        const mockStore = new Vuex.Store({
+            state: {
+                cell: {
+                    ref: cellRef
+                }
+            },
+            mutations
+        });
+
+        wrapper = shallowMount(TdGraphProperties, {
+            localVue,
+            store: mockStore,
+            mocks: {
+                $t: key => key
+            }
+        });
+
+        return mockStore;
+    };
+
+    const findNameInput = () => wrapper.findAllComponents(BFormTextarea)
+        .filter(x => x.attributes('id') === 'name')
+        .at(0);
+
     describe('emptyState', () => {
         beforeEach(() => {
-            const localVue = createLocalVue();
-            localVue.use(Vuex);
-            localVue.use(BootstrapVue);
-            localVue.use(Vuex);
-            const mockStore = new Vuex.Store({
-                state: {
-                    cell: {
-                        ref: null
-                    }
-                }
-            });
-            wrapper = shallowMount(TdGraphProperties, {
-                localVue,
-                store: mockStore,
-                mocks: {
-                    $t: key => key
-                }
-            });
+            mountComponent(null);
         });
 
         it('displays the empty state message', () => {
@@ -55,24 +66,7 @@ describe('components/GraphProperties.vue', () => {
                 setData: jest.fn(),
                 setName: jest.fn()
             };
-            const localVue = createLocalVue();
-            localVue.use(Vuex);
-            localVue.use(BootstrapVue);
-            localVue.use(Vuex);
-            const mockStore = new Vuex.Store({
-                state: {
-                    cell: {
-                        ref: cellRef
-                    }
-                }
-            });
-            wrapper = shallowMount(TdGraphProperties, {
-                localVue,
-                store: mockStore,
-                mocks: {
-                    $t: key => key
-                }
-            });
+            mountComponent(cellRef);
         });
 
         it('has a label for name', () => {
@@ -83,10 +77,7 @@ describe('components/GraphProperties.vue', () => {
         });
 
         it('displays the name in a textarea', () => {
-            const input = wrapper.findAllComponents(BFormTextarea)
-                .filter(x => x.attributes('id') === 'name')
-                .at(0);
-            expect(input.attributes('value')).toEqual(entityData.name);
+            expect(findNameInput().attributes('value')).toEqual(entityData.name);
         });
 
         it('updates the diagram label with the current textarea value', () => {
@@ -140,6 +131,65 @@ describe('components/GraphProperties.vue', () => {
 
             expect(entityData.isBidirectional).toEqual(false);
             expect(wrapper.vm.onChangeBidirection).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when selection changes while editing', () => {
+        let firstForm;
+        let secondCell;
+        let secondForm;
+        let selectedName;
+
+        const createCellRef = (id, name) => ({
+            id,
+            data: {
+                type: 'tm.Process',
+                name,
+                description: '',
+                outOfScope: false,
+                isTrustBoundary: false,
+                reasonOutOfScope: '',
+                handlesCardPayment: false,
+                handlesGoodsOrServices: false,
+                isWebApplication: false,
+                privilegeLevel: '',
+                threats: []
+            },
+            getData() {
+                return this.data;
+            },
+            updateStyle: jest.fn(),
+            isEdge: () => false,
+            setData: jest.fn(),
+            setName: jest.fn(function (name) {
+                this.data.name = name;
+            })
+        });
+
+        beforeEach(async () => {
+            const firstCell = createCellRef('first-cell', 'first process');
+            secondCell = createCellRef('second-cell', 'second process');
+            const mockStore = mountComponent(firstCell, {
+                selectCell(state, ref) {
+                    state.cell.ref = ref;
+                }
+            });
+
+            firstForm = wrapper.findComponent(BForm).element;
+
+            mockStore.commit('selectCell', secondCell);
+            await wrapper.vm.$nextTick();
+
+            secondForm = wrapper.findComponent(BForm).element;
+            selectedName = findNameInput().attributes('value');
+        });
+
+        it('recreates form controls when the selected cell changes', () => {
+            expect(secondForm).not.toBe(firstForm);
+        });
+
+        it('displays the newly selected cell name', () => {
+            expect(selectedName).toEqual(secondCell.data.name);
         });
     });
 


### PR DESCRIPTION
**Summary**:  

Closes #1632 

This seems like a regression from #1630 

The root cause appears to be a stale reference in the GraphProperties.vue for selected cell, which was sometimes using the bootstrap form references instead of the true cell reference.  The fix is to add a cell key so that the _cell_ is always referenced rather than the bootstrap form.  This causes the properties panel to be redrawn when the cell reference changes, and prevents the stale reference trap.

**Description for the changelog**:  

bugfix: fix component properties to always update when selected cell changes

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Find the root cause of #1632`


**Other info**:  

This was a combination of human-written code and AI assisted coding.  Codex correctly identified the root cause, but its code suggestions were terrible, so I rewrote it by hand.  The unit test fails prior to the cell key fix, and they pass after.  I manually tested as well.