### PR TITLE
chore: set buildState to latest post-release

### DIFF
--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -53,7 +53,7 @@
   },
   "license": "Apache-2.0",
   "homepage": "https://owasp.org/www-project-threat-dragon/",
-  "buildState": "",
+  "buildState": "-latest",
   "repository": {
     "type": "git",
     "url": "git://github.com/OWASP/threat-dragon.git"


### PR DESCRIPTION
**Summary**:  

Sets td.vue's buildState back to `-latest`

**Description for the changelog**:  

chore: reset buildState after release

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
