### PR TITLE
updating release notes template, process, and pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -331,7 +331,7 @@ jobs:
       # Snaps do not publish, even with snapcraft installed, so use Snap Store
       - name: Build Linux snap
         shell: bash
-        run: npm run build:desktop -- --linux snap
+        run: npm run build:desktop -- --linux snap --publish never
 
       - name: Upload to Snap Store
         shell: bash

--- a/.release-note-template.md
+++ b/.release-note-template.md
@@ -51,7 +51,7 @@ Select the method that is most convenient for your distribution of Linux:
 [appcs]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-linux.yml
 [deb]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/threat-dragon_2.x.x_amd64.deb
 [dmg]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/Threat-Dragon-ng-2.x.x.dmg
-[dmgarm64]: https://github.com/OWASP/threat-dragon/releases/download/v2.3.0/Threat-Dragon-ng-2.x.x-arm64.dmg
+[dmgarm64]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/Threat-Dragon-ng-2.x.x-arm64.dmg
 [dmgcs]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-mac.yml
 [dmgcsarm64]: https://github.com/OWASP/threat-dragon/releases/download/v2.x.x/checksum-mac-arm64.yml
 [docker]: https://hub.docker.com/r/owasp/threat-dragon

--- a/release-process.md
+++ b/release-process.md
@@ -130,7 +130,7 @@ Download desktop AppImage for Linux `Threat-Dragon-ng-2.6.1.AppImage` and the `l
 Create SHA512 `checksum-linux.yml` file:
 
  ```bash
-grep sha512 latest-linux.yml | tail -n 1 | cut -d ":" -f 2 | base64 -d |  \
+grep sha512 latest-linux.yml | tail -n 1 | cut -d " " -f 2 | base64 -d |  \
     hexdump -ve '1/1 "%.2x"' > checksum-linux.yml
 echo -n " Threat-Dragon-ng-2.6.1.AppImage" >> checksum-linux.yml
 ```


### PR DESCRIPTION
**Summary**:  

- .release-notes-template.md: fix hard-coded version
- release-process.md: update sha512 checksum script
- release.yaml: set snap build to never publish, and defer to the snap upload process

**Description for the changelog**:  

chore: release documentation

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

For the release-process, the `cut` command was returning a string that had a leading whitespace.  `base64` threw an error saying it was invalid b64.  Changing the cut to cut on the space fixed it.  This might be a linux-specific issue though, so I'm happy to revert!

The snap release pipeline has been failing, and I suspect that may be due to the token only having permissions for the stable channel.  The default build attempts to release to the `edge` channel.  By setting it to never publish on build, we are still able to manually upload the release, and I think that will resolve the release pipeline failure.
