### PR TITLE
Replace all b-dropdown components with td-dropdown

### DIFF
--- a/td.vue/src/components/Dropdown.vue
+++ b/td.vue/src/components/Dropdown.vue
@@ -3,9 +3,10 @@
         <button
             type="button"
             class="td-dropdown-toggle"
+            :class="toggleClasses"
             aria-haspopup="true"
             :aria-expanded="isOpen.toString()"
-            @click.stop.prevent="toggleDropdown"
+            @click.prevent="toggleDropdown"
         >
             <slot name="button-content">
                 {{ text }}
@@ -16,7 +17,6 @@
             class="td-dropdown-menu"
             :class="{ 'td-dropdown-menu-right': right }"
             role="menu"
-            @click.stop
         >
             <slot :close="closeDropdown"></slot>
         </div>
@@ -34,6 +34,22 @@ export default {
         right: {
             type: Boolean,
             default: false
+        },
+        variant: {
+            type: String,
+            default: 'primary'
+        },
+        noCaret: {
+            type: Boolean,
+            default: false
+        }
+    },
+    computed: {
+        toggleClasses() {
+            return {
+                [`td-dropdown-toggle-${this.variant}`]: true,
+                'td-dropdown-toggle-no-caret': this.noCaret
+            };
         }
     },
     data() {
@@ -71,10 +87,7 @@ export default {
 }
 
 .td-dropdown-toggle {
-    background-color: $orange;
-    border: 1px solid $orange;
     border-radius: 4px;
-    color: $white;
     cursor: pointer;
     display: block;
     flex: 1 1 auto;
@@ -92,10 +105,40 @@ export default {
     white-space: nowrap;
 }
 
-.td-dropdown-toggle:hover,
-.td-dropdown-toggle:focus {
+.td-dropdown-toggle-primary {
+    background-color: $orange;
+    border: 1px solid $orange;
+    color: $white;
+}
+
+.td-dropdown-toggle-primary:hover,
+.td-dropdown-toggle-primary:focus {
     background-color: #c8321d;
     border-color: #bd301c;
+}
+
+.td-dropdown-toggle-secondary {
+    background-color: $gray;
+    border: 1px solid $gray;
+    color: $white;
+}
+
+.td-dropdown-toggle-secondary:hover,
+.td-dropdown-toggle-secondary:focus {
+    background-color: #9b948c;
+    border-color: #938c84;
+}
+
+.td-dropdown-toggle-link {
+    background-color: transparent;
+    border: 1px solid transparent;
+    color: $orange;
+}
+
+.td-dropdown-toggle-link:hover,
+.td-dropdown-toggle-link:focus {
+    color: #c8321d;
+    text-decoration: none;
 }
 
 .td-dropdown-toggle::after {
@@ -109,21 +152,46 @@ export default {
     vertical-align: 0.255em;
 }
 
+.td-dropdown-toggle-no-caret::after {
+    display: none;
+}
+
+.btn-group > .td-dropdown:not(:first-child) {
+    margin-left: -1px;
+}
+
+.btn-group > .td-dropdown:not(:first-child) .td-dropdown-toggle {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+}
+
+.btn-group > .td-dropdown:not(:last-child) .td-dropdown-toggle {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+}
+
 .td-dropdown-menu {
     background-color: $white;
-    border: 1px solid rgba(0, 0, 0, 0.15);
+    background-clip: padding-box;
+    border: 1px solid rgba(51, 51, 51, 0.15);
     border-radius: 4px;
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
     color: $black;
+    font-family: Ubuntu, Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    left: 0;
+    line-height: 1.428571;
     margin-top: 2px;
-    min-width: 220px;
+    min-width: 10rem;
     padding: 8px 0;
     position: absolute;
+    text-align: left;
     top: 100%;
     z-index: 1000;
 }
 
 .td-dropdown-menu-right {
+    left: auto;
     right: 0;
 }
 
@@ -151,12 +219,14 @@ export default {
 .td-dropdown-item {
     background: transparent;
     border: 0;
-    color: $black;
+    clear: both;
+    color: #212529;
     cursor: pointer;
     display: block;
     font: inherit;
     padding: 4px 24px;
     text-align: left;
+    white-space: nowrap;
     width: 100%;
 }
 
@@ -164,6 +234,17 @@ export default {
 .td-dropdown-item:focus {
     background-color: #f8f9fa;
     color: #16181b;
+}
+
+.td-dropdown-item-danger {
+    color: #dc3545;
+}
+
+.td-dropdown-divider {
+    border-top: 1px solid #e9ecef;
+    height: 0;
+    margin: 8px 0;
+    overflow: hidden;
 }
 
 @media (max-width: 991.98px) {

--- a/td.vue/src/components/GraphButtons.vue
+++ b/td.vue/src/components/GraphButtons.vue
@@ -43,14 +43,16 @@
             :title="$t('threatmodel.buttons.toggleGrid')"
             text="" />
 
-        <b-dropdown right :text="$t('forms.export')" id="export-graph-btn">
-            <b-dropdown-item @click="exportPNG" id="export-graph-png">
-                PNG
-            </b-dropdown-item>
-            <b-dropdown-item @click="exportSVG" id="export-graph-svg">
-                SVG
-            </b-dropdown-item>
-        </b-dropdown>
+        <td-dropdown right variant="secondary" :text="$t('forms.export')" id="export-graph-btn">
+            <template #default="{ close }">
+                <button type="button" class="td-dropdown-item" @click="exportPNG(); close()" id="export-graph-png">
+                    PNG
+                </button>
+                <button type="button" class="td-dropdown-item" @click="exportSVG(); close()" id="export-graph-svg">
+                    SVG
+                </button>
+            </template>
+        </td-dropdown>
 
         <td-form-button
             :onBtnClick="closeDiagram"
@@ -69,11 +71,13 @@
 <script>
 import { mapState } from 'vuex';
 
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormButton from '@/components/FormButton.vue';
 
 export default {
     name: 'TdGraphButtons',
     components: {
+        TdDropdown,
         TdFormButton
     },
     computed: mapState({

--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -93,12 +93,12 @@ $icon-height: 1.2rem;
   align-items: center;
 }
 
-.td-admin-nav-dropdown>>>.td-dropdown-toggle {
+.td-admin-nav-dropdown :deep(.td-dropdown-toggle) {
   padding: 0;
 }
 
-.td-admin-nav-dropdown>>>.td-dropdown-toggle-link:hover,
-.td-admin-nav-dropdown>>>.td-dropdown-toggle-link:focus {
+.td-admin-nav-dropdown :deep(.td-dropdown-toggle-link:hover),
+.td-admin-nav-dropdown :deep(.td-dropdown-toggle-link:focus) {
   background-color: transparent;
 }
 

--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -19,19 +19,21 @@
           <font-awesome-icon icon="sign-out-alt" class="td-fa-nav" v-b-tooltip.hover
             :title="$t('nav.logOut')"></font-awesome-icon>
         </b-nav-item>
-        <!-- This is the dropdown from admin actions(manage tempaltes) -->
-        <b-nav-item-dropdown v-if="isAdmin" id="my-nav-dropdown" toggle-class="nav-link-custom" right >
-          <!-- Custom toggle content -->
+        <!-- This is the dropdown from admin actions(manage templates) -->
+        <li v-if="isAdmin" class="nav-item td-admin-nav-dropdown">
+          <td-dropdown id="my-nav-dropdown" class="nav-link-custom" variant="link" right no-caret>
           <template #button-content>
             <font-awesome-icon icon="cog" class="td-fa-nav text-white" v-b-tooltip.hover
               :title="$t('nav.contentManagement')" />
           </template>
 
-          <!-- Dropdown items -->
-          <b-dropdown-item @click="onManageTemplates">
-            Manage Templates
-          </b-dropdown-item>
-        </b-nav-item-dropdown>
+          <template #default="{ close }">
+            <button type="button" class="td-dropdown-item" @click="onManageTemplates(); close()">
+              Manage Templates
+            </button>
+          </template>
+          </td-dropdown>
+        </li>
 
 
         <b-nav-item href="https://www.threatdragon.com/docs/" target="_blank" rel="noopener noreferrer" id="nav-docs">
@@ -86,6 +88,20 @@ $icon-height: 1.2rem;
   }
 }
 
+.td-admin-nav-dropdown {
+  display: flex;
+  align-items: center;
+}
+
+.td-admin-nav-dropdown>>>.td-dropdown-toggle {
+  padding: 0;
+}
+
+.td-admin-nav-dropdown>>>.td-dropdown-toggle-link:hover,
+.td-admin-nav-dropdown>>>.td-dropdown-toggle-link:focus {
+  background-color: transparent;
+}
+
 @media (max-width: 576px) {
 
   /* This is the typical breakpoint for phones */
@@ -114,11 +130,13 @@ $icon-height: 1.2rem;
 import { mapGetters } from 'vuex';
 
 import { LOGOUT } from '@/store/actions/auth.js';
+import TdDropdown from './Dropdown.vue';
 import TdLocaleSelect from './LocaleSelect.vue';
 
 export default {
     name: 'TdNavbar',
     components: {
+        TdDropdown,
         TdLocaleSelect
     },
     computed: {

--- a/td.vue/src/views/ManageTemplates.vue
+++ b/td.vue/src/views/ManageTemplates.vue
@@ -62,20 +62,26 @@
                             </div>
 
                             <!-- Burger menu -->
-                            <b-dropdown right variant="link" class="template-actions">
+                            <td-dropdown right variant="link" no-caret class="template-actions">
                                 <template #button-content>
                                     <font-awesome-icon icon="ellipsis-v"></font-awesome-icon>
                                 </template>
-                                <b-dropdown-item @click="onEditTemplate(template)">
-                                    <font-awesome-icon icon="edit" class="mr-2"></font-awesome-icon>
-                                    {{ $t('forms.edit') }}
-                                </b-dropdown-item>
-                                <b-dropdown-divider></b-dropdown-divider>
-                                <b-dropdown-item @click="onDeleteTemplate(template)" variant="danger">
-                                    <font-awesome-icon icon="trash" class="mr-2"></font-awesome-icon>
-                                    {{ $t('forms.delete') }}
-                                </b-dropdown-item>
-                            </b-dropdown>
+                                <template #default="{ close }">
+                                    <button type="button" class="td-dropdown-item" @click="onEditTemplate(template); close()">
+                                        <font-awesome-icon icon="edit" class="mr-2"></font-awesome-icon>
+                                        {{ $t('forms.edit') }}
+                                    </button>
+                                    <div class="td-dropdown-divider"></div>
+                                    <button
+                                        type="button"
+                                        class="td-dropdown-item td-dropdown-item-danger"
+                                        @click="onDeleteTemplate(template); close()"
+                                    >
+                                        <font-awesome-icon icon="trash" class="mr-2"></font-awesome-icon>
+                                        {{ $t('forms.delete') }}
+                                    </button>
+                                </template>
+                            </td-dropdown>
                         </b-list-group-item>
                     </b-list-group>
 
@@ -107,6 +113,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { v4 } from 'uuid';
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormTags from '@/components/FormTags.vue';
 import templateActions from '@/store/actions/template.js';
 import schema from '@/service/schema/ajv.js';
@@ -114,6 +121,7 @@ import schema from '@/service/schema/ajv.js';
 export default {
     name: 'ManageTemplates',
     components: {
+        TdDropdown,
         TdFormTags
     },
     data() {
@@ -293,8 +301,4 @@ export default {
     cursor: pointer;
 }
 
-.template-actions>>>.btn::after,
-.template-actions>>>.dropdown-toggle::after {
-    display: none !important;
-}
 </style>

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -50,12 +50,19 @@
                     <td-form-button id="td-report-btn" :onBtnClick="onReportClick" icon="file-alt"
                         :text="$t('forms.report')" />
                     <!-- REPLACE the export template button with dropdown -->
-                    <b-dropdown right :text="$t('forms.manage')" id="manage-model-btn" v-if="enableTemplates">
-                        <b-dropdown-item @click="onExportTemplateClick" id="export-template-option">
-                            <font-awesome-icon icon="file-import" ></font-awesome-icon>
-                            {{ $t('forms.exportTemplate') }}
-                        </b-dropdown-item>
-                    </b-dropdown>
+                    <td-dropdown right variant="secondary" :text="$t('forms.manage')" id="manage-model-btn" v-if="enableTemplates">
+                        <template #default="{ close }">
+                            <button
+                                type="button"
+                                class="td-dropdown-item"
+                                @click="(evt) => { onExportTemplateClick(evt); close(); }"
+                                id="export-template-option"
+                            >
+                                <font-awesome-icon icon="file-import" ></font-awesome-icon>
+                                {{ $t('forms.exportTemplate') }}
+                            </button>
+                        </template>
+                    </td-dropdown>
                     <td-form-button id="td-close-btn" :onBtnClick="onCloseClick" icon="times"
                         :text="$t('forms.closeModel')" />
                 </b-btn-group>
@@ -88,6 +95,7 @@
 import { mapState } from 'vuex';
 
 import { getProviderType } from '@/service/provider/providers.js';
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormButton from '@/components/FormButton.vue';
 import TdThreatModelSummaryCard from '@/components/ThreatModelSummaryCard.vue';
 import tmActions from '@/store/actions/threatmodel.js';
@@ -95,6 +103,7 @@ import tmActions from '@/store/actions/threatmodel.js';
 export default {
     name: 'ThreatModel',
     components: {
+        TdDropdown,
         TdFormButton,
         TdThreatModelSummaryCard
     },

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -106,15 +106,17 @@
                                 class="mb-3"
                             >
                                 <b-input-group-prepend>
-                                    <b-dropdown variant="secondary" class="select-diagram-type" :text="model.detail.diagrams[idx].diagramType === 'EOP' ? $t('threatmodel.diagram.eop.select') : model.detail.diagrams[idx].diagramType">
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'CIA')">{{ $t('threatmodel.diagram.cia.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'CIADIE')">{{ $t('threatmodel.diagram.die.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'LINDDUN')">{{ $t('threatmodel.diagram.linddun.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'PLOT4ai')">{{ $t('threatmodel.diagram.plot4ai.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'STRIDE')">{{ $t('threatmodel.diagram.stride.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'EOP')">{{ $t('threatmodel.diagram.eop.select') }}</b-dropdown-item-button>
-                                        <b-dropdown-item-button @click="onDiagramTypeClick(idx, 'Generic')">{{ $t('threatmodel.diagram.generic.select') }}</b-dropdown-item-button>
-                                    </b-dropdown>
+                                    <td-dropdown variant="secondary" class="select-diagram-type" :text="model.detail.diagrams[idx].diagramType === 'EOP' ? $t('threatmodel.diagram.eop.select') : model.detail.diagrams[idx].diagramType">
+                                        <template #default="{ close }">
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'CIA'); close()">{{ $t('threatmodel.diagram.cia.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'CIADIE'); close()">{{ $t('threatmodel.diagram.die.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'LINDDUN'); close()">{{ $t('threatmodel.diagram.linddun.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'PLOT4ai'); close()">{{ $t('threatmodel.diagram.plot4ai.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'STRIDE'); close()">{{ $t('threatmodel.diagram.stride.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'EOP'); close()">{{ $t('threatmodel.diagram.eop.select') }}</button>
+                                            <button type="button" class="td-dropdown-item" @click="onDiagramTypeClick(idx, 'Generic'); close()">{{ $t('threatmodel.diagram.generic.select') }}</button>
+                                        </template>
+                                    </td-dropdown>
                                 </b-input-group-prepend>
                                 <b-form-input
                                     v-model="model.detail.diagrams[idx].title"
@@ -198,6 +200,7 @@
 import { mapState } from 'vuex';
 
 import { getProviderType } from '@/service/provider/providers.js';
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormButton from '@/components/FormButton.vue';
 import TdFormTags from '@/components/FormTags.vue';
 import tmActions from '@/store/actions/threatmodel.js';
@@ -205,6 +208,7 @@ import tmActions from '@/store/actions/threatmodel.js';
 export default {
     name: 'ThreatModelEdit',
     components: {
+        TdDropdown,
         TdFormButton,
         TdFormTags
     },

--- a/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
+++ b/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
@@ -184,10 +184,10 @@ describe('Regressions discovered during vue3 migration', () => {
         assertNoSecurityPolicyViolation();
     });
 
-    it('updates export-template tags through a Bootstrap dropdown without runtime errors', () => {
+    it('updates export-template tags through the manage dropdown without runtime errors', () => {
         openDemoModel('Demo Threat Model');
 
-        cy.get('#manage-model-btn button.dropdown-toggle, #manage-model-btn__BV_toggle_')
+        cy.get('#manage-model-btn .td-dropdown-toggle')
             .first()
             .click({ force: true });
         cy.get('#export-template-option').click({ force: true });

--- a/td.vue/tests/unit/components/dropdown.spec.js
+++ b/td.vue/tests/unit/components/dropdown.spec.js
@@ -93,6 +93,35 @@ describe('components/Dropdown.vue', () => {
         expect(wrapper.find('.td-dropdown-menu').exists()).toEqual(false);
     });
 
+    it('closes an open dropdown when another dropdown is opened', async () => {
+        wrapper = mount(
+            {
+                components: { TdDropdown },
+                template: `
+                    <div>
+                        <td-dropdown text="First" class="first-dropdown">
+                            <button type="button" class="first-action">First action</button>
+                        </td-dropdown>
+                        <td-dropdown text="Second" class="second-dropdown">
+                            <button type="button" class="second-action">Second action</button>
+                        </td-dropdown>
+                    </div>
+                `
+            },
+            {
+                attachTo: document.body
+            }
+        );
+
+        await wrapper.find('.first-dropdown .td-dropdown-toggle').trigger('click');
+        expect(wrapper.find('.first-dropdown .td-dropdown-menu').exists()).toEqual(true);
+
+        await wrapper.find('.second-dropdown .td-dropdown-toggle').trigger('click');
+
+        expect(wrapper.find('.first-dropdown .td-dropdown-menu').exists()).toEqual(false);
+        expect(wrapper.find('.second-dropdown .td-dropdown-menu').exists()).toEqual(true);
+    });
+
     it('closes the menu when pressing escape', async () => {
         mountComponent();
 
@@ -131,12 +160,44 @@ describe('components/Dropdown.vue', () => {
         expect(wrapper.find('.td-dropdown-menu-right').exists()).toEqual(true);
     });
 
+    it('left aligns menus by default', async () => {
+        mountComponent();
+
+        await findToggle().trigger('click');
+
+        expect(wrapper.find('.td-dropdown-menu').classes()).not.toContain('td-dropdown-menu-right');
+    });
+
     it('does not right align menus by default', async () => {
         mountComponent();
 
         await findToggle().trigger('click');
 
         expect(wrapper.find('.td-dropdown-menu-right').exists()).toEqual(false);
+    });
+
+    it('uses the primary button variant by default', () => {
+        mountComponent();
+
+        expect(findToggle().classes()).toContain('td-dropdown-toggle-primary');
+    });
+
+    it('supports secondary button variants', () => {
+        mountComponent({ variant: 'secondary' });
+
+        expect(findToggle().classes()).toContain('td-dropdown-toggle-secondary');
+    });
+
+    it('supports link button variants', () => {
+        mountComponent({ variant: 'link' });
+
+        expect(findToggle().classes()).toContain('td-dropdown-toggle-link');
+    });
+
+    it('can hide the toggle caret', () => {
+        mountComponent({ noCaret: true });
+
+        expect(findToggle().classes()).toContain('td-dropdown-toggle-no-caret');
     });
 
     it('removes the outside click listener on unmount', () => {

--- a/td.vue/tests/unit/components/graphButtons.spec.js
+++ b/td.vue/tests/unit/components/graphButtons.spec.js
@@ -1,7 +1,8 @@
-import { BootstrapVue, BDropdown } from 'bootstrap-vue';
+import { BootstrapVue } from 'bootstrap-vue';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormButton from '@/components/FormButton.vue';
 import TdGraphButtons from '@/components/GraphButtons.vue';
 
@@ -237,13 +238,21 @@ describe('components/GraphButtons.vue', () => {
     describe('export', () => {
         beforeEach(() => {
             btn = wrapper
-                .findAllComponents(BDropdown)
+                .findAllComponents(TdDropdown)
                 .filter((x) => x.attributes('id') === 'export-graph-btn')
                 .at(0);
         });
 
         it('has the export translation text', () => {
             expect(btn.attributes('text')).toEqual('forms.export');
+        });
+
+        it('right aligns the export menu', () => {
+            expect(btn.attributes('right')).toEqual('true');
+        });
+
+        it('uses the secondary variant', () => {
+            expect(btn.attributes('variant')).toEqual('secondary');
         });
 
         it('has a dropdown item for PNG', () => {


### PR DESCRIPTION
**Summary**:  

Improves #1080 

Continuation of the work in #1639 - I created the `td-dropdown` component, but only implemented it in `localeSelect`. 
Replaces remaining instances of `b-dropdown` with `td-dropdown`.

**Description for the changelog**:  

chore: replace bootstrap dropdown with local dropdown component

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Replace all b-dropdown components with td-dropdown`, `find and add any missing properties in the td-dropdown component that are not covered by the existing b-dropdown usages`

**Other info**:  

The `td-dropdown` still isn't a 1:1 replacement for `b-dropdown`, nor do I intend it to be. 
I added the variant and noCaret params to cover our existing usage of the `b-dropdown` component.
The Navbar contained the only reference to `b-nav-item`, so I opted to use inline CSS rather than writing a reusable component.