### PR TITLE
Send trust boundary curve to background

### DIFF
--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -90,8 +90,8 @@ const cellAdded = (graph) => ({ cell }) => {
 
     mouseLeave({ cell });
 
-    // boundary boxes must not overlap other diagram components
-    if (cell.shape === 'trust-boundary-box') {
+    // boundary shapes must not overlap other diagram components
+    if (cell.shape === 'trust-boundary-box' || cell.shape === 'trust-boundary-curve') {
         cell.zIndex = -1;
     }
 


### PR DESCRIPTION
**Summary**:  

Complementary to PR #521, this ensures that the _Trust Boundary Curve_ shape is also sent to the background in order to make sure the shape is not in front of an crossing dataflow text or something else.

**Description for the changelog**:  

Trust Boundary Curve is created in the background.

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [ ] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

closes #1649 

