### PR TITLE
fix: normalize store dispatch signatures and fix pagination state sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,8 +215,12 @@
 !td.vue/tests/e2e/desktop/support/*.js
 !td.vue/tests/e2e/fixtures/
 !td.vue/tests/e2e/fixtures/*.json
+!td.vue/tests/e2e/mock-server/
+!td.vue/tests/e2e/mock-server/*.js
 !td.vue/tests/e2e/specs/
 !td.vue/tests/e2e/specs/*.cy.js
+!td.vue/tests/e2e/specs/git/
+!td.vue/tests/e2e/specs/git/*.cy.js
 !td.vue/tests/e2e/specs/smokes/
 !td.vue/tests/e2e/specs/smokes/*.cy.js
 !td.vue/tests/e2e/specs/threatmodel/

--- a/td.vue/e2e.ci.config.js
+++ b/td.vue/e2e.ci.config.js
@@ -2,6 +2,13 @@
 // run by the CI pipeline using cypress
 
 const { defineConfig } = require('cypress');
+const { createMockApp } = require('./tests/e2e/mock-server/threatDragonBackEndServerMock');
+
+// Start the mock server on port 3000 to support pagination and other mock-dependent tests
+const mockApp = createMockApp();
+const mockServer = mockApp.listen(3000, () => {
+    console.log('[mock] CI mock server listening on port 3000');
+});
 
 module.exports = defineConfig({
     fixturesFolder: 'tests/e2e/fixtures',
@@ -14,3 +21,6 @@ module.exports = defineConfig({
         baseUrl: 'http://localhost:3000/'
     }
 });
+
+// Keep the process alive so the mock server stays up
+process.on('exit', () => mockServer.close());

--- a/td.vue/e2e.local.config.js
+++ b/td.vue/e2e.local.config.js
@@ -3,6 +3,14 @@
 // NOTE: excludes 'tests/e2e/specs/docs.cy.js' because no docs present for local dev
 
 const { defineConfig } = require('cypress');
+const { createMockApp } = require('./tests/e2e/mock-server/threatDragonBackEndServerMock');
+
+// Start the mock server on port 3000 (must match vue.config.js API proxy target).
+// The real backend is not running during e2e tests; this mock replaces it.
+const mockApp = createMockApp();
+const mockServer = mockApp.listen(3000, () => {
+    console.log('[mock] threatDragonBackEndServerMock listening on port 3000');
+});
 
 module.exports = defineConfig({
     fixturesFolder: 'tests/e2e/fixtures',
@@ -15,3 +23,6 @@ module.exports = defineConfig({
         experimentalRunAllSpecs: true
     }
 });
+
+// Keep the process alive so the mock server stays up
+process.on('exit', () => mockServer.close());

--- a/td.vue/e2e.local.config.js
+++ b/td.vue/e2e.local.config.js
@@ -14,8 +14,7 @@ const mockServer = mockApp.listen(3000, () => {
 
 module.exports = defineConfig({
     fixturesFolder: 'tests/e2e/fixtures',
-    screenshotsFolder: 'tests/e2e/screenshots',
-    videosFolder: 'tests/e2e/videos',
+    screenshotsFolder: 'tests/e2e/videos',
     e2e: {
         excludeSpecPattern: [ 'tests/e2e/specs/smokes/*.cy.js', 'tests/e2e/specs/docs.cy.js', 'tests/e2e/specs/visual/*.cy.js' ],
         supportFile: 'tests/e2e/support/e2e.js',

--- a/td.vue/package-lock.json
+++ b/td.vue/package-lock.json
@@ -68,7 +68,7 @@
         "bootstrap": "^4.6.1",
         "browserstack-cypress-cli": "1.36.5",
         "chromedriver": "^134.0.0",
-        "cypress": "^13.7.3",
+        "cypress": "^15.15.0",
         "electron": "^42.0.1",
         "electron-builder": "^26.8.1",
         "electron-builder-notarize": "^1.5.2",
@@ -1881,15 +1881,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@cyclonedx/cyclonedx-library": {
       "version": "10.0.0",
       "dev": true,
@@ -2010,7 +2001,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.10",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.0.tgz",
+      "integrity": "sha512-wGTQfwDMMMiz/muFw4YbCLwTh0uZsXKK+6zWBzftADpitSi6iM62C8GzEhNcng2srUiGPksOriQkA8zakW2R0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2030,11 +2023,10 @@
         "qs": "~6.14.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
+        "tunnel-agent": "^0.6.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -5526,6 +5518,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -8230,8 +8229,8 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10052,14 +10051,6 @@
       "dev": true,
       "license": "MIT/X11"
     },
-    "node_modules/check-more-types": {
-      "version": "2.24.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "dev": true,
@@ -10359,7 +10350,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.5",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10369,7 +10362,18 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "@colors/colors": "1.5.0"
+        "colors": "1.4.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/cli-tableau": {
@@ -10384,8 +10388,8 @@
     },
     "node_modules/cli-truncate": {
       "version": "2.1.0",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -11506,41 +11510,39 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.15.0.tgz",
+      "integrity": "sha512-N8qBv3AUYn6xfIG73O5O58kTClUBSZ7a3C08IQFkSGTUdEauJ3BqwTFb/f9KPZgadftoZjllC0XSwD7xNNolbA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.6",
+        "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
+        "@types/tmp": "^0.2.3",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
+        "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
-        "ci-info": "^4.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.1",
+        "ci-info": "^4.1.0",
+        "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
         "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
+        "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "listr2": "^9.0.5",
+        "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -11548,10 +11550,11 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "systeminformation": "^5.31.1",
+        "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
+        "tslib": "1.14.1",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -11559,7 +11562,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -11659,17 +11662,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cypress/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cypress/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "dev": true,
@@ -11691,6 +11683,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/cypress/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -13322,18 +13321,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/entities": {
       "version": "7.0.1",
       "license": "BSD-2-Clause",
@@ -13350,6 +13337,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/err-code": {
@@ -15130,28 +15130,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -15879,6 +15857,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "dev": true,
@@ -16019,14 +16010,6 @@
       "version": "16.18.126",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.0"
-      }
     },
     "node_modules/getpass": {
       "version": "0.1.7",
@@ -16524,6 +16507,46 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "dev": true,
@@ -16855,6 +16878,8 @@
     },
     "node_modules/http-signature": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19836,6 +19861,8 @@
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -19850,6 +19877,8 @@
     },
     "node_modules/jsprim/node_modules/verror": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -19978,14 +20007,6 @@
         "launch-editor": "^2.13.0"
       }
     },
-    "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "> 0.8"
-      }
-    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "license": "MIT"
@@ -20096,29 +20117,180 @@
       "license": "ISC"
     },
     "node_modules/listr2": {
-      "version": "3.14.0",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/loader-runner": {
@@ -20322,49 +20494,219 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loglevel": {
@@ -20691,6 +21033,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -24390,6 +24745,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "dev": true,
@@ -25132,6 +25500,8 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
     },
@@ -25375,14 +25745,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/safaridriver": {
       "version": "0.1.2",
@@ -26157,8 +26519,8 @@
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -27091,7 +27453,6 @@
       "version": "5.31.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin",
         "linux",
@@ -30275,6 +30636,20 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/vue-cli-plugin-electron-builder/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/vue-cli-plugin-electron-builder/node_modules/unique-filename": {

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -122,7 +122,7 @@
     "bootstrap": "^4.6.1",
     "browserstack-cypress-cli": "1.36.5",
     "chromedriver": "^134.0.0",
-    "cypress": "^13.7.3",
+    "cypress": "^15.15.0",
     "electron": "^42.0.1",
     "electron-builder": "^26.8.1",
     "electron-builder-notarize": "^1.5.2",

--- a/td.vue/src/components/AddBranchDialog.vue
+++ b/td.vue/src/components/AddBranchDialog.vue
@@ -127,7 +127,7 @@ export default {
 
             // sometimes the branch is not immediately available, so we wait for it (only for 30 seconds)
             for (let i = 0; i < 30; i++) {
-                await this.$store.dispatch(branchActions.fetch, 1);
+                await this.$store.dispatch(branchActions.fetch, { page: 1 });
                 if (this.branchNames.includes(this.newBranchName)) {
                     break;
                 }

--- a/td.vue/src/components/SelectionPage.vue
+++ b/td.vue/src/components/SelectionPage.vue
@@ -91,6 +91,9 @@ export default {
         },
         localFilter(newFilter) {
             this.$emit('update:filter', newFilter);
+        },
+        page(newPage) {
+            this.pageRef = newPage;
         }
     },
     props: {
@@ -175,3 +178,4 @@ export default {
     }
 };
 </script>
+

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -26,7 +26,7 @@ const state = {
 
 const actions = {
     [BRANCH_CLEAR]: ({ commit }) => commit(BRANCH_CLEAR),
-    [BRANCH_FETCH]: async ({ commit, dispatch, rootState }, page = 1) => {
+    [BRANCH_FETCH]: async ({ commit, dispatch, rootState }, { page = 1 } = {}) => {
         dispatch(BRANCH_CLEAR);
         const resp = await threatmodelApi.branchesAsync(rootState.repo.selected, page);
         commit(BRANCH_FETCH, {
@@ -64,3 +64,4 @@ export default {
     mutations,
     getters
 };
+

--- a/td.vue/src/views/git/BranchAccess.vue
+++ b/td.vue/src/views/git/BranchAccess.vue
@@ -93,7 +93,7 @@ export default {
             this.$store.dispatch(repoActions.selected, this.$route.params.repository);
         }
 
-        this.$store.dispatch(branchActions.fetch, 1);
+        this.$store.dispatch(branchActions.fetch, { page: 1 });
     },
     methods: {
         selectRepoClick() {
@@ -110,7 +110,7 @@ export default {
             this.$router.push({ name: routeName, params });
         },
         paginate(page) {
-            this.$store.dispatch(branchActions.fetch, page, this.searchQuery);
+            this.$store.dispatch(branchActions.fetch, { page });
         },
         toggleNewBranchDialog(){
             this.showNewBranchDialog = !this.showNewBranchDialog;
@@ -118,3 +118,4 @@ export default {
     }
 };
 </script>
+

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -60,7 +60,7 @@ export default {
             page = this.$route.query.page;
         }
 
-        this.$store.dispatch(repoActions.fetch, { page, searchQuery: '' });
+        this.$store.dispatch(repoActions.fetch, { page });
     },
     methods: {
         onRepoClick(repoName) {

--- a/td.vue/src/views/git/RepositoryAccess.vue
+++ b/td.vue/src/views/git/RepositoryAccess.vue
@@ -60,7 +60,7 @@ export default {
             page = this.$route.query.page;
         }
 
-        this.$store.dispatch(repoActions.fetch, page);
+        this.$store.dispatch(repoActions.fetch, { page, searchQuery: '' });
     },
     methods: {
         onRepoClick(repoName) {
@@ -71,8 +71,9 @@ export default {
             this.$router.push({ name: `${this.providerType}Branch`, params, query: this.$route.query });
         },
         paginate(page) {
-            this.$store.dispatch(repoActions.fetch, page, this.searchQuery);
+            this.$store.dispatch(repoActions.fetch, { page, searchQuery: this.searchQuery });
         }
     }
 };
 </script>
+

--- a/td.vue/tests/e2e/mock-server/data-generator.js
+++ b/td.vue/tests/e2e/mock-server/data-generator.js
@@ -1,0 +1,11 @@
+const generateItems = (names, total) => {
+    const items = [];
+    for (let idx = 0; idx < total; idx++) {
+        const name = names[idx % names.length];
+        const suffix = Math.floor(idx / names.length);
+        items.push(suffix > 0 ? `${name}-${suffix}` : name);
+    }
+    return items;
+};
+
+module.exports = { generateItems };

--- a/td.vue/tests/e2e/mock-server/dataset-github.js
+++ b/td.vue/tests/e2e/mock-server/dataset-github.js
@@ -1,0 +1,38 @@
+/**
+ * GitHub dataset for the mock server and pagination E2E tests.
+ * Centralises magic numbers so specs and the mock server stay in sync.
+ * Provider-specific: add dataset-bitbucket.js, dataset-gitlab.js etc for other providers.
+ */
+const dataset = Object.freeze({
+    repos: {
+        total: 75,
+        perPage: 30,
+        orgs: ['owasp', 'my-company', 'open-source-org', 'owasp', 'owasp'],
+        names: [
+            'threat-dragon', 'web-app', 'api-gateway', 'mobile-backend', 'auth-service',
+            'data-pipeline', 'frontend-app', 'payment-processor', 'notification-service',
+            'search-engine',
+        ],
+    },
+    branches: {
+        total: 35,
+        perPage: 15,
+        names: [
+            'main', 'develop', 'feature/auth-overhaul', 'feature/new-dashboard', 'fix/login-bug',
+            'release/v2.1.0', 'chore/dependency-update', 'hotfix/security-patch',
+            'feature/search-refactor', 'fix/input-validation', 'release/v2.2.0',
+            'chore/ci-upgrade', 'feature/oauth-flow', 'fix/rate-limiting', 'docs/api-reference',
+            'feature/mobile-support', 'fix/cors-headers', 'release/v3.0.0-beta',
+            'chore/docker-compose', 'feature/webhook-integration', 'fix/session-timeout',
+            'release/v2.3.0', 'chore/eslint-upgrade', 'feature/graphql-api', 'fix/null-pointer',
+            'release/v2.0.1', 'chore/readme-update', 'feature/caching-layer', 'fix/db-migration',
+            'docs/architecture', 'feature/rbac', 'fix/unicode-escape', 'release/v3.1.0-rc1',
+            'chore/terraform', 'feature/audit-log', 'fix/thread-safety', 'release/v1.9.0',
+            'chore/webpack5', 'feature/service-mesh', 'fix/config-encoding', 'docs/deployment',
+            'feature/rate-limiter-v2', 'fix/oauth-refresh', 'release/v4.0.0-alpha',
+            'chore/github-actions', 'feature/event-sourcing',
+        ],
+    },
+});
+
+module.exports = dataset;

--- a/td.vue/tests/e2e/mock-server/response-builder.js
+++ b/td.vue/tests/e2e/mock-server/response-builder.js
@@ -1,0 +1,10 @@
+const buildPagedResponse = (allItems, page, perPage) => {
+    const totalPages = Math.ceil(allItems.length / perPage);
+    const startIdx = (page - 1) * perPage;
+    return {
+        items: allItems.slice(startIdx, startIdx + perPage),
+        pagination: { page, next: page < totalPages, prev: page > 1 },
+    };
+};
+
+module.exports = { buildPagedResponse };

--- a/td.vue/tests/e2e/mock-server/threatDragonBackEndServerMock.js
+++ b/td.vue/tests/e2e/mock-server/threatDragonBackEndServerMock.js
@@ -1,0 +1,134 @@
+const express = require('express');
+const cfg = require('./dataset-github');
+const { generateItems } = require('./data-generator');
+const { buildPagedResponse } = require('./response-builder');
+
+const getAllRepos = () => {
+    const { names, total, orgs } = cfg.repos;
+    return generateItems(names, total).map((name, idx) => ({
+        id: idx + 1,
+        full_name: `${orgs[idx % orgs.length]}/${name}`,
+        name,
+        owner: { login: orgs[idx % orgs.length] },
+        private: idx % 3 === 0,
+        html_url: `https://github.com/${orgs[idx % orgs.length]}/${name}`,
+        description: `Fake repository #${idx + 1} for testing pagination`,
+        fork: false,
+        language: ['JavaScript', 'TypeScript', 'Python', 'Go', 'Rust'][idx % 5],
+    }));
+};
+
+const getAllBranches = () => {
+    const { names, total } = cfg.branches;
+    return generateItems(names, total).map((name, idx) => ({
+        name,
+        commit: { sha: `abc123def${idx}` },
+        protected: idx === 0 || idx % 6 === 0,
+    }));
+};
+
+const createFakeJwt = () => {
+    const jwtPayload = Buffer.from(JSON.stringify({
+        provider: { github: 'fake-encrypted-token' },
+        user: { login: 'test-user', name: 'Test User' }
+    })).toString('base64');
+    return `header.${jwtPayload}.fake-signature`;
+};
+
+const createMockApp = () => {
+    const app = express();
+    app.use(express.json());
+
+    app.get('/api/config', (_req, res) => {
+        res.status(200).json({
+            status: 200,
+            data: {
+                githubEnabled: true, bitbucketEnabled: false, gitlabEnabled: false,
+                googleEnabled: false, localEnabled: true,
+                allowedLocales: ['en'], defaultLocale: 'en',
+            }
+        });
+    });
+
+    app.get('/api/login/:provider', (_req, res) => {
+        res.status(200).json({
+            status: 200,
+            data: 'http://localhost:3000/api/oauth/return?code=fake-code'
+        });
+    });
+
+    app.get('/api/oauth/return', (req, res) => {
+        res.redirect(`http://localhost:8080/#/oauth-return?code=${req.query.code || 'fake-code'}`);
+    });
+
+    app.get('/api/oauth/:provider', (_req, res) => {
+        const fakeJwt = createFakeJwt();
+        res.status(200).json({
+            status: 200,
+            data: { accessToken: fakeJwt, refreshToken: fakeJwt, }
+        });
+    });
+
+    app.post('/api/auth/local', (_req, res) => {
+        const fakeJwt = createFakeJwt();
+        res.status(200).json({
+            status: 200,
+            data: {
+                accessToken: fakeJwt,
+                refreshToken: fakeJwt,
+                user: { login: 'local-user', name: 'Local User', provider: 'local' }
+            }
+        });
+    });
+
+    app.get('/api/threatmodel/organisation', (_req, res) => {
+        res.status(200).json({
+            status: 200,
+            data: { protocol: 'https', hostname: 'api.github.com', port: '', }
+        });
+    });
+
+    app.get('/api/threatmodel/repos', (req, res) => {
+        const page = parseInt(req.query.page, 10) || 1;
+        const searchQuery = (req.query.searchQuery || '').toLowerCase();
+        const allRepos = getAllRepos();
+        const matched = searchQuery
+            ? allRepos.filter(r => r.full_name.toLowerCase().includes(searchQuery))
+            : allRepos;
+        const { items, pagination } = buildPagedResponse(matched, page, cfg.repos.perPage);
+        res.status(200).json({
+            status: 200,
+            data: {
+                repos: items.map(r => r.full_name),
+                pagination: {
+                    ...pagination,
+                    next: items.length > 0 && pagination.next,
+                }
+            }
+        });
+    });
+
+    app.get('/api/threatmodel/:organisation/:repo/branches', (req, res) => {
+        const page = parseInt(req.query.page, 10) || 1;
+        const allBranches = getAllBranches();
+        const { items, pagination } = buildPagedResponse(allBranches, page, cfg.branches.perPage);
+        res.status(200).json({
+            status: 200,
+            data: {
+                branches: items.map(b => ({ name: b.name, protected: b.protected })),
+                pagination,
+            }
+        });
+    });
+
+    app.get('/api/threatmodel/:organisation/:repo/:branch/models', (_req, res) => {
+        res.status(200).json({
+            status: 200,
+            data: ['Demo Threat Model', 'Web Application', 'API Gateway']
+        });
+    });
+
+    return app;
+};
+
+module.exports = { createMockApp };

--- a/td.vue/tests/e2e/specs/git/branch-pagination.cy.js
+++ b/td.vue/tests/e2e/specs/git/branch-pagination.cy.js
@@ -1,0 +1,62 @@
+const cfg = require('../../mock-server/dataset-github');
+
+const totalPages = Math.ceil(cfg.branches.total / cfg.branches.perPage);
+const lastPageRemainder = cfg.branches.total - cfg.branches.perPage * (totalPages - 1);
+
+// Count 'feature' prefixed names within the first perPage items
+const featureCountOnPage1 = cfg.branches.names.slice(0, cfg.branches.perPage)
+    .filter(n => n.startsWith('feature/')).length;
+
+const loginViaGitHub = () => {
+    cy.visit('/', { onBeforeLoad: (win) => win.sessionStorage.clear() });
+    cy.get('#local-login-btn').should('be.visible');
+    cy.visit('/#/git/github/repository');
+};
+
+describe('GitHub provider — branch pagination', () => {
+    beforeEach(() => {
+        loginViaGitHub();
+    });
+
+    it('page 1 shows first page of branches with Next enabled and Previous disabled', () => {
+        cy.contains('owasp/threat-dragon').click();
+        cy.get('.list-group-item').should('have.length', cfg.branches.perPage);
+        cy.contains('button', 'Next').should('not.be.disabled');
+        cy.contains('button', 'Previous').should('be.disabled');
+    });
+
+    it('page 2 shows a full page with Next and Previous enabled', () => {
+        cy.contains('owasp/threat-dragon').click();
+        cy.contains('button', 'Next').click();
+        cy.get('.list-group-item').should('have.length', cfg.branches.perPage);
+        cy.contains('button', 'Next').should('not.be.disabled');
+        cy.contains('button', 'Previous').should('not.be.disabled');
+    });
+
+    it('last page has fewer items with Next disabled and Previous enabled', () => {
+        cy.contains('owasp/threat-dragon').click();
+        for (let i = 1; i < totalPages; i++) {
+            cy.contains('button', 'Next').click();
+        }
+        cy.get('.list-group-item').should('have.length', lastPageRemainder);
+        cy.contains('button', 'Next').should('be.disabled');
+        cy.contains('button', 'Previous').should('not.be.disabled');
+    });
+
+    it('navigates forward and back maintaining item count', () => {
+        cy.contains('owasp/threat-dragon').click();
+        cy.contains('button', 'Next').click();
+        cy.get('.list-group-item').should('have.length', cfg.branches.perPage);
+        cy.contains('button', 'Previous').click();
+        cy.get('.list-group-item').should('have.length', cfg.branches.perPage);
+    });
+
+    it('filters branches by name on page 1', () => {
+        cy.contains('owasp/threat-dragon').click();
+        cy.get('#filter').type('feature');
+        cy.get('.list-group-item').should('have.length', featureCountOnPage1);
+        cy.get('.list-group-item').each($el => {
+            cy.wrap($el).should('contain', 'feature');
+        });
+    });
+});

--- a/td.vue/tests/e2e/specs/git/repository-pagination.cy.js
+++ b/td.vue/tests/e2e/specs/git/repository-pagination.cy.js
@@ -1,0 +1,74 @@
+const cfg = require('../../mock-server/dataset-github');
+
+const loginViaGitHub = () => {
+    cy.visit('/', { onBeforeLoad: (win) => win.sessionStorage.clear() });
+    cy.get('#local-login-btn').should('be.visible');
+    cy.visit('/#/git/github/repository');
+};
+
+describe('GitHub provider — repository pagination', () => {
+    beforeEach(() => {
+        loginViaGitHub();
+    });
+
+    it('page 1 shows first page of repos with Next enabled and Previous disabled', () => {
+        cy.get('.list-group-item').should('have.length', cfg.repos.perPage);
+        cy.contains('button', 'Next').should('not.be.disabled');
+        cy.contains('button', 'Previous').should('be.disabled');
+    });
+
+    it('page 2 shows a full page with Next and Previous enabled', () => {
+        cy.contains('button', 'Next').click();
+        cy.get('.list-group-item').should('have.length', cfg.repos.perPage);
+        cy.contains('button', 'Next').should('not.be.disabled');
+        cy.contains('button', 'Previous').should('not.be.disabled');
+    });
+
+    it('last page has fewer items with Next disabled and Previous enabled', () => {
+        cy.contains('button', 'Next').click();
+        cy.contains('button', 'Next').click();
+        const remainder = cfg.repos.total - cfg.repos.perPage * 2;
+        cy.get('.list-group-item').should('have.length', remainder);
+        cy.contains('button', 'Next').should('be.disabled');
+        cy.contains('button', 'Previous').should('not.be.disabled');
+    });
+
+    it('navigates forward and back maintaining item count', () => {
+        cy.contains('button', 'Next').click();
+        cy.get('.list-group-item').should('have.length', cfg.repos.perPage);
+        cy.contains('button', 'Previous').click();
+        cy.get('.list-group-item').should('have.length', cfg.repos.perPage);
+    });
+
+    it('filtering by my-company shows fewer items and disables both pagination buttons on page 1', () => {
+        cy.get('#filter').type('my-company');
+        const orgCount = cfg.repos.orgs.filter(o => o === 'my-company').length;
+        const totalForOrg = Math.floor(cfg.repos.total / cfg.repos.orgs.length) * orgCount;
+        cy.get('.list-group-item').should('have.length', Math.min(totalForOrg, cfg.repos.perPage));
+        cy.contains('button', 'Next').should('be.disabled');
+        cy.contains('button', 'Previous').should('be.disabled');
+    });
+
+    it('filter by owasp keeps pagination active and all items contain the org name', () => {
+        cy.get('#filter').type('owasp');
+        cy.get('.list-group-item').should('have.length', cfg.repos.perPage);
+        cy.contains('button', 'Next').should('not.be.disabled');
+        cy.get('.list-group-item').each($el => {
+            cy.wrap($el).should('contain', 'owasp');
+        });
+    });
+
+    it('filter + pagination shows owasp items on page 2', () => {
+        cy.get('#filter').type('owasp');
+        cy.contains('button', 'Next').click();
+        const orgCount = cfg.repos.orgs.filter(o => o === 'owasp').length;
+        const totalForOrg = Math.floor(cfg.repos.total / cfg.repos.orgs.length) * orgCount;
+        const remainder = totalForOrg - cfg.repos.perPage;
+        cy.get('.list-group-item').should('have.length', remainder);
+        cy.contains('button', 'Previous').should('not.be.disabled');
+        cy.contains('button', 'Next').should('be.disabled');
+        cy.get('.list-group-item').each($el => {
+            cy.wrap($el).should('contain', 'owasp');
+        });
+    });
+});

--- a/td.vue/tests/unit/components/addBranchDialog.spec.js
+++ b/td.vue/tests/unit/components/addBranchDialog.spec.js
@@ -87,36 +87,33 @@ describe('components/AddBranchDialog.vue', () => {
     });
 
     describe('addBranch', () => {
-        let dispatch;
+        let branches, commit, dispatch;
 
         beforeEach(() => {
-            const branches = ['main', 'develop', 'feature'];
-            dispatch = jest.fn((branchActions, payload) => {
-                if(branchActions === 'BRANCH_CREATE') {
+            branches = ['main', 'develop', 'feature'];
+            commit = jest.fn();
+            dispatch = jest.fn((action, payload) => {
+                if (action === 'BRANCH_CREATE') {
                     const { branchName } = payload;
                     branches.push(branchName);
+                    return Promise.resolve();
                 }
-
-                if (branchActions === 'BRANCH_FETCH') {
-                    return wrapper.setProps({ branches: [...branches] });
+                if (action === 'BRANCH_FETCH') {
+                    wrapper.setProps({ branches: [...branches] });
+                    return Promise.resolve();
                 }
-
                 return Promise.resolve();
             });
             wrapper = shallowMount(AddBranchDialog, {
                 localVue,
-                propsData: {
-                    branches
-                },
+                propsData: { branches },
                 mocks: {
                     $t: key => key,
-                    $store: {
-                        dispatch
-                    }
+                    $store: { dispatch, commit }
                 },
                 data() {
                     return {
-                        newBranchName:  'new-branch',
+                        newBranchName: 'new-branch',
                         refBranch: 'main'
                     };
                 }
@@ -129,9 +126,15 @@ describe('components/AddBranchDialog.vue', () => {
         });
 
         it('closes the dialog after adding the branch', async () => {
-            await wrapper.setData({ newBranchName: 'new-branch', refBranch: 'main'});
+            await wrapper.setData({ newBranchName: 'new-branch', refBranch: 'main' });
             await wrapper.vm.addBranch();
             expect(wrapper.emitted('close-dialog')).toHaveLength(1);
         });
+
+        it('dispatches BRANCH_FETCH with { page: 1 } when polling for the new branch', async () => {
+            await wrapper.vm.addBranch();
+            expect(dispatch).toHaveBeenCalledWith('BRANCH_FETCH', { page: 1 });
+        });
     });
 });
+

--- a/td.vue/tests/unit/components/selectionPage.spec.js
+++ b/td.vue/tests/unit/components/selectionPage.spec.js
@@ -3,52 +3,47 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 
 import SelectionPage from '@/components/SelectionPage.vue';
 
+const tMock = key => key;
+
 describe('components/SelectionPage.vue', () => {
-    let localVue, wrapper;
+    let localVue;
 
     beforeEach(() => {
         localVue = createLocalVue();
         localVue.use(BootstrapVue);
     });
 
+    const createWrapper = (props = {}, options = {}) => shallowMount(SelectionPage, {
+        localVue,
+        propsData: { items: [], onItemClick: jest.fn(), ...props },
+        mocks: { $t: tMock },
+        ...options,
+    });
+
     describe('with data', () => {
-        const items = [ 'one', 'two', 'three', 'four', ({
-            value: 'five',
-            icon: 'lock',
-            iconTooltip: 'foobar',
-        }) ];
-        let onItemClick;
+        const items = ['one', 'two', 'three', 'four', {
+            value: 'five', icon: 'lock', iconTooltip: 'foobar',
+        }];
+        let onItemClick, wrapper;
 
         beforeEach(() => {
             onItemClick = jest.fn();
-            wrapper = shallowMount(SelectionPage, {
-                localVue,
-                propsData: {
-                    items,
-                    onItemClick
-                },
-                scopedSlots: {
-                    default: function () {
-                        return 'Hello, world!';
-                    }
-                },
-                mocks: {
-                    $t: key => key
-                }
+            wrapper = createWrapper({ items, onItemClick }, {
+                scopedSlots: { default() { return 'Hello, world!'; } },
             });
         });
 
         it('shows the jumbotron text', () => {
-            expect(wrapper.findComponent(BJumbotron).text()).toEqual('Hello, world!');
+            expect(wrapper.findComponent(BJumbotron).text()).toBe('Hello, world!');
         });
 
         it('displays the items', () => {
-            expect(wrapper.findAllComponents(BListGroupItem).at(1).text()).toEqual(items[1]);
+            expect(wrapper.findAllComponents(BListGroupItem).at(1).text()).toBe(items[1]);
         });
 
         it('filters items based on the search bar', async () => {
             await wrapper.setData({ filter: 'FOUR' });
-            expect(wrapper.findComponent(BListGroupItem).text()).toEqual('four');
+            expect(wrapper.findComponent(BListGroupItem).text()).toBe('four');
         });
 
         it('emits filter updates from the search bar model', async () => {
@@ -61,72 +56,238 @@ describe('components/SelectionPage.vue', () => {
             expect(onItemClick).toHaveBeenCalledTimes(1);
         });
 
-        it('display the icon only on the last item', () => {
-            expect(wrapper.findAllComponents(BListGroupItem).at(3).find('b-icon-stub').exists()).toBeFalsy();
-            expect(wrapper.findAllComponents(BListGroupItem).at(3).find('span').text()).toEqual(items[3]);
-            expect(wrapper.findAllComponents(BListGroupItem).at(4).html()).toMatch(`<font-awesome-icon icon="${items[4].icon}" title="${items[4].iconTooltip}"></font-awesome-icon>`);
+        it('displays the icon only on the last (object) item', () => {
+            const listItems = wrapper.findAllComponents(BListGroupItem);
+            expect(listItems.at(3).find('b-icon-stub').exists()).toBe(false);
+            expect(listItems.at(3).find('span').text()).toBe(items[3]);
+            expect(listItems.at(4).html()).toMatch(
+                `<font-awesome-icon icon="${items[4].icon}" title="${items[4].iconTooltip}"></font-awesome-icon>`,
+            );
         });
     });
 
-    describe('empty state with action', () => {
-        const items = [];
-        let emptyStateText = 'foobar', onEmptyStateClick, onItemClick;
+    describe('empty state', () => {
+        let onEmptyStateClick, onItemClick, wrapper;
 
         beforeEach(() => {
+            onItemClick = jest.fn();
             onEmptyStateClick = jest.fn();
-            onItemClick = jest.fn();
-            wrapper = shallowMount(SelectionPage, {
-                localVue,
-                propsData: {
-                    emptyStateText,
-                    items,
-                    onItemClick,
-                    onEmptyStateClick,
-                },
-                mocks: {
-                    $t: key => key
-                }
+        });
+
+        describe('with onEmptyStateClick handler', () => {
+            beforeEach(() => {
+                wrapper = createWrapper({
+                    items: [], emptyStateText: 'foobar',
+                    onItemClick, onEmptyStateClick,
+                });
+            });
+
+            it('shows the empty state text', () => {
+                expect(wrapper.findComponent(BListGroupItem).text()).toBe('foobar');
+            });
+
+            it('calls onEmptyStateClick on click', async () => {
+                await wrapper.findComponent(BListGroupItem).trigger('click');
+                expect(onEmptyStateClick).toHaveBeenCalledTimes(1);
+            });
+
+            it('does not call onItemClick on click', async () => {
+                await wrapper.findComponent(BListGroupItem).trigger('click');
+                expect(onItemClick).not.toHaveBeenCalled();
             });
         });
 
-        it('shows the empty state', () => {
-            expect(wrapper.findComponent(BListGroupItem).text()).toEqual(emptyStateText);
-        });
+        describe('without onEmptyStateClick handler', () => {
+            beforeEach(() => {
+                wrapper = createWrapper({ items: [], emptyStateText: 'foobar', onItemClick });
+            });
 
-        it('calls the onEmptyStateClick action', async () => {
-            await wrapper.findComponent(BListGroupItem).trigger('click');
-            expect(onEmptyStateClick).toHaveBeenCalledTimes(1);
-        });
-
-        it('does not call the onItemClick action', async () => {
-            await wrapper.findComponent(BListGroupItem).trigger('click');
-            expect(onItemClick).not.toHaveBeenCalled();
+            it('does not call onItemClick on click', async () => {
+                await wrapper.findComponent(BListGroupItem).trigger('click');
+                expect(onItemClick).not.toHaveBeenCalled();
+            });
         });
     });
 
-    describe('empty state with default click', () => {
-        const items = [];
-        let emptyStateText = 'foobar', onItemClick;
+    describe('page prop', () => {
+        let wrapper;
 
         beforeEach(() => {
-            onItemClick = jest.fn();
-            wrapper = shallowMount(SelectionPage, {
-                localVue,
-                propsData: {
-                    emptyStateText,
-                    items,
-                    onItemClick
-                },
-                mocks: {
-                    $t: key => key
-                }
+            wrapper = createWrapper({
+                items: ['repo1', 'repo2', 'repo3'],
+                page: 1, pageNext: true, pagePrev: false,
             });
         });
 
-        it('does not call the onItemClick action', async () => {
-            await wrapper.findComponent(BListGroupItem).trigger('click');
-            expect(onItemClick).not.toHaveBeenCalled();
+        it('initializes pageRef from the page prop', () => {
+            expect(wrapper.vm.pageRef).toBe(1);
+        });
+
+        it('updates pageRef when the page prop changes', async () => {
+            await wrapper.setProps({ page: 3 });
+            expect(wrapper.vm.pageRef).toBe(3);
+        });
+
+        it('renders the page number in the pagination button', () => {
+            expect(wrapper.findAll('button').at(1).text()).toBe('1');
+        });
+
+        it('updates rendered page number when page prop changes', async () => {
+            await wrapper.setProps({ page: 5 });
+            expect(wrapper.findAll('button').at(1).text()).toBe('5');
         });
     });
 
+    describe('pagination buttons', () => {
+        let paginate, wrapper;
+
+        beforeEach(() => {
+            paginate = jest.fn();
+            wrapper = createWrapper({
+                items: ['repo1', 'repo2'],
+                paginate, page: 3, pageNext: true, pagePrev: true,
+            });
+        });
+
+        const prevBtn = () => wrapper.findAll('button').at(0);
+        const nextBtn = () => wrapper.findAll('button').at(2);
+
+        it('renders Previous, page number, and Next buttons', () => {
+            const buttons = wrapper.findAll('button');
+            expect(buttons).toHaveLength(3);
+            expect(buttons.at(0).text()).toBe('Previous');
+            expect(buttons.at(1).text()).toBe('3');
+            expect(buttons.at(2).text()).toBe('Next');
+        });
+
+        it('disables Previous when pagePrev is false', async () => {
+            await wrapper.setProps({ pagePrev: false });
+            expect(prevBtn().attributes('disabled')).toBeDefined();
+        });
+
+        it('disables Next when pageNext is false', async () => {
+            await wrapper.setProps({ pageNext: false });
+            expect(nextBtn().attributes('disabled')).toBeDefined();
+        });
+
+        it('enables Previous when pagePrev is true', () => {
+            expect(prevBtn().attributes('disabled')).toBeUndefined();
+        });
+
+        it('enables Next when pageNext is true', () => {
+            expect(nextBtn().attributes('disabled')).toBeUndefined();
+        });
+
+        it('calls paginate with pageRef-1 when Previous is clicked', () => {
+            prevBtn().trigger('click');
+            expect(paginate).toHaveBeenCalledWith(2);
+        });
+
+        it('calls paginate with pageRef+1 when Next is clicked', () => {
+            nextBtn().trigger('click');
+            expect(paginate).toHaveBeenCalledWith(4);
+        });
+
+        it('updates pageRef when Previous is clicked', () => {
+            prevBtn().trigger('click');
+            expect(wrapper.vm.pageRef).toBe(2);
+        });
+
+        it('updates pageRef when Next is clicked', () => {
+            nextBtn().trigger('click');
+            expect(wrapper.vm.pageRef).toBe(4);
+        });
+    });
+
+    describe('onBackClick', () => {
+
+        let onBackClick, wrapper;
+
+        beforeEach(() => {
+            onBackClick = jest.fn();
+        });
+
+        it('displays the back item when showBackItem is true', () => {
+            wrapper = createWrapper({ items: ['item1', 'item2'], showBackItem: true, onBackClick });
+            expect(wrapper.text()).toContain('...');
+        });
+
+        it('does not display the back item when showBackItem is false', () => {
+            wrapper = createWrapper({ items: ['item1', 'item2'] });
+            expect(wrapper.text()).not.toContain('...');
+        });
+
+        it('calls onBackClick when the back item is clicked', () => {
+            wrapper = createWrapper({ items: ['item1', 'item2'], showBackItem: true, onBackClick });
+            wrapper.find('a').trigger('click');
+            expect(onBackClick).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('items prop validator', () => {
+        const validator = SelectionPage.props.items.validator;
+
+        it('accepts an array of strings', () => {
+            expect(validator(['a', 'b', 'c'])).toBe(true);
+        });
+
+        it('accepts an array of objects with value string', () => {
+            expect(validator([{ value: 'a' }, { value: 'b' }])).toBe(true);
+        });
+
+        it('accepts objects with value, icon, and iconTooltip', () => {
+            expect(validator([{ value: 'a', icon: 'lock', iconTooltip: 'locked' }])).toBe(true);
+        });
+
+        it('throws on a non-array', () => {
+            expect(() => validator('not-array')).toThrow();
+        });
+
+        it('rejects an item that is not string or object with value', () => {
+            expect(validator([42])).toBe(false);
+        });
+
+        it('rejects an object with icon but missing value', () => {
+            expect(validator([{ icon: 'lock' }])).toBe(false);
+        });
+    });
+
+    describe('filter (client-side search)', () => {
+        const items = [
+            { value: 'alpha-repo', icon: 'lock', iconTooltip: 'protected' },
+            'beta-repo',
+            'gamma-service',
+        ];
+        let wrapper;
+
+        beforeEach(() => {
+            wrapper = createWrapper({ items, filter: '' });
+        });
+
+        it('shows all items when filter is empty', () => {
+            expect(wrapper.vm.displayedItems).toHaveLength(3);
+        });
+
+        it('filters by name matching the filter string', async () => {
+            await wrapper.setProps({ filter: 'beta' });
+            expect(wrapper.vm.displayedItems).toHaveLength(1);
+            expect(wrapper.vm.displayedItems[0]).toContain('beta-repo');
+        });
+
+        it('is case-insensitive when filtering', async () => {
+            await wrapper.setProps({ filter: 'ALPHA' });
+            expect(wrapper.vm.displayedItems).toHaveLength(1);
+            expect(wrapper.vm.displayedItems[0].value).toContain('alpha-repo');
+        });
+
+        it('filters based on value property for object items', async () => {
+            await wrapper.setProps({ filter: 'alpha' });
+            expect(wrapper.vm.displayedItems).toHaveLength(1);
+        });
+
+        it('shows empty list when filter matches nothing', async () => {
+            await wrapper.setProps({ filter: 'zzznonexistent' });
+            expect(wrapper.vm.displayedItems).toHaveLength(0);
+        });
+    });
 });

--- a/td.vue/tests/unit/helpers/store.js
+++ b/td.vue/tests/unit/helpers/store.js
@@ -1,0 +1,9 @@
+export const createStoreMocks = (overrides = {}) => ({
+    commit: jest.fn(),
+    dispatch: jest.fn(),
+    rootState: {
+        auth: { jwt: 'test' },
+        repo: { selected: 'foobar' },
+        ...overrides,
+    },
+});

--- a/td.vue/tests/unit/helpers/utils.js
+++ b/td.vue/tests/unit/helpers/utils.js
@@ -1,0 +1,1 @@
+export const artificialDelay = (ms) => new Promise(resolve => setTimeout(resolve, ms));

--- a/td.vue/tests/unit/store/modules/branch.spec.js
+++ b/td.vue/tests/unit/store/modules/branch.spec.js
@@ -1,28 +1,21 @@
 import { BRANCH_CLEAR, BRANCH_FETCH, BRANCH_SELECTED } from '@/store/actions/branch.js';
 import branchModule, { clearState } from '@/store/modules/branch.js';
 import threatmodelApi from '@/service/api/threatmodelApi.js';
+import { createStoreMocks } from '../../helpers/store';
 
 describe('store/modules/branch.js', () => {
-    const mocks = {
-        commit: () => {},
-        dispatch: () => {},
-        rootState: {
-            auth: {
-                jwt: 'test'
-            },
-            repo: {
-                selected: 'foobar'
-            }
-        }
-    };
+    let apiSpy;
+    const mocks = createStoreMocks();
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
         jest.spyOn(mocks, 'dispatch');
+        apiSpy = jest.spyOn(threatmodelApi, 'branchesAsync');
     });
 
     afterEach(() => {
         clearState(branchModule.state);
+        apiSpy.mockRestore();
     });
 
     describe('state', () => {
@@ -31,19 +24,13 @@ describe('store/modules/branch.js', () => {
         });
 
         it('defines a selected string', () => {
-            expect(branchModule.state.selected).toEqual('');
+            expect(branchModule.state.selected).toBe('');
         });
 
-        it('defines a page number', () => {
-            expect(branchModule.state.page).toEqual(1);
-        });
-
-        it('defines a pageNext bool', () => {
-            expect(branchModule.state.pageNext).toEqual(false);
-        });
-
-        it('defines a pagePrev bool', () => {
-            expect(branchModule.state.pagePrev).toEqual(false);
+        it('defines pagination defaults', () => {
+            expect(branchModule.state.page).toBe(1);
+            expect(branchModule.state.pageNext).toBe(false);
+            expect(branchModule.state.pagePrev).toBe(false);
         });
     });
 
@@ -53,85 +40,85 @@ describe('store/modules/branch.js', () => {
             expect(mocks.commit).toHaveBeenCalledWith(BRANCH_CLEAR);
         });
 
+        it('commits the selected branch', () => {
+            branchModule.actions[BRANCH_SELECTED](mocks, 'my-branch');
+            expect(mocks.commit).toHaveBeenCalledWith(BRANCH_SELECTED, 'my-branch');
+        });
+
         describe('fetch', () => {
-            const branches = [ 'foo', 'bar' ];
-            const pagination = {
-                page: 1,
-                next: true,
-                prev: false
-            };
+            const branches = ['foo', 'bar'];
+            const pagination = { page: 1, next: true, prev: false };
 
             beforeEach(async () => {
-                jest.spyOn(threatmodelApi, 'branchesAsync').mockResolvedValue({ data: { branches, pagination }});
+                apiSpy.mockResolvedValue({ data: { branches, pagination } });
                 await branchModule.actions[BRANCH_FETCH](mocks);
             });
 
-            it('dispatches the clear event', () => {
+            it('dispatches clear before fetching', () => {
                 expect(mocks.dispatch).toHaveBeenCalledWith(BRANCH_CLEAR);
             });
 
-            it('commits the fetch action', () => {
-                expect(mocks.commit).toHaveBeenCalledWith(
-                    BRANCH_FETCH,
-                    {
-                        'branches': branches,
-                        'page': pagination.page,
-                        'pageNext': pagination.next,
-                        'pagePrev': pagination.prev
-                    } 
-                );
+            it('commits the fetch result with pagination', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(BRANCH_FETCH, {
+                    branches,
+                    page: pagination.page,
+                    pageNext: pagination.next,
+                    pagePrev: pagination.prev,
+                });
+            });
+
+            it('passes repo from rootState and default page 1 to the API', () => {
+                expect(apiSpy).toHaveBeenCalledWith(mocks.rootState.repo.selected, 1);
             });
         });
 
-        it('commits the selected branch', () => {
-            const branch = 'branch';
-            branchModule.actions[BRANCH_SELECTED](mocks, branch);
-            expect(mocks.commit).toHaveBeenCalledWith(BRANCH_SELECTED, branch);
+        describe('fetch with page parameter', () => {
+            const pagination = { page: 2, next: true, prev: true };
+
+            it('passes the requested page to branchesAsync', async () => {
+                apiSpy.mockResolvedValue({ data: { branches: ['page2branch'], pagination } });
+                await branchModule.actions[BRANCH_FETCH](mocks, { page: 2 });
+                expect(apiSpy).toHaveBeenCalledWith(mocks.rootState.repo.selected, 2);
+            });
+
+            it('defaults to page 1 when dispatched with empty payload', async () => {
+                apiSpy.mockResolvedValue({ data: { branches: [], pagination } });
+                await branchModule.actions[BRANCH_FETCH](mocks, {});
+                expect(apiSpy).toHaveBeenCalledWith(mocks.rootState.repo.selected, 1);
+            });
+
+            it('defaults to page 1 when dispatched without arguments', async () => {
+                apiSpy.mockResolvedValue({ data: { branches: [], pagination } });
+                await branchModule.actions[BRANCH_FETCH](mocks);
+                expect(apiSpy).toHaveBeenCalledWith(mocks.rootState.repo.selected, 1);
+            });
         });
     });
 
     describe('mutations', () => {
         describe('clear', () => {
             beforeEach(() => {
-                branchModule.state.all.push('test1');
-                branchModule.state.all.push('test2');
+                branchModule.state.all.push('test1', 'test2');
                 branchModule.state.selected = 'test5';
-                branchModule.state.page = 1;
-                branchModule.state.pageNext = false;
-                branchModule.state.pagePrev = false;
+                branchModule.state.page = 5;
+                branchModule.state.pageNext = true;
+                branchModule.state.pagePrev = true;
                 branchModule.mutations[BRANCH_CLEAR](branchModule.state);
             });
 
-            it('empties the all array', () => {
+            it('resets all state properties', () => {
                 expect(branchModule.state.all).toHaveLength(0);
-            });
-
-            it('resets the selected property', () => {
-                expect(branchModule.state.selected).toEqual('');
-            });
-
-            it('resets the page property', () => {
-                expect(branchModule.state.page).toEqual(1);
-            });
-
-            it('resets the pageNext property', () => {
-                expect(branchModule.state.pageNext).toEqual(false);
-            });
-
-            it('resets the pagePrev property', () => {
-                expect(branchModule.state.pagePrev).toEqual(false);
+                expect(branchModule.state.selected).toBe('');
+                expect(branchModule.state.page).toBe(1);
+                expect(branchModule.state.pageNext).toBe(false);
+                expect(branchModule.state.pagePrev).toBe(false);
             });
         });
 
         describe('selected', () => {
-            const branch = 'test';
-
-            beforeEach(() => {
-                branchModule.mutations[BRANCH_SELECTED](branchModule.state, branch);
-            });
-
             it('sets the branch prop', () => {
-                expect(branchModule.state.selected).toEqual(branch);
+                branchModule.mutations[BRANCH_SELECTED](branchModule.state, 'my-branch');
+                expect(branchModule.state.selected).toBe('my-branch');
             });
         });
     });

--- a/td.vue/tests/unit/store/modules/repository.spec.js
+++ b/td.vue/tests/unit/store/modules/repository.spec.js
@@ -1,25 +1,21 @@
 import { REPOSITORY_CLEAR, REPOSITORY_FETCH, REPOSITORY_SELECTED } from '@/store/actions/repository.js';
 import repoModule, { clearState } from '@/store/modules/repository.js';
 import threatmodelApi from '@/service/api/threatmodelApi.js';
+import { createStoreMocks } from '../../helpers/store';
 
 describe('store/modules/repository.js', () => {
-    const mocks = {
-        commit: () => {},
-        dispatch: () => {},
-        rootState: {
-            auth: {
-                jwt: 'test'
-            }
-        }
-    };
+    let apiSpy;
+    const mocks = createStoreMocks();
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
         jest.spyOn(mocks, 'dispatch');
+        apiSpy = jest.spyOn(threatmodelApi, 'reposAsync');
     });
 
     afterEach(() => {
         clearState(repoModule.state);
+        apiSpy.mockRestore();
     });
 
     describe('state', () => {
@@ -28,19 +24,13 @@ describe('store/modules/repository.js', () => {
         });
 
         it('defines a selected string', () => {
-            expect(repoModule.state.selected).toEqual('');
+            expect(repoModule.state.selected).toBe('');
         });
 
-        it('defines a page number', () => {
-            expect(repoModule.state.page).toEqual(1);
-        });
-
-        it('defines a pageNext bool', () => {
-            expect(repoModule.state.pageNext).toEqual(false);
-        });
-
-        it('defines a pagePrev bool', () => {
-            expect(repoModule.state.pagePrev).toEqual(false);
+        it('defines pagination defaults', () => {
+            expect(repoModule.state.page).toBe(1);
+            expect(repoModule.state.pageNext).toBe(false);
+            expect(repoModule.state.pagePrev).toBe(false);
         });
     });
 
@@ -50,85 +40,79 @@ describe('store/modules/repository.js', () => {
             expect(mocks.commit).toHaveBeenCalledWith(REPOSITORY_CLEAR);
         });
 
+        it('commits the selected repo', () => {
+            repoModule.actions[REPOSITORY_SELECTED](mocks, 'my-repo');
+            expect(mocks.commit).toHaveBeenCalledWith(REPOSITORY_SELECTED, 'my-repo');
+        });
+
         describe('fetch', () => {
-            const repos = [ 'foo', 'bar' ];
-            const pagination = {
-                page: 1,
-                next: true,
-                prev: false
-            };
+            const repos = ['foo', 'bar'];
+            const pagination = { page: 1, next: true, prev: false };
 
             beforeEach(async () => {
-                jest.spyOn(threatmodelApi, 'reposAsync').mockResolvedValue({ data: { repos, pagination }});
-                await repoModule.actions[REPOSITORY_FETCH](mocks, 1);
+                apiSpy.mockResolvedValue({ data: { repos, pagination } });
+                await repoModule.actions[REPOSITORY_FETCH](mocks, { page: 1, searchQuery: '' });
             });
 
-            it('dispatches the clear event', () => {
+            it('dispatches clear before fetching', () => {
                 expect(mocks.dispatch).toHaveBeenCalledWith(REPOSITORY_CLEAR);
             });
 
-            it('commits the fetch action', () => {
-                expect(mocks.commit).toHaveBeenCalledWith(
-                    REPOSITORY_FETCH,
-                    {
-                        'repos': repos,
-                        'page': pagination.page,
-                        'pageNext': pagination.next,
-                        'pagePrev': pagination.prev
-                    }
-                );
+            it('commits the fetch result with pagination', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(REPOSITORY_FETCH, {
+                    repos,
+                    page: pagination.page,
+                    pageNext: pagination.next,
+                    pagePrev: pagination.prev,
+                });
+            });
+
+            it('passes page and searchQuery to the API', () => {
+                expect(apiSpy).toHaveBeenCalledWith(1, '');
             });
         });
 
-        it('commits the selected repo', () => {
-            const repo = 'repo';
-            repoModule.actions[REPOSITORY_SELECTED](mocks, repo);
-            expect(mocks.commit).toHaveBeenCalledWith(REPOSITORY_SELECTED, repo);
+        describe('fetch with different parameters', () => {
+            const p = { page: 1, next: false, prev: false };
+
+            it('passes page 3 and search query to reposAsync', async () => {
+                apiSpy.mockResolvedValue({ data: { repos: ['filtered-repo'], pagination: p } });
+                await repoModule.actions[REPOSITORY_FETCH](mocks, { page: 3, searchQuery: 'owasp' });
+                expect(apiSpy).toHaveBeenCalledWith(3, 'owasp');
+            });
+
+            it('dispatches clear before the async API call', async () => {
+                apiSpy.mockResolvedValue({ data: { repos: [], pagination: p } });
+                await repoModule.actions[REPOSITORY_FETCH](mocks, { page: 1, searchQuery: '' });
+                expect(mocks.dispatch).toHaveBeenCalledWith(REPOSITORY_CLEAR);
+            });
         });
     });
 
     describe('mutations', () => {
         describe('clear', () => {
             beforeEach(() => {
-                repoModule.state.all.push('test1');
-                repoModule.state.all.push('test2');
+                repoModule.state.all.push('test1', 'test2');
                 repoModule.state.selected = 'github';
-                repoModule.state.page = 1;
-                repoModule.state.pageNext = false;
-                repoModule.state.pagePrev = false;
+                repoModule.state.page = 5;
+                repoModule.state.pageNext = true;
+                repoModule.state.pagePrev = true;
                 repoModule.mutations[REPOSITORY_CLEAR](repoModule.state);
             });
 
-            it('empties the all array', () => {
+            it('resets all state properties', () => {
                 expect(repoModule.state.all).toHaveLength(0);
-            });
-
-            it('resets the selected property', () => {
-                expect(repoModule.state.selected).toEqual('');
-            });
-
-            it('resets the page property', () => {
-                expect(repoModule.state.page).toEqual(1);
-            });
-
-            it('resets the pageNext property', () => {
-                expect(repoModule.state.pageNext).toEqual(false);
-            });
-
-            it('resets the pagePrev property', () => {
-                expect(repoModule.state.pagePrev).toEqual(false);
+                expect(repoModule.state.selected).toBe('');
+                expect(repoModule.state.page).toBe(1);
+                expect(repoModule.state.pageNext).toBe(false);
+                expect(repoModule.state.pagePrev).toBe(false);
             });
         });
 
         describe('selected', () => {
-            const repo = 'test';
-
-            beforeEach(() => {
-                repoModule.mutations[REPOSITORY_SELECTED](repoModule.state, repo);
-            });
-
             it('sets the repo prop', () => {
-                expect(repoModule.state.selected).toEqual(repo);
+                repoModule.mutations[REPOSITORY_SELECTED](repoModule.state, 'my-repo');
+                expect(repoModule.state.selected).toBe('my-repo');
             });
         });
     });

--- a/td.vue/tests/unit/views/branchAccess.spec.js
+++ b/td.vue/tests/unit/views/branchAccess.spec.js
@@ -8,132 +8,89 @@ import { REPOSITORY_CLEAR, REPOSITORY_SELECTED } from '@/store/actions/repositor
 import TdSelectionPage from '@/components/SelectionPage.vue';
 import AddBranchDialog from '@/components/AddBranchDialog.vue';
 
+const PROVIDER = 'github';
+const REPO = 'someRepo';
+
+const buildStore = () => new Vuex.Store({
+    state: {
+        provider: { selected: PROVIDER },
+        repo: { selected: REPO, page: 1, pageNext: true, pagePrev: false },
+        branch: {
+            selected: 'someBranch',
+            all: [
+                { name: 'b1', protected: true },
+                { name: 'b2', protected: false },
+                { name: 'b3', protected: false },
+            ],
+            page: 1, pageNext: true, pagePrev: false,
+        },
+    },
+    actions: {
+        [BRANCH_FETCH]: () => Promise.resolve(buildStore().state.branch.all),
+        [BRANCH_SELECTED]: () => {},
+        [PROVIDER_SELECTED]: () => {},
+        [REPOSITORY_CLEAR]: () => {},
+        [REPOSITORY_SELECTED]: () => {},
+    },
+});
+
+const mountComponent = (params, query = {}) => {
+    localVue = createLocalVue();
+    localVue.use(Vuex);
+    mockStore = buildStore();
+    mockRouter = { push: jest.fn() };
+    jest.spyOn(mockStore, 'dispatch');
+    wrapper = shallowMount(BranchAccess, {
+        localVue, store: mockStore,
+        mocks: { $route: { params, query }, $router: mockRouter, $t: k => k },
+    });
+};
+
+let localVue, mockRouter, mockStore, wrapper;
 
 describe('views/BranchAccess.vue', () => {
-    const repo = 'someRepo';
-    let wrapper, localVue, mockStore, mockRouter;
-
-    beforeEach(() => {
-        localVue = createLocalVue();
-        localVue.use(Vuex);
-        mockStore = getMockStore();
-    });
-
-    const getLocalVue = (mockRoute) => {
-        mockRouter = { push: jest.fn() };
-        jest.spyOn(mockStore, 'dispatch');
-        wrapper = shallowMount(BranchAccess, {
-            localVue,
-            store: mockStore,
-            mocks: {
-                $route: mockRoute,
-                $router: mockRouter,
-                $t: key => key
-            }
-        });
-    };
-
-    const getMockStore = () => new Vuex.Store({
-        state: {
-            repo: {
-                selected: repo,
-                page: 1,
-                pageNext: true,
-                pagePrev: false
-            },
-            branch: {
-                selected: 'someBranch',
-                all: [{ name: 'b1', protected: true }, { name: 'b2', protected: false }, { name: 'b3', protected: false }],
-                page: 1,
-                pageNext: true,
-                pagePrev: false
-            },
-            provider: {
-                selected: 'github'
-            }
-        },
-        actions: {
-            [BRANCH_FETCH]: () =>  Promise.resolve(getMockStore().state.branch.all),
-            [BRANCH_SELECTED]: () => { },
-            [PROVIDER_SELECTED]: () => { },
-            [REPOSITORY_CLEAR]: () => { },
-            [REPOSITORY_SELECTED]: () => { }
-        }
-    });
-
     describe('mounted', () => {
         it('sets the provider from the route', () => {
-            getLocalVue({
-                params: {
-                    provider: 'local',
-                    repository: mockStore.state.repo.selected
-                }
-            });
+            mountComponent({ provider: 'local', repository: REPO });
             expect(mockStore.dispatch).toHaveBeenCalledWith(PROVIDER_SELECTED, 'local');
         });
 
         it('sets the repo name from the route', () => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected,
-                    repository: 'fakeRepoBad'
-                }
-            });
+            mountComponent({ provider: PROVIDER, repository: 'fakeRepoBad' });
             expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_SELECTED, 'fakeRepoBad');
         });
 
-        it('fetches the branches', () => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected,
-                    repository: mockStore.state.repo.selected
-                }
-            });
-            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_FETCH, 1);
+        it('fetches branches and maps protected ones with lock icon', () => {
+            mountComponent({ provider: PROVIDER, repository: REPO });
+            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_FETCH, { page: 1 });
             expect(wrapper.vm.branches).toEqual([
-                {
-                    value: 'b1',
-                    icon: 'lock',
-                    iconTooltip: 'branch.protectedBranch'
-                },
-                'b2','b3'
+                { value: 'b1', icon: 'lock', iconTooltip: 'branch.protectedBranch' },
+                'b2', 'b3',
             ]);
         });
     });
 
     describe('branches', () => {
-        beforeEach(() => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected,
-                    repository: mockStore.state.repo.selected
-                }
-            });
+        beforeEach(() => mountComponent({ provider: PROVIDER, repository: REPO }));
+
+        it('renders the selection page wrapper', () => {
+            expect(wrapper.findComponent(TdSelectionPage).exists()).toBe(true);
         });
 
-        it('displays the branches', () => {
-            expect(wrapper.findComponent(TdSelectionPage).exists()).toEqual(true);
-        });
-
-        it('displays the translated text', () => {
+        it('shows translated header text', () => {
             expect(wrapper.findComponent(TdSelectionPage).text()).toContain('branch.chooseRepo');
         });
 
-        it('updates the search query from the selection page filter event', async () => {
+        it('updates searchQuery on filter emit from child', async () => {
             wrapper.findComponent(TdSelectionPage).vm.$emit('update:filter', 'feature');
             await wrapper.vm.$nextTick();
-            expect(wrapper.vm.searchQuery).toEqual('feature');
+            expect(wrapper.vm.searchQuery).toBe('feature');
         });
     });
 
     describe('selectRepoClick', () => {
         beforeEach(() => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected,
-                    repository: mockStore.state.repo.selected
-                }
-            });
+            mountComponent({ provider: PROVIDER, repository: REPO });
             wrapper.vm.selectRepoClick();
         });
 
@@ -141,102 +98,67 @@ describe('views/BranchAccess.vue', () => {
             expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_CLEAR);
         });
 
-        it('navigates to the repo select page', () => {
+        it('navigates back to the repository selection page', () => {
             expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitRepository' });
         });
     });
 
-    describe('onBranchClick - select', () => {
+    describe('onBranchClick', () => {
         const testBranch = 'testBranch';
-        let routeParams;
-        beforeEach(() => {
-            routeParams = {
-                provider: mockStore.state.provider.selected,
-                repository: mockStore.state.repo.selected
-            };
-            getLocalVue({
-                params: routeParams,
-                query: {}
-            });
-            wrapper.vm.onBranchClick(testBranch);
-        });
 
-        it('sets the selected branch', () => {
+        it('selects the branch and navigates to the edit page (default action)', () => {
+            mountComponent({ provider: PROVIDER, repository: REPO }, {});
+            wrapper.vm.onBranchClick(testBranch);
             expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_SELECTED, testBranch);
-        });
-
-        it('navigates to the edit page', () => {
-            routeParams.branch = testBranch;
-            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitThreatModelSelect', params: routeParams });
-        });
-    });
-
-    describe('onBranchClick - new', () => {
-        const testBranch = 'testBranch';
-        let routeParams;
-        beforeEach(() => {
-            routeParams = {
-                provider: mockStore.state.provider.selected,
-                repository: mockStore.state.repo.selected
-            };
-            getLocalVue({
-                params: routeParams,
-                query: {
-                    action: 'create'
-                }
+            expect(mockRouter.push).toHaveBeenCalledWith({
+                name: 'gitThreatModelSelect',
+                params: { provider: PROVIDER, repository: REPO, branch: testBranch },
             });
+        });
+
+        it('navigates to the new-threat-model page when action=create', () => {
+            mountComponent({ provider: PROVIDER, repository: REPO }, { action: 'create' });
             wrapper.vm.onBranchClick(testBranch);
+            expect(mockRouter.push).toHaveBeenCalledWith({
+                name: 'gitNewThreatModel',
+                params: { provider: PROVIDER, repository: REPO, branch: testBranch },
+            });
         });
 
-        it('navigates to the new page', () => {
-            routeParams.branch = testBranch;
-            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitNewThreatModel', params: routeParams });
-        });
-    });
-
-    describe('onBranchClick - protected branch object', () => {
-        const protectedBranch = {
-            value: 'protectedBranchName',
-            icon: 'lock',
-            iconTooltip: 'branch.protectedBranch'
-        };
-        let routeParams;
-        beforeEach(() => {
-            routeParams = {
-                provider: mockStore.state.provider.selected,
-                repository: mockStore.state.repo.selected
+        it('extracts the branch name from a protected-branch object', () => {
+            const protectedBranch = {
+                value: 'protectedBranchName',
+                icon: 'lock',
+                iconTooltip: 'branch.protectedBranch',
             };
-            getLocalVue({
-                params: routeParams,
-                query: {}
-            });
+            mountComponent({ provider: PROVIDER, repository: REPO }, {});
             wrapper.vm.onBranchClick(protectedBranch);
-        });
-
-        it('extracts the branch name from the object', () => {
             expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_SELECTED, 'protectedBranchName');
-        });
-
-        it('navigates with the correct branch name', () => {
-            routeParams.branch = 'protectedBranchName';
-            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitThreatModelSelect', params: routeParams });
+            expect(mockRouter.push).toHaveBeenCalledWith({
+                name: 'gitThreatModelSelect',
+                params: { provider: PROVIDER, repository: REPO, branch: 'protectedBranchName' },
+            });
         });
     });
 
-    describe('open add branch dialog', () => {
+    describe('add branch dialog', () => {
         beforeEach(() => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected,
-                    repository: mockStore.state.repo.selected
-                }
-            });
+            mountComponent({ provider: PROVIDER, repository: REPO });
             wrapper.vm.toggleNewBranchDialog();
         });
 
-        it('sets the dialog to open', () => {
-            expect(wrapper.vm.showNewBranchDialog).toEqual(true);
-            expect(wrapper.findComponent(AddBranchDialog).exists()).toEqual(true);
+        it('opens the dialog when toggled', () => {
+            expect(wrapper.vm.showNewBranchDialog).toBe(true);
+            expect(wrapper.findComponent(AddBranchDialog).exists()).toBe(true);
+        });
+    });
+
+    describe('paginate', () => {
+        beforeEach(() => mountComponent({ provider: PROVIDER, repository: REPO }));
+
+        it('dispatches BRANCH_FETCH with the requested page number', () => {
+            wrapper.vm.paginate(3);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(BRANCH_FETCH, { page: 3 });
         });
     });
 });

--- a/td.vue/tests/unit/views/repositoryAccess.spec.js
+++ b/td.vue/tests/unit/views/repositoryAccess.spec.js
@@ -44,14 +44,14 @@ describe('views/RepositoryAccess.vue', () => {
             expect(mockStore.dispatch).toHaveBeenCalledWith(PROVIDER_SELECTED, 'local');
         });
 
-        it('fetches with default page 1 and empty search', () => {
+        it('fetches with default page 1', () => {
             mountComponent({ provider: PROVIDER }, {});
-            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: '' });
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1 });
         });
 
         it('uses the page from the route query', () => {
             mountComponent({ provider: PROVIDER }, { page: 3 });
-            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 3, searchQuery: '' });
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 3 });
         });
 
         it('does not re-dispatch an already-matched provider', () => {
@@ -181,6 +181,12 @@ describe('views/RepositoryAccess.vue', () => {
             wrapper.vm.searchQuery = '';
             wrapper.vm.paginate(3);
             expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 3, searchQuery: '' });
+        });
+
+        it('paginates with empty searchQuery when no filter is active', () => {
+            wrapper.vm.searchQuery = '';
+            wrapper.vm.paginate(5);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 5, searchQuery: '' });
         });
 
         it('preserves the current filter when paginating', () => {

--- a/td.vue/tests/unit/views/repositoryAccess.spec.js
+++ b/td.vue/tests/unit/views/repositoryAccess.spec.js
@@ -6,130 +6,187 @@ import { REPOSITORY_CLEAR, REPOSITORY_SELECTED, REPOSITORY_FETCH } from '@/store
 import RepositoryAccess from '@/views/git/RepositoryAccess.vue';
 import TdSelectionPage from '@/components/SelectionPage.vue';
 
+import { artificialDelay } from '../helpers/utils';
+
+const PROVIDER = 'github';
+
+const buildStore = () => new Vuex.Store({
+    state: {
+        provider: { selected: PROVIDER },
+        repo: { all: [], selected: '', page: 1, pageNext: true, pagePrev: false },
+    },
+    actions: {
+        [PROVIDER_SELECTED]: () => {},
+        [REPOSITORY_CLEAR]: () => {},
+        [REPOSITORY_FETCH]: () => {},
+        [REPOSITORY_SELECTED]: () => {},
+    },
+});
+
+const mountComponent = (params, query = {}) => {
+    localVue = createLocalVue();
+    localVue.use(Vuex);
+    mockStore = buildStore();
+    mockRouter = { push: jest.fn() };
+    jest.spyOn(mockStore, 'dispatch');
+    wrapper = shallowMount(RepositoryAccess, {
+        localVue, store: mockStore,
+        mocks: { $route: { params, query }, $router: mockRouter, $t: k => k },
+    });
+};
+
+let localVue, mockRouter, mockStore, wrapper;
 
 describe('views/RepositoryAccess.vue', () => {
-    let wrapper, localVue, mockStore, mockRouter;
-
-    beforeEach(() => {
-        localVue = createLocalVue();
-        localVue.use(Vuex);
-        mockStore = getMockStore();
-    });
-
-    const getLocalVue = (mockRoute) => {
-        mockRouter = { push: jest.fn() };
-        jest.spyOn(mockStore, 'dispatch');
-        wrapper = shallowMount(RepositoryAccess, {
-            localVue,
-            store: mockStore,
-            mocks: {
-                $route: mockRoute,
-                $router: mockRouter,
-                $t: key => key
-            }
-        });
-    };
-
-    const getMockStore = () => new Vuex.Store({
-        state: {
-            provider: {
-                selected: 'github'
-            },
-            repo: {
-                all: [],
-                selected: '',
-                page: 1,
-                pageNext: true,
-                pagePrev: false
-            }
-        },
-        actions: {
-            [PROVIDER_SELECTED]: () => { },
-            [REPOSITORY_CLEAR]: () => { },
-            [REPOSITORY_FETCH]: () => { },
-            [REPOSITORY_SELECTED]: () => { }
-        }
-    });
-
     describe('mounted', () => {
         it('sets the provider from the route', () => {
-            getLocalVue({
-                params: {
-                    provider: 'local'
-                },
-                query: {
-                    page: 1
-                }
-            });
+            mountComponent({ provider: 'local' }, { page: 1 });
             expect(mockStore.dispatch).toHaveBeenCalledWith(PROVIDER_SELECTED, 'local');
         });
-        
-        it('fetches the repos', () => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected
-                },
-                query: {
-                    page: 1
-                }
-            });
-            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, 1);
+
+        it('fetches with default page 1 and empty search', () => {
+            mountComponent({ provider: PROVIDER }, {});
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: '' });
+        });
+
+        it('uses the page from the route query', () => {
+            mountComponent({ provider: PROVIDER }, { page: 3 });
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 3, searchQuery: '' });
+        });
+
+        it('does not re-dispatch an already-matched provider', () => {
+            mountComponent({ provider: PROVIDER }, { page: 1 });
+            expect(mockStore.dispatch).not.toHaveBeenCalledWith(PROVIDER_SELECTED, PROVIDER);
         });
     });
 
     describe('repos', () => {
-        beforeEach(() => {
-            getLocalVue({
-                params: {
-                    provider: mockStore.state.provider.selected
-                },
-                query: {
-                    page: 1
-                }
-            });
+        beforeEach(() => mountComponent({ provider: PROVIDER }, { page: 1 }));
+
+        it('renders the selection page wrapper', () => {
+            expect(wrapper.findComponent(TdSelectionPage).exists()).toBe(true);
         });
 
-        it('displays the repositories', () => {
-            expect(wrapper.findComponent(TdSelectionPage).exists()).toEqual(true);
-        });
-
-        it('displays the translated text', () => {
+        it('shows translated header text', () => {
             expect(wrapper.findComponent(TdSelectionPage).text()).toContain('repository.select');
         });
 
-        it('updates the search query from the selection page filter event', async () => {
+        it('updates searchQuery on filter emit from child', async () => {
             wrapper.findComponent(TdSelectionPage).vm.$emit('update:filter', 'threat-dragon');
             await wrapper.vm.$nextTick();
-            expect(wrapper.vm.searchQuery).toEqual('threat-dragon');
+            expect(wrapper.vm.searchQuery).toBe('threat-dragon');
+        });
+
+        it('forwards pagination state as props', () => {
+            const sel = wrapper.findComponent(TdSelectionPage);
+            expect(sel.props('page')).toBe(mockStore.state.repo.page);
+            expect(sel.props('pageNext')).toBe(mockStore.state.repo.pageNext);
+            expect(sel.props('pagePrev')).toBe(mockStore.state.repo.pagePrev);
+        });
+
+        it('passes method references as callback props', () => {
+            const sel = wrapper.findComponent(TdSelectionPage);
+            expect(sel.props('paginate')).toBe(wrapper.vm.paginate);
+            expect(sel.props('onItemClick')).toBe(wrapper.vm.onRepoClick);
         });
     });
 
     describe('onRepoClick', () => {
         const repoName = 'fakeRepo';
-        const query = {
-            page: 1
-        };
-        let mockRoute;
+        const query = { page: 1 };
 
         beforeEach(() => {
-            mockRoute = {
-                provider: mockStore.state.provider.selected
-            };
-
-            getLocalVue({
-                params: mockRoute,
-                query
-            });
+            mountComponent({ provider: PROVIDER }, query);
             wrapper.vm.onRepoClick(repoName);
         });
 
-        it('sets the selected repo', () => {
+        it('dispatches the selected repo', () => {
             expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_SELECTED, repoName);
         });
 
-        it('navigates to the branch select page', () => {
-            mockRoute.repository = repoName;
-            expect(mockRouter.push).toHaveBeenCalledWith({ name: 'gitBranch', params: mockRoute,  query});
+        it('navigates to the branch page', () => {
+            expect(mockRouter.push).toHaveBeenCalledWith({
+                name: 'gitBranch',
+                params: { provider: PROVIDER, repository: repoName },
+                query,
+            });
+        });
+    });
+
+    describe('searchQuery watcher (500ms debounce)', () => {
+        beforeEach(() => {
+            mountComponent({ provider: PROVIDER }, { page: 3 });
+            mockStore.dispatch.mockClear();
+        });
+
+        it('fires fetch with page 1 after the timeout', async () => {
+            wrapper.vm.searchQuery = 'owasp';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(500);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: 'owasp' });
+        });
+
+        it('always uses page 1 regardless of current page', async () => {
+            wrapper.vm.searchQuery = 'test';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(500);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: 'test' });
+        });
+
+        it('does not fire before the timeout', async () => {
+            wrapper.vm.searchQuery = 'test';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(300);
+            expect(mockStore.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('debounces: only the last of rapid changes fires', async () => {
+            wrapper.vm.searchQuery = 'a';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(200);
+            wrapper.vm.searchQuery = 'ab';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(200);
+            wrapper.vm.searchQuery = 'abc';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(500);
+
+            expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: 'abc' });
+        });
+
+        it('cancels an earlier timeout when superseded', async () => {
+            wrapper.vm.searchQuery = 'first';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(400);
+            wrapper.vm.searchQuery = 'second';
+            await wrapper.vm.$nextTick();
+            await artificialDelay(500);
+
+            expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 1, searchQuery: 'second' });
+        });
+    });
+
+    describe('paginate', () => {
+        beforeEach(() => mountComponent({ provider: PROVIDER }, { page: 2 }));
+
+        it('dispatches fetch with given page and current search query', () => {
+            wrapper.vm.searchQuery = 'test-repo';
+            wrapper.vm.paginate(2);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 2, searchQuery: 'test-repo' });
+        });
+
+        it('sends empty search when no filter is active', () => {
+            wrapper.vm.searchQuery = '';
+            wrapper.vm.paginate(3);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 3, searchQuery: '' });
+        });
+
+        it('preserves the current filter when paginating', () => {
+            wrapper.vm.searchQuery = 'owasp';
+            wrapper.vm.paginate(4);
+            expect(mockStore.dispatch).toHaveBeenCalledWith(REPOSITORY_FETCH, { page: 4, searchQuery: 'owasp' });
         });
     });
 });

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -12,6 +12,30 @@ console.log('Server API protocol: ' + serverApiProtocol + ' and port: ' + server
 // Check if TLS credentials are available in the environment file
 const hasTlsCredentials = process.env.APP_USE_TLS && process.env.APP_TLS_CERT_PATH && process.env.APP_TLS_KEY_PATH && process.env.APP_HOSTNAME;
 let port;
+
+// Shared proxy configuration with request/response logging for visual debug
+const timestamp = () => new Date().toISOString();
+const proxyConfig = {
+    '^/api': {
+        target: `${serverApiProtocol}://localhost:${serverApiPort}`,
+        ws: true,
+        changeOrigin: true,
+        logLevel: 'debug',
+        onProxyReq: (proxyReq, req) => {
+            console.log(`[proxy:req] ${timestamp()} ${req.method} ${req.url} -> target ${proxyReq.path}`);
+            if (req.body) {
+                console.log(`[proxy:req:body] ${timestamp()} ${req.method} ${req.url}`, JSON.stringify(req.body));
+            }
+        },
+        onProxyRes: (proxyRes, req) => {
+            console.log(`[proxy:res] ${timestamp()} ${req.method} ${req.url} <- status ${proxyRes.statusCode}`);
+        },
+        onError: (err, req) => {
+            console.error(`[proxy:error] ${timestamp()} ${req.method} ${req.url} - ${err.code || err.message}`);
+        },
+    },
+};
+
 // Configure dev server to use HTTPS with env.port if TLS credentials are available, otherwise use HTTP with port 8080
 const devServerConfig = hasTlsCredentials
     ? {
@@ -20,25 +44,13 @@ const devServerConfig = hasTlsCredentials
             cert: fs.readFileSync(process.env.APP_TLS_CERT_PATH),
         },
         port: PORT,
-        proxy: {
-            '^/api': {
-                target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server
-                ws: true, // Proxy WebSocket connections
-                changeOrigin: true,
-            },
-        },
+        proxy: proxyConfig,
         allowedHosts: [appHostname],
     }
     : {
         // note that client webSocketURL config has been removed, as it was incompatible with desktop version
         port: 8080,
-        proxy: {
-            '^/api': {
-                target: `${serverApiProtocol}://localhost:${serverApiPort}`, // Backend server
-                ws: true, // Proxy WebSocket connections
-                changeOrigin: true,
-            },
-        },
+        proxy: proxyConfig,
         allowedHosts: [appHostname],
     };
 port = devServerConfig.port;


### PR DESCRIPTION
**Summary**:  
Closes #1650

Store dispatch signatures for BRANCH_FETCH and REPOSITORY_FETCH accepted page as a positional argument, but callers sometimes passed a second positional searchQuery that was silently ignored. The page prop watcher was also missing from SelectionPage.vue, so pagination buttons used a stale pageRef that never synced with the store. This caused GitHub repository pagination to always return the same first page of repos.

I've added E2E tests by means of a mocked backend and the upgrade of cypress. I've tested locally with
`cd td.vue && npx vue-cli-service test:e2e -C e2e.local.config.js --browser firefox --headless` all tests are passing. Goes without saying that it all needs your eyes and that I'm happy to refactor as required.

**Description for the changelog**:  
Fix GitHub pagination by normalizing store dispatch signatures to use object payloads and adding a missing page watcher on the selection page component

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[DeepSeek]`
  - LLMs and versions: `[DeepSeek]`
  - Prompts: `[Too long to mention]`

**Other info**:  
Given I have not 800 repositories, I used mocked repos responses.

Filtering by search query needs work across pages, but that was not the bug.
