### PR TITLE
fix: remove Docker from e2e_tests job in push.yaml - port conflict wi…

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -376,19 +376,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run Threat Dragon
-        run: |
-          docker run -d \
-            -p 3000:3000 \
-            -e GITHUB_CLIENT_ID='${{ secrets.CI_GITHUB_CLIENT_ID }}' \
-            -e GITHUB_CLIENT_SECRET='${{ secrets.CI_GITHUB_CLIENT_SECRET }}' \
-            -e ENCRYPTION_JWT_REFRESH_SIGNING_KEY='${{ secrets.CI_JWT_REFRESH_SIGNING_KEY }}' \
-            -e ENCRYPTION_JWT_SIGNING_KEY='${{ secrets.CI_JWT_SIGNING_KEY }}' \
-            -e ENCRYPTION_KEYS='${{ secrets.CI_SESSION_ENCRYPTION_KEYS }}' \
-            -e NODE_ENV='development' \
-            -e SERVER_API_PROTOCOL='http' \
-            ${{ env.IMAGE_NAME }}
-
       - name: Use node LTS 24.15
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -405,6 +392,9 @@ jobs:
 
       - name: Install clean packages
         run: npm clean-install
+
+      - name: Build and run locally
+        run: npm run start:serve
 
       - name: Run e2e tests
         run: npm run test:e2e-ci


### PR DESCRIPTION
**Summary**:  

Removes Docker container from  `push.yaml`, `e2e_tests` job to fix port conflict with mock server. The Docker container binds to port 3000, blocking the mock server (e2e.ci.config.js) from starting on the same port (EADDRINUSE). Replace with the vue dev server (npm run start:serve) on port 8080, which proxies API calls to the mock on port 3000 — matching the pattern already used in pull_request.yaml.

**Description for the changelog**: 

Fix EADDRINUSE in push pipeline e2e tests by removing Docker container and using vue dev server with mock

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [ ] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  
Testing... otherwise have to install chromium locally