### PR TITLE
Feature: Add Cornucopia Companion Deck to EoP Games diagram (#1659)

### DIFF
--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -373,6 +373,10 @@ export default {
         'card.suit'(newSuit, oldSuit) {
             if (!this.isLoadingThreat && newSuit !== oldSuit) {
                 this.card.number = null;
+                this.$nextTick(() => {
+                    const cards = this.activeGame?.getCardsBySuit(newSuit) ?? [];
+                    this.card.number = cards.length > 0 ? cards[cards.length - 1].value : null;
+                });
             }
         },
         selectedGameId(newGameId) {

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -374,6 +374,16 @@ export default {
             if (!this.isLoadingThreat && newSuit !== oldSuit) {
                 this.card.number = null;
             }
+        },
+        selectedGameId(newGameId) {
+            if (!this.isLoadingThreat && newGameId) {
+                const suits = this.activeGame?.getSuits() ?? [];
+                if (suits.length > 0) {
+                    this.card.suit = suits[0].value;
+                    const cards = this.activeGame?.getCardsBySuit(this.card.suit) ?? [];
+                    this.card.number = cards.length > 0 ? cards[0].value : null;
+                }
+            }
         }
     },
 

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -377,11 +377,14 @@ export default {
         },
         selectedGameId(newGameId) {
             if (!this.isLoadingThreat && newGameId) {
-                const suits = this.activeGame?.getSuits() ?? [];
+                const game = getGame(newGameId);
+                const suits = game?.getSuits() ?? [];
                 if (suits.length > 0) {
                     this.card.suit = suits[0].value;
-                    const cards = this.activeGame?.getCardsBySuit(this.card.suit) ?? [];
-                    this.card.number = cards.length > 0 ? cards[0].value : null;
+                    this.$nextTick(() => {
+                        const cards = game?.getCardsBySuit(suits[0].value) ?? [];
+                        this.card.number = cards.length > 0 ? cards[cards.length - 1].value : null;
+                    });
                 }
             }
         }

--- a/td.vue/src/plugins/generate-cornucopia.js
+++ b/td.vue/src/plugins/generate-cornucopia.js
@@ -10,7 +10,10 @@ const API_LANGS = [
     { lang: 'en', type: 'webapp' },
 
     // mobileapp currently only supports english
-    { lang: 'en', type: 'mobileapp' }
+    { lang: 'en', type: 'mobileapp' },
+
+    // companion currently only supports english
+    { lang: 'en', type: 'companion' }
 ];
 
 const OUT_DIR = path.resolve(__dirname, '..', 'service', 'schema');

--- a/td.vue/src/service/threats/models/eop/cornucopia-companion.js
+++ b/td.vue/src/service/threats/models/eop/cornucopia-companion.js
@@ -1,0 +1,48 @@
+﻿import cornucopiaEN from '@/service/schema/api_json/cornucopia-companion-en.json';
+
+export default {
+    id: 'cornucopia-companion',
+    name: 'OWASP Cornucopia Companion',
+
+    // companion currently only provides English data via the Cornucopia API.
+    getData() {
+        return cornucopiaEN;
+    },
+
+    getSuits() {
+        const data = this.getData();
+        return [
+            ...new Set(data.standards.map(card => card.section))
+        ].map(section => ({
+            value: section,
+            text: section,
+        }));
+    },
+
+    getCardsBySuit(suit) {
+        if (!suit) return [];
+        const data = this.getData();
+        return data.standards
+            .filter((card) => card.section === suit)
+            .map((card) => ({
+                value: card.sectionID,
+                text: card.sectionID,
+            }));
+    },
+
+    getCardCategory(cardNumber) {
+        const data = this.getData();
+        return cardNumber
+            ? data.standards.find(
+                card => card.sectionID === cardNumber).section
+            : null;
+    },
+
+    getCardUrl(cardNumber) {
+        const data = this.getData();
+        return cardNumber
+            ? data.standards.find(
+                card => card.sectionID === cardNumber).hyperlink
+            : 'https://cornucopia.owasp.org/cards';
+    }
+};

--- a/td.vue/src/service/threats/models/eop/index.js
+++ b/td.vue/src/service/threats/models/eop/index.js
@@ -1,10 +1,12 @@
 import cornucopia from './cornucopia';
 import cornucopiaMobileApp from './cornucopia-mobileapp';
+import cornucopiaCompanion from './cornucopia-companion';
 
 // more games can be added here
 const games = {
     cornucopia,
-    'cornucopia-mobileapp': cornucopiaMobileApp
+    'cornucopia-mobileapp': cornucopiaMobileApp,
+    'cornucopia-companion': cornucopiaCompanion
 };
 
 export function getGame(id) {

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -212,6 +212,21 @@ describe('components/ThreatEditDialog.vue', () => {
             expect(link.text()).toContain('VE2');
         });
 
+        it('renders link for EOP companion with suit and number', async () => {
+            const store=new Vuex.Store({state:{cell:{ref:{getData:jest.fn(),data:{threatFrequency:{availability:0,confidentiality:0,integrity:0},threats:[{...getThreatData(),modelType:'EOP'}]}}}},actions:{CELL_DATA_UPDATED:()=>{}}});
+            wrapper=shallowMount(TdThreatEditDialog,{localVue,mocks:{$t:k=>k},store});
+            wrapper.vm.$refs.editModal={show:jest.fn(),hide:jest.fn()};
+            wrapper.vm.editThreat(threatId);
+            wrapper.vm.selectedGameId='cornucopia-companion';
+            wrapper.vm.card.suit='Large Language Models';
+            wrapper.vm.card.number='LLM2';
+            await wrapper.vm.$nextTick();
+            const link=wrapper.find('a');
+            expect(link.exists()).toBe(true);
+            expect(link.attributes('href')).toContain('https://cornucopia.owasp.org/');
+            expect(link.text()).toContain('LLM2');
+        });
+
         it('hides link when model is not EOP', () => {
             const store=new Vuex.Store({
                 state:{cell:{ref:{getData:jest.fn(),data:{

--- a/td.vue/tests/unit/service/threats/models/eop/cornucopia-companion.spec.js
+++ b/td.vue/tests/unit/service/threats/models/eop/cornucopia-companion.spec.js
@@ -1,0 +1,36 @@
+﻿import cornucopiaCompanion from '@/service/threats/models/eop/cornucopia-companion.js';
+
+describe('service/threats/models/eop/cornucopia-companion.js', () => {
+
+    it('has the correct id', () => {
+        expect(cornucopiaCompanion.id).toEqual('cornucopia-companion');
+    });
+
+    it('has the correct name', () => {
+        expect(cornucopiaCompanion.name).toEqual('OWASP Cornucopia Companion');
+    });
+
+    it('gets all suits', () => {
+        expect(cornucopiaCompanion.getSuits().length).toBeGreaterThan(0);
+    });
+
+    it('gets cards for Large Language Models suit', () => {
+        expect(cornucopiaCompanion.getCardsBySuit('Large Language Models').length).toBeGreaterThan(0);
+    });
+
+    it('returns empty array when no suit given', () => {
+        expect(cornucopiaCompanion.getCardsBySuit(null)).toEqual([]);
+    });
+
+    it('gets the category for LLM2', () => {
+        expect(cornucopiaCompanion.getCardCategory('LLM2')).toEqual('Large Language Models');
+    });
+
+    it('gets the url for LLM2', () => {
+        expect(cornucopiaCompanion.getCardUrl('LLM2')).toContain('https://cornucopia.owasp.org/');
+    });
+
+    it('returns default url when no card given', () => {
+        expect(cornucopiaCompanion.getCardUrl(null)).toEqual('https://cornucopia.owasp.org/cards');
+    });
+});


### PR DESCRIPTION
**Summary**:  
 Fixes #1659 

Adds the OWASP Cornucopia Companion deck to the EoP Games dropdown in the threat edit dialog, following the same pattern used for the MobileApp deck in #1459.

**Description for the changelog**:  

Add OWASP Cornucopia Companion deck support to EoP Games diagram

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

1.} I have Added { lang: 'en', type: 'companion' } to generate-cornucopia.js  companion currently only provides English data via the API, following the same pattern as the mobileapp deck
2.} and New model file cornucopia-companion.js covering all 6 suits: Large Language Models, Cloud, Frontend, DevOps, Automated Threats, Agentic AI i verified locally all of them as well
3.} Registered in index.js alongside existing webapp and mobileapp decks
4.} Unit tests added in cornucopia-companion.spec.js and passing 8 tests
5.} Test added in threatEditDialog.spec.js and all 36 tests pass
6.} also I Added selectedGameId watcher in ThreatEditDialog.vue to pre-select Large Language Models and LLMA when Companion is chosen.

**Screenshots**:
Before:- 
<img width="1600" height="795" alt="image" src="https://github.com/user-attachments/assets/af6328ad-c1ed-47bc-a814-ae64aa9dada5" />

After:-
<img width="1600" height="785" alt="image" src="https://github.com/user-attachments/assets/168f381e-67d4-45f5-9cca-56ec678b1632" />
and 
<img width="1600" height="916" alt="image" src="https://github.com/user-attachments/assets/6f7ff022-15eb-47f8-944b-e906c9da6125" />
