### PR TITLE
Chore: config update for stale workflow handling

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -5,9 +5,6 @@ on:
     - cron: '45 6 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 env:
   IMAGE_NAME: threatdragon/owasp-threat-dragon:latest
 
@@ -18,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: write
+      contents: read
     steps:
       - name: Delete stale workflow runs
         uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7 # v2.1.0
@@ -31,6 +29,10 @@ jobs:
         uses: otto-de/purge-deprecated-workflow-runs@4781dc30eb7236b195e896b9a26b14296341b63a # v4.0.10
         with:
           token: ${{ github.token }}
+          remove-obsolete: true
+          remove-failed: true
+          remove-older-than: 2w2w *
+          remove-skipped: true
 
   stale:
     name: Tidy pull requests


### PR DESCRIPTION
**Summary**:  

The workflows were not being deleted from end/mid April onwards, so this is an attempt to make sure the do get deleted

**Description for the changelog**:  

config update for stale workflow handling

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [NA] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
