### PR TITLE
Supply Chain: enforce minimum release age

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -256,8 +256,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install clean packages
-        # TODO: remove --legacy-peer-deps after the Vue 3 migration
-        run: npm clean-install --legacy-peer-deps
+        run: npm clean-install
 
       - name: Build Linux desktop app
         run: npm run build:desktop -- --linux AppImage --x64 --publish never

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -295,8 +295,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install clean packages
-        # TODO: remove --legacy-peer-deps after the Vue 3 migration
-        run: npm clean-install --legacy-peer-deps
+        run: npm clean-install
 
       - name: Build Linux desktop app
         run: npm run build:desktop -- --linux AppImage --x64 --publish never

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !.markdownlint.yaml
 !.wordlist.txt
 !.spellcheck.yaml
+!.npmrc
 !CNAME
 
 # docker files
@@ -108,6 +109,7 @@
 !td.server/test/repositories/
 !td.server/test/repositories/*.spec.js
 !td.server/.babelrc
+!td.server/.npmrc
 !td.server/.eslintrc.js
 !td.server/README.md
 !td.server/dev.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=10

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -28,6 +28,7 @@ CN
 CMS
 CodeQL
 Config
+cooldowns
 cron
 CVE
 CVEs

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG         NODE_VERSION=24.15.0
 FROM        node:$NODE_VERSION-alpine AS base-node
 RUN         apk -U upgrade
 WORKDIR     /app
-RUN         npm i -g npm@latest
+COPY        .npmrc /app/.npmrc
+RUN         NPM_CONFIG_USERCONFIG=/app/.npmrc npm i -g npm@latest
 RUN         chown -R node:node /app
 USER        node
 
@@ -15,8 +16,8 @@ FROM        base-node AS build
 RUN         mkdir -p boms td.server td.vue td.vue/src/service/schema/api_json
 
 COPY        package-lock.json package.json /app/
-COPY        ./td.server/package-lock.json ./td.server/package.json ./td.server/
-COPY        ./td.vue/package-lock.json ./td.vue/package.json ./td.vue/
+COPY        ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
+COPY        ./td.vue/.npmrc ./td.vue/package-lock.json ./td.vue/package.json ./td.vue/
 
 COPY        ./td.server/.babelrc ./td.server/
 COPY        ./td.server/src/ ./td.server/src/
@@ -26,8 +27,7 @@ COPY        ./td.vue/*.config.js ./td.vue/
 
 RUN         npm clean-install --ignore-scripts
 RUN         cd td.server && npm clean-install
-# TODO: Remove --legacy-peer-deps when Vue3 migration is complete
-RUN         cd td.vue && npm clean-install --legacy-peer-deps
+RUN         cd td.vue && npm clean-install
 RUN         npm run build
 RUN         cd td.server && npm run make-sbom
 RUN         cp td.server/sbom.json        boms/threat-dragon-server-bom.json && \
@@ -54,7 +54,7 @@ FROM        base-node
 COPY        --chown=node:node --from=build-docs /td.docs/_site /app/docs
 COPY        --chown=node:node --from=build /app/boms /app/boms
 
-COPY        --chown=node:node ./td.server/package-lock.json ./td.server/package.json ./td.server/
+COPY        --chown=node:node ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
 RUN         cd td.server && npm clean-install --omit dev --ignore-scripts
 COPY        --chown=node:node --from=build /app/td.server/dist ./td.server/dist
 COPY        --chown=node:node --from=build /app/td.vue/dist ./dist

--- a/docs/trust/dependencies.md
+++ b/docs/trust/dependencies.md
@@ -13,7 +13,8 @@ The following controls are in place to assist with dependency management of the 
 - Trivy scanning per commit for SCA and OS dependency management within docker
 - Trivy scanning daily on the latest build in the default branch
 - Dependabot alerts
-- `npm` for dependency resolution and auditing
+- Dependabot cooldowns and `npm` minimum release age set to 10 days
+- `npm` version 11.10.0 or higher is required for dependency resolution, minimum release age, and auditing
 
 ### Fixing a vulnerable dependency
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "baseline-browser-mapping": "^2.10.30",
         "npm-run-all2": "^8.0.4",
         "rimraf": "^6.1.3"
+      },
+      "engines": {
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,16 @@
     "url": "https://owasp.org/www-project-threat-dragon/"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "npm": ">=11.10.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.10.0",
+      "onFail": "error"
+    }
+  },
   "homepage": "https://owasp.org/www-project-threat-dragon/",
   "repository": {
     "type": "git",

--- a/td.server/.npmrc
+++ b/td.server/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=10

--- a/td.server/package-lock.json
+++ b/td.server/package-lock.json
@@ -47,6 +47,9 @@
         "sinon": "^10.0.0",
         "sinon-chai": "^3.7.0",
         "supertest": "^4.0.2"
+      },
+      "engines": {
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/td.server/package.json
+++ b/td.server/package.json
@@ -27,6 +27,16 @@
     "url": "https://owasp.org/www-project-threat-dragon/"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "npm": ">=11.10.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.10.0",
+      "onFail": "error"
+    }
+  },
   "homepage": "https://github.com/OWASP/www-project-threat-dragon/",
   "repository": {
     "type": "git",

--- a/td.vue/.npmrc
+++ b/td.vue/.npmrc
@@ -1,3 +1,5 @@
+min-release-age=10
+
 # TODO: Remove this file once Vue 3 migration build is no longer in use.
 # Required while Vue 3 migration build is in use: some dependencies still declare Vue 2 peer.
 legacy-peer-deps=true

--- a/td.vue/package-lock.json
+++ b/td.vue/package-lock.json
@@ -104,6 +104,9 @@
         "webdriverio": "^8.3.3",
         "webpack": "^5.106.2"
       },
+      "engines": {
+        "npm": ">=11.10.0"
+      },
       "optionalDependencies": {
         "dmg-license": "^1.0.11"
       }

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -52,6 +52,16 @@
     "url": "https://owasp.org/www-project-threat-dragon/"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "npm": ">=11.10.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.10.0",
+      "onFail": "error"
+    }
+  },
   "homepage": "https://owasp.org/www-project-threat-dragon/",
   "buildState": "-latest",
   "repository": {


### PR DESCRIPTION
**Summary**:  

Closes #1673 

- Add / update `.npmrc` files to include a minimum release age of 10 days for root, td.vue, and td.server
- Remove hard-coded `--legacy-peer-deps` in favor of `.npmrc`
- Requires npm version >= 11.10.0 to ensure the minimum release age flag works
- Update docs to include the minimum release age setting and npm version floor
- Update Dockerfile to use `.npmrc` files, including the `npm i -g npm@latest`, this was one of the remaining supply-chain gaps

**Description for the changelog**:  

chore: enforce a minimum release age of 10 days for all npm dependencies

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

There is another supply chain gap that I want to address, but I prefer having a separate issue/PR for it: we are relying on tags for our Dockerfile base image. Tags are mutable, and Dockerfile supports and recommends pinning by sha256. Dependabot supports the Docker ecosystem. 

The reason I am leaving that out of scope is for node version drift. We would have to be careful to update all of the NODE_VERSION flags every time a Dockerfile base image is updated. I also want to make sure that the cooldown works as expected, _and_ that it supports the version comments the same way we manage github actions.  This could be automated as well.

I opted out of a `.node-version` implementation for now, but am happy to reconsider. My concern is that if we pin the node-version too hard, it becomes more difficult to contribute. I think enforcing a strict node version for the build and deploys makes sense, but we are already doing that. I don't think pinning the node version adds enough value to justify forcing node version management into the developer experience. (feel free to disagree!)

I also did not use `engine-strict=true` because td.vue depends on `@achrinza/node-ipc@9.2.2`, which only declares node version support through v17 :woozy_face: The engine-strict flag causes the install to fail. Hopefully we can revisit that after the vue3 migration is complete.