### PR TITLE
Force Dependabot PRs to use package.json overrides

### DIFF
--- a/.github/workflows/dependabot-force-package-json-overrides.yaml
+++ b/.github/workflows/dependabot-force-package-json-overrides.yaml
@@ -1,0 +1,22 @@
+name: Dependabot - Force package.json overrides
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  overrides:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: lreading/dependabot-npm-force-overrides@9565f45fa8f140a7d52ce1c34af0c71adfec0ee2 # v1.0.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/dependabot-force-package-json-overrides.yaml
+++ b/.github/workflows/dependabot-force-package-json-overrides.yaml
@@ -1,22 +1,25 @@
 name: Dependabot - Force package.json overrides
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   overrides:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: lreading/dependabot-npm-force-overrides@9565f45fa8f140a7d52ce1c34af0c71adfec0ee2 # v1.0.0
+      - uses: lreading/dependabot-npm-force-overrides@a1c38a755edfdbaf02080e62069ba188773bd5bd # v1.0.1
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
**Summary**:  

Dependabot will sometimes open a PR with only a package-lock.json update.
While this may be technically correct, lockfiles are often regenerated, and we risk losing the update.
Using package.json level overrides is the better option for Threat Dragon.

Currently, this is a manual task for maintainers. It doesn't have to be.
I'm experimenting with an action that will react to new PRs from dependabot, and if only the package-lock.json file is updated, it will ensure the correct override is in place in the corresponding package.json file.

I only build this today and am testing it in at least one other repo, but I wanted to see if there's appetite to test it here as well?

**Description for the changelog**:  

chore: force dependabot to use package.json overrides

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

The AI disclaimer is somewhere in the middle. I most definitely used a _lot_ of AI to create the new action, but _this_ PR was done by hand.  The action was created using Codex/GPT-5.5

[Marketplace Listing](https://github.com/marketplace/actions/dependabot-npm-force-overrides)
[Action Source Code](https://github.com/lreading/dependabot-npm-force-overrides)
[Example Dependabot PR Update](https://github.com/lreading/test-dependabot-npm-force-overrides/pull/1)

In the example, note the order of the commits:
1. Dependabot opened the PR and only updated the package-lock.json file
2. The _action_ made a second commit to add the override entry with a minimum version


I won't be offended if we don't want to add this action! I think it might save us a few minutes every week when dealing with a Dependabot update.