### PR TITLE
De-bootstrap Navbar

### DIFF
--- a/td.vue/src/components/Navbar.vue
+++ b/td.vue/src/components/Navbar.vue
@@ -1,57 +1,78 @@
 <template>
-  <b-navbar toggleable="lg" fixed="top" id="navbar">
-    <b-navbar-brand :to="username ? '/dashboard' : '/'" class="td-brand">
-      <b-img src="@/assets/threatdragon_logo_image.svg" class="td-brand-img" alt="Threat Dragon Logo" />
+  <nav id="navbar" class="navbar navbar-expand-lg navbar-light fixed-top">
+    <router-link :to="username ? '/dashboard' : '/'" class="navbar-brand td-brand">
+      <img :src="threatDragonLogo" class="td-brand-img" alt="Threat Dragon Logo" />
       Threat Dragon v{{ this.$store.state.packageBuildVersion }}{{ this.$store.state.packageBuildState }}
-    </b-navbar-brand>
+    </router-link>
 
-    <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
-    <b-collapse id="nav-collapse" is-nav>
-      <b-navbar-nav>
-        <b-nav-item>
-          <td-locale-select />
-        </b-nav-item>
-      </b-navbar-nav>
+    <button
+      class="navbar-toggler"
+      type="button"
+      aria-controls="nav-collapse"
+      :aria-expanded="isNavExpanded.toString()"
+      aria-label="Toggle navigation"
+      @click="toggleNav"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
 
-      <b-navbar-nav class="ml-auto">
-        <b-nav-text v-show="username" class="logged-in-as">{{ $t('nav.loggedInAs') }} {{ username }}</b-nav-text>
-        <b-nav-item v-show="username" @click="onLogOut" id="nav-sign-out">
-          <font-awesome-icon icon="sign-out-alt" class="td-fa-nav" v-b-tooltip.hover
-            :title="$t('nav.logOut')"></font-awesome-icon>
-        </b-nav-item>
+    <div id="nav-collapse" class="navbar-collapse collapse" :class="{ show: isNavExpanded }">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="#" @click.prevent>
+            <td-locale-select />
+          </a>
+        </li>
+      </ul>
+
+      <ul class="navbar-nav ml-auto">
+        <li v-show="username" class="navbar-text logged-in-as">{{ $t('nav.loggedInAs') }} {{ username }}</li>
+        <li v-show="username" class="nav-item" id="nav-sign-out">
+          <a class="nav-link" href="#" @click="onLogOut">
+            <font-awesome-icon icon="sign-out-alt" class="td-fa-nav" v-b-tooltip.hover
+              :title="$t('nav.logOut')"></font-awesome-icon>
+          </a>
+        </li>
         <!-- This is the dropdown from admin actions(manage templates) -->
         <li v-if="isAdmin" class="nav-item td-admin-nav-dropdown">
           <td-dropdown id="my-nav-dropdown" class="nav-link-custom" variant="link" right no-caret>
-          <template #button-content>
-            <font-awesome-icon icon="cog" class="td-fa-nav text-white" v-b-tooltip.hover
-              :title="$t('nav.contentManagement')" />
-          </template>
+            <template #button-content>
+              <font-awesome-icon icon="cog" class="td-fa-nav text-white" v-b-tooltip.hover
+                :title="$t('nav.contentManagement')" />
+            </template>
 
-          <template #default="{ close }">
-            <button type="button" class="td-dropdown-item" @click="onManageTemplates(); close()">
-              Manage Templates
-            </button>
-          </template>
+            <template #default="{ close }">
+              <button type="button" class="td-dropdown-item" @click="onManageTemplates(); close()">
+                Manage Templates
+              </button>
+            </template>
           </td-dropdown>
         </li>
 
-
-        <b-nav-item href="https://www.threatdragon.com/docs/" target="_blank" rel="noopener noreferrer" id="nav-docs">
-          <font-awesome-icon icon="question-circle" class="td-fa-nav" v-b-tooltip.hover
-            :title="$t('desktop.help.docs')"></font-awesome-icon>
-        </b-nav-item>
-        <b-nav-item href="https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html"
-          target="_blank" rel="noopener noreferrer" id="nav-tm-cheat-sheet">
-          <font-awesome-icon icon="gift" class="td-fa-nav" v-b-tooltip.hover
-            :title="$t('desktop.help.sheets')"></font-awesome-icon>
-        </b-nav-item>
-        <b-nav-item href="https://owasp.org/www-project-threat-dragon/" target="_blank" rel="noopener noreferrer"
-          id="nav-owasp-td">
-          <b-img src="@/assets/owasp.svg" class="td-fa-nav td-owasp-logo" :title="$t('desktop.help.visit')" />
-        </b-nav-item>
-      </b-navbar-nav>
-    </b-collapse>
-  </b-navbar>
+        <li class="nav-item" id="nav-docs">
+          <a class="nav-link" href="https://www.threatdragon.com/docs/" target="_blank" rel="noopener noreferrer">
+            <font-awesome-icon icon="question-circle" class="td-fa-nav" v-b-tooltip.hover
+              :title="$t('desktop.help.docs')"></font-awesome-icon>
+          </a>
+        </li>
+        <li class="nav-item" id="nav-tm-cheat-sheet">
+          <a class="nav-link"
+            href="https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html"
+            target="_blank" rel="noopener noreferrer">
+            <font-awesome-icon icon="gift" class="td-fa-nav" v-b-tooltip.hover
+              :title="$t('desktop.help.sheets')"></font-awesome-icon>
+          </a>
+        </li>
+        <li class="nav-item" id="nav-owasp-td">
+          <a class="nav-link" href="https://owasp.org/www-project-threat-dragon/" target="_blank"
+            rel="noopener noreferrer">
+            <img :src="owaspLogo" class="td-fa-nav td-owasp-logo" :title="$t('desktop.help.visit')"
+              alt="OWASP Threat Dragon" />
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </template>
 
 <style lang="scss" scoped>
@@ -129,6 +150,8 @@ $icon-height: 1.2rem;
 <script>
 import { mapGetters } from 'vuex';
 
+import threatDragonLogo from '@/assets/threatdragon_logo_image.svg';
+import owaspLogo from '@/assets/owasp.svg';
 import { LOGOUT } from '@/store/actions/auth.js';
 import TdDropdown from './Dropdown.vue';
 import TdLocaleSelect from './LocaleSelect.vue';
@@ -139,6 +162,13 @@ export default {
         TdDropdown,
         TdLocaleSelect
     },
+    data() {
+        return {
+            isNavExpanded: false,
+            owaspLogo,
+            threatDragonLogo
+        };
+    },
     computed: {
         ...mapGetters([
             'username',
@@ -146,6 +176,9 @@ export default {
         ])
     },
     methods: {
+        toggleNav() {
+            this.isNavExpanded = !this.isNavExpanded;
+        },
         async onLogOut(evt) {
             evt.preventDefault();
             await Promise.resolve(this.$router.push('/')).catch(error => {

--- a/td.vue/src/plugins/vue-test-utils-compat.js
+++ b/td.vue/src/plugins/vue-test-utils-compat.js
@@ -202,7 +202,6 @@ const createBootstrapCompat = (name, tag = 'div') => defineComponent({
 const BootstrapButtonCompat = createClickableCompat('BButton');
 const BootstrapDropdownItemCompat = createClickableCompat('BDropdownItem');
 const BootstrapListGroupItemCompat = createClickableCompat('BListGroupItem', 'a');
-const BootstrapNavItemCompat = createClickableCompat('BNavItem', 'a');
 const BootstrapCardTextCompat = createBootstrapCompat('BCardText');
 const BootstrapModalCompat = createBootstrapCompat('BModal');
 const BootstrapFormInputCompat = createBootstrapCompat('BFormInput', 'input');
@@ -219,7 +218,6 @@ const bootstrapComponentStubs = {
     BFormTextarea: BootstrapFormTextareaCompat,
     BListGroupItem: BootstrapListGroupItemCompat,
     BModal: BootstrapModalCompat,
-    BNavItem: BootstrapNavItemCompat,
     BTable: BootstrapTableCompat
 };
 

--- a/td.vue/tests/unit/components/navbar.spec.js
+++ b/td.vue/tests/unit/components/navbar.spec.js
@@ -1,11 +1,3 @@
-import {
-    BootstrapVue,
-    BNavbarBrand,
-    BImg,
-    BCollapse,
-    BNavbarNav,
-    BNavItem
-} from 'bootstrap-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
@@ -13,17 +5,32 @@ import Vuex from 'vuex';
 import { LOGOUT } from '@/store/actions/auth.js';
 import Navbar from '@/components/Navbar.vue';
 
+jest.mock('@/assets/threatdragon_logo_image.svg', () => 'threatdragon_logo_image.svg');
+jest.mock('@/assets/owasp.svg', () => 'owasp.svg');
+
+const RouterLinkStub = {
+    name: 'RouterLink',
+    props: {
+        to: {
+            type: String,
+            required: true
+        }
+    },
+    template: '<a :href="\'#\' + to"><slot /></a>'
+};
+
 describe('components/Navbar.vue', () => {
     let wrapper, localVue, mockStore, routerMock;
 
     beforeEach(() => {
         localVue = createLocalVue();
-        localVue.use(BootstrapVue);
         localVue.component('font-awesome-icon', FontAwesomeIcon);
+        localVue.directive('b-tooltip', {});
         localVue.use(Vuex);
         routerMock = { push: jest.fn() };
         mockStore = new Vuex.Store({
             getters: {
+                isAdmin: () => false,
                 username: () => 'foobar'
             },
             dispatch: () => {}
@@ -34,6 +41,9 @@ describe('components/Navbar.vue', () => {
             mocks: {
                 $router: routerMock,
                 $t: key => key
+            },
+            stubs: {
+                RouterLink: RouterLinkStub
             }
         });
     });
@@ -42,22 +52,22 @@ describe('components/Navbar.vue', () => {
         let navbarBrand;
 
         beforeEach(() => {
-            navbarBrand = wrapper.findComponent(BNavbarBrand);
+            navbarBrand = wrapper.find('.navbar-brand');
         });
         it('renders the navbar-brand', () => {
             expect(navbarBrand.exists()).toBe(true);
         });
 
         it('routes to the dashboard page', () => {
-            expect(navbarBrand.attributes('to')).toEqual('/dashboard');
+            expect(navbarBrand.attributes('href')).toEqual('#/dashboard');
         });
 
         it('renders the brand image', () => {
-            expect(navbarBrand.findComponent(BImg).exists()).toBe(true);
+            expect(navbarBrand.find('img').exists()).toBe(true);
         });
 
         it('displays threatdragon_logo.svg', () => {
-            expect(navbarBrand.findComponent(BImg).attributes('src'))
+            expect(navbarBrand.find('img').attributes('src'))
                 .toContain('threatdragon_logo');
         });
     });
@@ -66,21 +76,25 @@ describe('components/Navbar.vue', () => {
         let collapse;
 
         beforeEach(() => {
-            collapse = wrapper.findComponent(BCollapse);
+            collapse = wrapper.find('#nav-collapse');
         });
 
-        it('renders the b-collapse', () => {
+        it('renders the collapse container', () => {
             expect(collapse.exists()).toBe(true);
+        });
+
+        it('toggles the nav collapse', async () => {
+            expect(collapse.classes()).not.toContain('show');
+            await wrapper.find('.navbar-toggler').trigger('click');
+            expect(collapse.classes()).toContain('show');
         });
     });
 
     describe('nav', () => {
-        let nav,
-            navItems;
+        let nav;
 
         beforeEach(() => {
-            nav = wrapper.findComponent(BNavbarNav);
-            navItems = wrapper.findAllComponents(BNavItem);
+            nav = wrapper.find('ul.navbar-nav');
         });
 
         it('renders the nav', () => {
@@ -91,9 +105,7 @@ describe('components/Navbar.vue', () => {
             let signOut;
 
             beforeEach(() => {
-                signOut = navItems
-                    .filter(x => x.attributes('id') === 'nav-sign-out')
-                    .at(0);
+                signOut = wrapper.find('#nav-sign-out');
                 mockStore.dispatch = jest.fn();
             });
 
@@ -107,12 +119,12 @@ describe('components/Navbar.vue', () => {
             });
 
             it('dispatches the logout event', async () => {
-                await signOut.trigger('click');
+                await signOut.find('a').trigger('click');
                 expect(mockStore.dispatch).toHaveBeenCalledWith(LOGOUT);
             });
 
             it('navigates to the home page', async () => {
-                await signOut.trigger('click');
+                await signOut.find('a').trigger('click');
                 expect(routerMock.push).toHaveBeenCalledWith('/');
             });
         });
@@ -121,9 +133,7 @@ describe('components/Navbar.vue', () => {
             let docs;
 
             beforeEach(() => {
-                docs = navItems
-                    .filter(x => x.attributes('id') === 'nav-docs')
-                    .at(0);
+                docs = wrapper.find('#nav-docs');
             });
 
             it('uses fa question-circle', () => {
@@ -136,9 +146,7 @@ describe('components/Navbar.vue', () => {
             let cheatSheet;
 
             beforeEach(() => {
-                cheatSheet = navItems
-                    .filter(x => x.attributes('id') === 'nav-tm-cheat-sheet')
-                    .at(0);
+                cheatSheet = wrapper.find('#nav-tm-cheat-sheet');
             });
 
             it('uses fa gift', () => {
@@ -151,13 +159,11 @@ describe('components/Navbar.vue', () => {
             let tdOwasp;
 
             beforeEach(() => {
-                tdOwasp = navItems
-                    .filter(x => x.attributes('id') === 'nav-owasp-td')
-                    .at(0);
+                tdOwasp = wrapper.find('#nav-owasp-td');
             });
 
             it('uses the OWASP image', () => {
-                expect(tdOwasp.findComponent(BImg).attributes('src'))
+                expect(tdOwasp.find('img').attributes('src'))
                     .toContain('owasp');
             });
         });


### PR DESCRIPTION
**Summary**:  

Removes the native Boostrap navbar and navbar adjacent components.
Relates to #1080 

**Description for the changelog**:  

chore: replace bootstrap navbar with custom component

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Reference issue 1080 and replace bootstrap's b-navbar component and other related nav components with a custom component. Do not replace components 1:1 - only create a component if helpful for developer experience or reusability`

**Other info**:  

With Bootstrap (live):
<img width="2505" height="1038" alt="image" src="https://github.com/user-attachments/assets/d9ddcff9-38f3-4fd7-8230-3d06797561b7" />

After:
<img width="2500" height="981" alt="image" src="https://github.com/user-attachments/assets/6a79816a-d6be-4aa6-817e-37c9f40e59b6" />
