### PR TITLE
De-bootstrapification: b-img / b-img-lazy

### DIFF
--- a/td.vue/src/components/Image.vue
+++ b/td.vue/src/components/Image.vue
@@ -1,0 +1,32 @@
+<template>
+    <img
+        :src="src"
+        :alt="alt"
+        :loading="loading"
+    />
+</template>
+
+<script>
+export default {
+    name: 'TdImage',
+    props: {
+        src: {
+            type: String,
+            required: true
+        },
+        alt: {
+            type: String,
+            default: ''
+        },
+        lazy: {
+            type: Boolean,
+            default: false
+        }
+    },
+    computed: {
+        loading() {
+            return this.lazy ? 'lazy' : undefined;
+        }
+    }
+};
+</script>

--- a/td.vue/src/views/HomePage.vue
+++ b/td.vue/src/views/HomePage.vue
@@ -8,10 +8,11 @@
             </b-row>
             <b-row>
                 <b-col md="4">
-                    <b-img class="td-cupcake"
-                           id="home-td-logo"
-                           :alt="$t('home.imgAlt')"
-                           src="@/assets/threatdragon_logo_image.svg"
+                    <td-image
+                        class="td-cupcake"
+                        id="home-td-logo"
+                        :alt="$t('home.imgAlt')"
+                        :src="threatDragonLogo"
                     />
                 </b-col>
                 <b-col md="8">
@@ -57,13 +58,20 @@
 <script>
 import {allProviders} from '@/service/provider/providers.js';
 import isElectron from 'is-electron';
+import threatDragonLogo from '@/assets/threatdragon_logo_image.svg';
 import TdHero from '@/components/Hero.vue';
+import TdImage from '@/components/Image.vue';
 import TdProviderLoginButton from '@/components/ProviderLoginButton.vue';
 import configActions from '@/store/actions/config.js';
 import {mapState} from 'vuex';
 
 export default {
     name: 'HomePage',
+    data() {
+        return {
+            threatDragonLogo
+        };
+    },
     computed:
         mapState({
             config: state => {
@@ -104,6 +112,7 @@ export default {
     },
     components: {
         TdHero,
+        TdImage,
         TdProviderLoginButton,
     },};
 </script>

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -31,10 +31,12 @@
                         </h6>
                     </template>
                     <a href="#" @click.prevent="editDiagram(diagram)">
-                        <!-- "thumbnail": "./public/content/images/thumbnail.jpg", --> <b-img-lazy
-                            class="m-auto d-block td-diagram-thumb"
+                        <!-- "thumbnail": "./public/content/images/thumbnail.jpg", --> <td-image
+                            class="td-diagram-thumb"
                             :src="require(`../assets/${diagram.thumbnail ? diagram.thumbnail.split('/').pop() : 'thumbnail.jpg'}`)"
-                            :alt="diagram.title" />
+                            :alt="diagram.title"
+                            lazy
+                        />
                     </a>
                     <h6 v-if=diagram.description class="diagram-description-text">
                         {{ diagram.description }}
@@ -86,6 +88,8 @@
 }
 
 .td-diagram-thumb {
+    display: block;
+    margin: auto;
     max-width: 200px;
     max-height: 160px;
 }
@@ -97,6 +101,7 @@ import { mapState } from 'vuex';
 import { getProviderType } from '@/service/provider/providers.js';
 import TdDropdown from '@/components/Dropdown.vue';
 import TdFormButton from '@/components/FormButton.vue';
+import TdImage from '@/components/Image.vue';
 import TdThreatModelSummaryCard from '@/components/ThreatModelSummaryCard.vue';
 import tmActions from '@/store/actions/threatmodel.js';
 
@@ -105,6 +110,7 @@ export default {
     components: {
         TdDropdown,
         TdFormButton,
+        TdImage,
         TdThreatModelSummaryCard
     },
     computed: mapState({

--- a/td.vue/tests/unit/components/image.spec.js
+++ b/td.vue/tests/unit/components/image.spec.js
@@ -1,0 +1,54 @@
+import { shallowMount } from '@vue/test-utils';
+
+import TdImage from '@/components/Image.vue';
+
+describe('components/Image.vue', () => {
+    it('renders a native image with src and alt text', () => {
+        const wrapper = shallowMount(TdImage, {
+            propsData: {
+                src: 'logo.svg',
+                alt: 'Threat Dragon'
+            }
+        });
+
+        expect(wrapper.element.tagName).toBe('IMG');
+        expect(wrapper.attributes('src')).toBe('logo.svg');
+        expect(wrapper.attributes('alt')).toBe('Threat Dragon');
+    });
+
+    it('does not lazy load by default', () => {
+        const wrapper = shallowMount(TdImage, {
+            propsData: {
+                src: 'logo.svg'
+            }
+        });
+
+        expect(wrapper.attributes('loading')).toBeUndefined();
+    });
+
+    it('uses native lazy loading when requested', () => {
+        const wrapper = shallowMount(TdImage, {
+            propsData: {
+                src: 'thumbnail.jpg',
+                lazy: true
+            }
+        });
+
+        expect(wrapper.attributes('loading')).toBe('lazy');
+    });
+
+    it('passes attributes through to the image', () => {
+        const wrapper = shallowMount(TdImage, {
+            propsData: {
+                src: 'thumbnail.jpg'
+            },
+            attrs: {
+                id: 'thumbnail',
+                class: 'td-thumbnail'
+            }
+        });
+
+        expect(wrapper.attributes('id')).toBe('thumbnail');
+        expect(wrapper.classes()).toContain('td-thumbnail');
+    });
+});

--- a/td.vue/tests/unit/views/homePage.spec.js
+++ b/td.vue/tests/unit/views/homePage.spec.js
@@ -1,15 +1,19 @@
-import { BootstrapVue, BContainer, BImg } from 'bootstrap-vue';
+import { BootstrapVue, BContainer } from 'bootstrap-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import { AUTH_SET_LOCAL } from '@/store/actions/auth.js';
+import configActions from '@/store/actions/config.js';
 import HomePage from '@/views/HomePage.vue';
 import loginApi from '@/service/api/loginApi.js';
 import { PROVIDER_SELECTED } from '@/store/actions/provider.js';
 import router from '@/router/index.js';
 import TdHero from '@/components/Hero.vue';
+import TdImage from '@/components/Image.vue';
 import TdProviderLoginButton from '@/components/ProviderLoginButton.vue';
+
+jest.mock('@/assets/threatdragon_logo_image.svg', () => 'threatdragon_logo_image.svg');
 
 describe('HomePage.vue', () => {
     const redirectUrl = 'https://threatdragon.org';
@@ -32,6 +36,7 @@ describe('HomePage.vue', () => {
                 },
                 actions: {
                     [AUTH_SET_LOCAL]: () => {},
+                    [configActions.fetch]: () => {},
                     [PROVIDER_SELECTED]: () => {}
                 }
             });
@@ -74,7 +79,7 @@ describe('HomePage.vue', () => {
             });
 
             it('displays the threat dragon logo', () => {
-                expect(wrapper.findComponent(BImg).attributes('src'))
+                expect(wrapper.findComponent(TdImage).props('src'))
                     .toContain('threatdragon_logo_image');
             });
 

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -151,8 +151,6 @@ module.exports = {
                 options.source = 'src';
                 options.img = 'src';
                 options.image = 'xlink:href';
-                options['b-img'] = 'src';
-                options['b-img-lazy'] = ['src', 'blank-src'];
                 options.compilerOptions = {
                     ...options.compilerOptions,
                     // Sets the compatability mode to 2, meaning "vue 2"


### PR DESCRIPTION
**Summary**:  

Add a custom td-image component with a lazy prop
Replace b-img and b-img-lazy with td-img

Relates to #1080 

**Description for the changelog**:  

chore: replace b-img and b-img-lazy with custom component

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Continuing issue 1080, create a td-img component with an optional lazy prop that replaces the b-img and b-img-lazy bootstrap components. We should not have any b-img or b-img compat or test shims remaining when done`

**Other info**:  

This was my first PR since adding the AGENTS file. 

What worked well is it explicitly checked the contributing guidelines, read the roadmap and reasoned about if this related to any of the strategic pillars, and it knew what tests to run based on its changes.

What didn't work well is the "PR Handoff" - it just said "this was generated with AI assistance", I think we need to be more explicit in saying that it should remind the user to disclose their use of AI in the PR. 
