### PR TITLE
De-bootstrapification: b-overlay

### DIFF
--- a/td.vue/src/App.vue
+++ b/td.vue/src/App.vue
@@ -2,9 +2,9 @@
   <div>
     <td-navbar />
     <b-container fluid id="app">
-      <b-overlay style="max-height: 100vh;" :show="isLoading" spinner-variant="primary">
+      <td-overlay style="max-height: 100vh;" :show="isLoading">
         <router-view />
-      </b-overlay>
+      </td-overlay>
     </b-container>
   </div>
 </template>
@@ -46,11 +46,13 @@ import { mapState } from 'vuex';
 
 import { LOADER_FINISHED } from '@/store/actions/loader.js';
 import TdNavbar from '@/components/Navbar.vue';
+import TdOverlay from '@/components/Overlay.vue';
 
 export default {
     name: 'TdApp',
     components: {
-        TdNavbar
+        TdNavbar,
+        TdOverlay
     },
     computed: mapState({
         isLoading: (state) => state.loader.loading

--- a/td.vue/src/components/AddBranchDialog.vue
+++ b/td.vue/src/components/AddBranchDialog.vue
@@ -13,7 +13,7 @@
     >
         <form @submit.prevent="addBranch">
             <b-row>
-                <b-col lg="12" class="pb-2">
+                <b-col lg="12" class="td-add-branch-field">
                     <b-form-group id="input-group-1" :label="$t('branch.name')" label-for="branchName">
                         <b-form-input
                             type="text"
@@ -32,7 +32,7 @@
                 </b-col>
             </b-row>
             <b-row>
-                <b-col lg="12" class="pb-2">
+                <b-col lg="12" class="td-add-branch-field">
                     <b-form-group id="input-group-2" :label="$t('branch.refBranch')" label-for="refBranch">
                         <td-form-select id="refBranch" v-model="refBranch" :options="branchNames" size="md"
                             required />
@@ -41,28 +41,42 @@
             </b-row>
         </form>
         <hr/>
-        <div class="d-flex justify-content-end">
-            <b-overlay
+        <div class="td-add-branch-actions">
+            <td-overlay
                 :show="wait"
-                variant="light"
-                blur="true"
-                opacity="0.8"
-                spinner-small
+                small
             >
-                <b-button variant="primary" type="submit" @click="addBranch" class="m-1">{{ $t('branch.add') }}</b-button>
-            </b-overlay>
-            <b-button variant="secondary" @click="closeDialog" class="m-1">{{ $t('branch.cancel') }}</b-button>
+                <b-button variant="primary" type="submit" @click="addBranch" class="td-add-branch-button">{{ $t('branch.add') }}</b-button>
+            </td-overlay>
+            <b-button variant="secondary" @click="closeDialog" class="td-add-branch-button">{{ $t('branch.cancel') }}</b-button>
         </div>
     </b-modal>
 </template>
+<style lang="scss" scoped>
+.td-add-branch-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
+.td-add-branch-field {
+    padding-bottom: 0.5rem;
+}
+
+.td-add-branch-button {
+    margin: 0.25rem;
+}
+</style>
 <script>
 import TdFormSelect from '@/components/FormSelect.vue';
+import TdOverlay from '@/components/Overlay.vue';
 import branchActions from '@/store/actions/branch.js';
 
 export default {
     name: 'AddBranchModal',
     components: {
-        TdFormSelect
+        TdFormSelect,
+        TdOverlay
     },
     props: {
         branches: {

--- a/td.vue/src/components/Overlay.vue
+++ b/td.vue/src/components/Overlay.vue
@@ -1,0 +1,69 @@
+<template>
+    <div class="td-overlay" :aria-busy="show ? 'true' : 'false'">
+        <slot />
+        <div v-if="show" class="td-overlay-backdrop" role="status" :aria-label="label">
+            <span class="td-overlay-spinner" :class="{ 'td-overlay-spinner-small': small }"></span>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.td-overlay {
+    position: relative;
+}
+
+.td-overlay-backdrop {
+    align-items: center;
+    background-color: rgba($white, 0.8);
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 10;
+}
+
+.td-overlay-spinner {
+    animation: td-overlay-spin 0.75s linear infinite;
+    border: 0.25rem solid rgba($orange, 0.25);
+    border-radius: 50%;
+    border-top-color: $orange;
+    display: inline-block;
+    height: 2rem;
+    width: 2rem;
+}
+
+.td-overlay-spinner-small {
+    border-width: 0.15rem;
+    height: 1rem;
+    width: 1rem;
+}
+
+@keyframes td-overlay-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+</style>
+
+<script>
+export default {
+    name: 'TdOverlay',
+    props: {
+        show: {
+            type: Boolean,
+            default: false
+        },
+        small: {
+            type: Boolean,
+            default: false
+        },
+        label: {
+            type: String,
+            default: 'Loading'
+        }
+    }
+};
+</script>

--- a/td.vue/tests/unit/app.spec.js
+++ b/td.vue/tests/unit/app.spec.js
@@ -7,6 +7,7 @@ import App from '@/App.vue';
 import i18nFactory from '@/i18n/index.js';
 import { LOADER_FINISHED } from '@/store/actions/loader.js';
 import Navbar from '@/components/Navbar.vue';
+import TdOverlay from '@/components/Overlay.vue';
 
 describe('App.vue', () => {
     let wrapper, localVue, mockStore;
@@ -45,5 +46,9 @@ describe('App.vue', () => {
 
     it('has a b-container', () => {
         expect(wrapper.find('#app').exists()).toBe(true);
+    });
+
+    it('uses the Threat Dragon overlay', () => {
+        expect(wrapper.findComponent(TdOverlay).exists()).toBe(true);
     });
 });

--- a/td.vue/tests/unit/components/addBranchDialog.spec.js
+++ b/td.vue/tests/unit/components/addBranchDialog.spec.js
@@ -2,6 +2,7 @@ import { BootstrapVue, BModal, BFormInput, BButton } from 'bootstrap-vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import AddBranchDialog from '@/components/AddBranchDialog.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
+import TdOverlay from '@/components/Overlay.vue';
 
 describe('components/AddBranchDialog.vue', () => {
     let localVue, wrapper;
@@ -40,6 +41,10 @@ describe('components/AddBranchDialog.vue', () => {
 
         it('displays the add button', () => {
             expect(wrapper.findAllComponents(BButton).at(0).text()).toBe('branch.add');
+        });
+
+        it('wraps the add button in the Threat Dragon overlay', () => {
+            expect(wrapper.findComponent(TdOverlay).exists()).toBe(true);
         });
 
         it('displays the cancel button', () => {
@@ -137,4 +142,3 @@ describe('components/AddBranchDialog.vue', () => {
         });
     });
 });
-

--- a/td.vue/tests/unit/components/overlay.spec.js
+++ b/td.vue/tests/unit/components/overlay.spec.js
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils';
+
+import TdOverlay from '@/components/Overlay.vue';
+
+describe('components/Overlay.vue', () => {
+    it('renders the default slot', () => {
+        const wrapper = mount(TdOverlay, {
+            slots: {
+                default: '<button>Save</button>'
+            }
+        });
+
+        expect(wrapper.find('button').text()).toBe('Save');
+    });
+
+    it('marks content as busy when shown', () => {
+        const wrapper = mount(TdOverlay, {
+            propsData: {
+                show: true
+            }
+        });
+
+        expect(wrapper.attributes('aria-busy')).toBe('true');
+    });
+
+    it('does not render the spinner when hidden', () => {
+        const wrapper = mount(TdOverlay);
+
+        expect(wrapper.find('[role="status"]').exists()).toBe(false);
+    });
+
+    it('uses the small spinner style when requested', () => {
+        const wrapper = mount(TdOverlay, {
+            propsData: {
+                show: true,
+                small: true
+            }
+        });
+
+        expect(wrapper.find('.td-overlay-spinner-small').exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
**Summary**:  

Add td-overlay
Replace b-overlay with td-overlay

Relates to #1080 

**Description for the changelog**:  

chore: replace b-overlay with custom component

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Continuing issue 1080, create a td-overlay component to replace the b-overlay bootstrap component. When we're done, there should be no b-overlay compat or test shims remaining`

**Other info**:  

No screenshots for this one. I did visually test the local changes against the live site by right-clicking on the config api call in the network tab and selecting throttle request. That slowed it down enough for the overlay to show on the home page.  

The visual diff is perceptible but minimal - positioning color and shape are all aligned, but the animated spinner has a slightly thinner stroke. I don't think that's worth chasing down for a loading indicator - it still looks how it should IMO. 

This component is not covered by visual regression tests, no need to update baselines.