### PR TITLE
AGENTS.md - make PR reminder more explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ regardless of whether the contributor is carbon-based, silicon-based, or legally
 6. Agents may point out docs gaps, but a human must write the final docs text.
 7. Agents may test docs with markdown linting, spellcheck, link checks, and local docs builds.
 8. Agents may edit code, tests, configuration, workflows, and maintainer scripts when explicitly asked.
-9. Agents must declare AI assistance in PR handoff text when a human will use the work in a PR.
+9. Agents must remind users of expectations when opening a PR: adhere to the template and include the AI disclosure.
 10. Agents must not open issues, comment on GitHub, open PRs, approve PRs, merge, release, or publish.
 11. Agents must not commit or push unless a human explicitly asks for that exact git action.
 12. Keep PR-sized work small and reviewer-friendly: one bug, feature, or chore per change.


### PR DESCRIPTION
**Summary**:  

In #1684 - I wasn't quite satisfied with the PR handoff language. It just reminded the user that AI assistance was used. 
The reason for the reminder is so that humans follow the contributing guidelines, follow the PR template and disclose the use of AI.

**Description for the changelog**:  

chore: agents - make PR reminder more explicit

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `give me a PR handoff`

**Other info**:  

For the AI disclaimer, I marked both:
- The AGENTS.md update was done by me without AI
- I used AI to test the change

<img width="1265" height="892" alt="image" src="https://github.com/user-attachments/assets/36cd6419-2efd-4f9e-ae50-09a151ada652" />
