### PR TITLE
Feature: use type field instead of eopGameId for EOP threats

### DIFF
--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -158,7 +158,6 @@ export default {
         mitigation: { type: String },
         modelType: { type: String },
         number: { type: Number },
-        eopGameId: { type: String },
         cardSuit: { type: String },
         cardNumber: { type: String }
     },
@@ -176,7 +175,6 @@ export default {
                 mitigation: t.mitigation || this.mitigation || '',
                 modelType: t.modelType || this.modelType || '',
                 number: t.number || this.number || null,
-                eopGameId: t.eopGameId || this.eopGameId || '',
                 cardSuit: t.cardSuit || this.cardSuit || '',
                 cardNumber: t.cardNumber || this.cardNumber || ''
             };
@@ -191,8 +189,7 @@ export default {
         mitigationResolved() { return this.threatData.mitigation; },
         modelTypeResolved() { return this.threatData.modelType; },
         numberResolved() { return this.threatData.number; },
-        eopGameIdResolved() { return this.threatData.eopGameId; },
-        cardSuitResolved() { return getGame(this.threatData.eopGameId)?.getCardCategory(this.threatData.cardNumber); },
+        cardSuitResolved() { return getGame(this.threatData.type)?.getCardCategory(this.threatData.cardNumber); },
         cardNumberResolved() { return this.threatData.cardNumber; }
     },
 

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -413,7 +413,7 @@ export default {
                     'Trying to access a non-existent threatId: ' + threatId
                 );
             } else {
-                this.selectedGameId = this.threat.eopGameId;
+                this.selectedGameId = this.threat.type || this.threat.eopGameId;
                 this.card.suit = this.activeGame?.getCardCategory(this.threat.cardNumber);
                 this.card.number = this.threat.cardNumber;
                 this.number = this.threat.number;
@@ -472,10 +472,9 @@ export default {
                 threatRef.number = this.number;
                 threatRef.score = this.threat.score;
                 if (threatRef.modelType === 'EOP') {
-                    threatRef.eopGameId = this.selectedGameId;
                     threatRef.cardSuit = this.card.suit;
                     threatRef.cardNumber = this.card.number;
-                    threatRef.type = null;
+                    threatRef.type = this.selectedGameId;
                 } else {
                     threatRef.type = this.threat.type;
                 }

--- a/td.vue/src/service/threats/index.js
+++ b/td.vue/src/service/threats/index.js
@@ -46,7 +46,7 @@ const valuesToTranslations = {
 const convertToTranslationString = (val) => valuesToTranslations[val];
 
 export const createNewTypedThreat = function (modelType, cellType,number) {
-    let title, type, eopGameId;
+    let title, type;
 
     if (!modelType) {
         modelType = 'STRIDE';
@@ -106,7 +106,7 @@ export const createNewTypedThreat = function (modelType, cellType,number) {
 
         case 'EOP':
             title = tc('threats.generic.eop');
-            eopGameId = 'cornucopia';
+            type = 'cornucopia';
             break;
 
         default:
@@ -122,7 +122,6 @@ export const createNewTypedThreat = function (modelType, cellType,number) {
         status: 'Open',
         severity: 'TBD',
         type,
-        eopGameId,
         description: tc('threats.description'),
         mitigation: tc('threats.mitigation'),
         modelType,

--- a/td.vue/tests/unit/service/threats/index.spec.js
+++ b/td.vue/tests/unit/service/threats/index.spec.js
@@ -121,6 +121,30 @@ describe('service/threats/index.js', () => {
         });
     });
 
+
+    describe('create new EOP threat', () => {
+        let threat;
+
+        beforeEach(() => {
+            threat = createNewTypedThreat('EOP');
+        });
+
+        it('has a typed title', () => {
+            expect(threat.title).toEqual('New EoP threat');
+        });
+
+        it('has cornucopia as type', () => {
+            expect(threat.type).toEqual('cornucopia');
+        });
+
+        it('has no eopGameId field', () => {
+            expect(threat.eopGameId).toBeUndefined();
+        });
+
+        it('has an EOP modelType', () => {
+            expect(threat.modelType).toEqual('EOP');
+        });
+    });
     describe('hasOpenThreats', () => {
         it('returns false if there is no data', () => {
             expect(threats.hasOpenThreats(null))


### PR DESCRIPTION
## Summary:  

closes #1672

EOP threats were storing the game ID in a separate eopGameId field with type set to null, which was redundant. This PR fixes that by storing the game ID directly in the type field and removing eopGameId.

## Description for the changelog:  

Use type field instead of eopGameId for EOP threats

## Declaration:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

## Other info:  

Tested locally - new EOP threats now save with type: "cornucopia" 
instead of type: null and eopGameId: "cornucopia".

Old models with eopGameId still load correctly for backward compatibility.
And i also run the unit test all test passed including 36 threatEditDialog tests.