### PR TITLE
Pin Docker base images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,30 @@ updates:
         update-types:
           - "version-update:semver-major"
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 10
+    groups:
+      docker-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-ARG         NODE_VERSION=24.16.0
-
 # The base image with updates applied
-FROM        node:$NODE_VERSION-alpine AS base-node
+FROM        node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base-node
 RUN         apk -U upgrade
 WORKDIR     /app
 COPY        .npmrc /app/.npmrc
@@ -36,7 +34,7 @@ RUN         cp td.server/sbom.json        boms/threat-dragon-server-bom.json && 
             cp td.vue/dist/.sbom/bom.xml  boms/threat-dragon-site-bom.xml
 
 
-FROM        ruby:4.0-slim-bookworm AS build-docs
+FROM        ruby:4.0-slim-bookworm@sha256:53c027bbb00469b5237eabadde82b0b7f0e1c38c4b0090c78b8553b85fcee2ff AS build-docs
 RUN         apt-get update \
             && apt-get install -y --no-install-recommends \
             build-essential \


### PR DESCRIPTION
**Summary**:  

Pins the docker base images and adds a dependabot config to manage them.
Closes #1675 

The original issue was suggesting a lot of automation and moving parts. It felt a bit too fragile.
Where I added a couple of maintenance scripts including one to upgrade the node version across actions, I think it's unnecessary. 

**Description for the changelog**:  

chore: pin docker base images

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
