### PR TITLE
Optimize Dockerfile

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -431,12 +431,12 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           tags:  ${{ env.IMAGE_NAME }}
+          load: false
           outputs: type=oci,dest=/tmp/${{ env.IMAGE_NAME }}.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # If you add more platforms, make sure to include them in ./push.yaml too!
           platforms: linux/amd64,linux/arm64
-          load: true
           sbom: true
           provenance: mode=max
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -446,6 +446,8 @@ jobs:
           # If you add more platforms, make sure to include them in ./push.yaml too!
           platforms: linux/amd64,linux/arm64
           load: true
+          sbom: true
+          provenance: mode=max
 
       - name: Upload docker local image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -432,13 +432,29 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           tags:  ${{ env.IMAGE_NAME }}
           load: false
-          outputs: type=oci,dest=/tmp/${{ env.IMAGE_NAME }}.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # If you add more platforms, make sure to include them in ./push.yaml too!
           platforms: linux/amd64,linux/arm64
           sbom: true
           provenance: mode=max
+
+      - name: Build for amd64 only for further tests below
+        id: docker_build_amd64
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          tags:  ${{ env.IMAGE_NAME }}
+          load: false
+          outputs: type=docker,dest=/tmp/${{ env.IMAGE_NAME }}.tar
+          # Should pull from the step before, so this one should be all cached
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          # Note: no sbom or provenance, we need to produce the simplest image form
+          # so that "docker load" will like it afterwards
 
       - name: Upload docker local image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -423,15 +423,6 @@ jobs:
         with:
           install: true
 
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-            ${{ runner.os }}-
-
       - name: Build for all supported architectures to test buildability
         id: docker_build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -441,8 +432,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           tags:  ${{ env.IMAGE_NAME }}
           outputs: type=oci,dest=/tmp/${{ env.IMAGE_NAME }}.tar
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # If you add more platforms, make sure to include them in ./push.yaml too!
           platforms: linux/amd64,linux/arm64
           load: true
@@ -459,13 +450,6 @@ jobs:
         run: |
           docker load --input /tmp/${{ env.IMAGE_NAME }}.tar
           docker image ls -a
-
-      - # Temp fix for large cache bug
-        # https://github.com/docker/build-push-action/issues/252
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   scan_image_with_trivy:
     name: Scan with Trivy

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -437,7 +437,7 @@ jobs:
           # If you add more platforms, make sure to include them in ./push.yaml too!
           platforms: linux/amd64,linux/arm64
           sbom: true
-          provenance: mode=max
+          provenance: mode=max,version=v1
 
       - name: Build for amd64 only for further tests below
         id: docker_build_amd64

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -432,7 +432,7 @@ jobs:
             ${{ runner.os }}-buildx-
             ${{ runner.os }}-
 
-      - name: Build for amd64
+      - name: Build for all supported architectures to test buildability
         id: docker_build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -440,10 +440,11 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           tags:  ${{ env.IMAGE_NAME }}
-          outputs: type=docker,dest=/tmp/${{ env.IMAGE_NAME }}.tar
+          outputs: type=oci,dest=/tmp/${{ env.IMAGE_NAME }}.tar
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          platforms: linux/amd64
+          # If you add more platforms, make sure to include them in ./push.yaml too!
+          platforms: linux/amd64,linux/arm64
           load: true
 
       - name: Upload docker local image

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -150,15 +150,6 @@ jobs:
         with:
           install: true
 
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-            ${{ runner.os }}-
-
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -174,8 +165,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags:  ${{ env.IMAGE_NAME }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # If you add more platforms, make sure to include them in ./pull_request.yaml too!
           platforms: linux/amd64,linux/arm64
           # Do not load the image heare, as multiplatform images can't be loaded that way
@@ -196,13 +187,6 @@ jobs:
           path: './boms/*'
           include-hidden-files: true
           if-no-files-found: error
-
-      - # Temp fix for large cache bug
-        # https://github.com/docker/build-push-action/issues/252
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   heroku_deploy:
     name: Upload to Heroku

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -165,9 +165,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # platform manifests not (yet) supported, so split out architectures
-      - name: Build  for amd64 and push latest
-        id: docker_build_amd64
+      - name: Build for supported architectures and push latest
+        id: docker_build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./
@@ -177,22 +176,11 @@ jobs:
           tags:  ${{ env.IMAGE_NAME }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
-          platforms: linux/amd64
-          load: true
-
-      - name: Build for arm64 and push latest-arm64
-        id: docker_build_arm64
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: ./
-          file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
-          push: true
-          tags:  ${{ env.IMAGE_NAME }}-arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          platforms: linux/arm64
-          load: true
+          # If you add more platforms, make sure to include them in ./pull_request.yaml too!
+          platforms: linux/amd64,linux/arm64
+          # Do not load the image heare, as multiplatform images can't be loaded that way
+          # The following docker run will instead pull from the registry we just pushed to
+          load: false
 
       - name: fetch app SBOMs
         run: docker run --rm --entrypoint tar "$IMAGE_ID" -c boms | tar -xv

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -173,7 +173,7 @@ jobs:
           # The following docker run will instead pull from the registry we just pushed to
           load: false
           sbom: true
-          provenance: mode=max
+          provenance: mode=max,version=v1
 
       - name: fetch app SBOMs
         run: docker run --rm --entrypoint tar "$IMAGE_ID" -c boms | tar -xv

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -167,9 +167,9 @@ jobs:
           tags:  ${{ env.IMAGE_NAME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # If you add more platforms, make sure to include them in ./pull_request.yaml too!
+          # If you add more platforms, make sure to include them in ./pull_request.yaml and ./release.yaml too!
           platforms: linux/amd64,linux/arm64
-          # Do not load the image heare, as multiplatform images can't be loaded that way
+          # Do not load the image here, as multiplatform images can't be loaded that way
           # The following docker run will instead pull from the registry we just pushed to
           load: false
           sbom: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -181,6 +181,8 @@ jobs:
           # Do not load the image heare, as multiplatform images can't be loaded that way
           # The following docker run will instead pull from the registry we just pushed to
           load: false
+          sbom: true
+          provenance: mode=max
 
       - name: fetch app SBOMs
         run: docker run --rm --entrypoint tar "$IMAGE_ID" -c boms | tar -xv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -369,24 +369,14 @@ jobs:
         with:
           install: true
 
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-            ${{ runner.os }}-
-
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # platform manifests not (yet) supported, so split out architectures
-      - name: Build for amd64 and push to Docker Hub
-        id: docker_build_amd64
+      - name: Build for supported architectures and push to Docker Hub
+        id: docker_build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./
@@ -394,24 +384,32 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.IMAGE_NAME }}:stable
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
-          platforms: linux/amd64
-          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # If you add more platforms, make sure to include them in ./pull_request.yaml and ./push.yaml too!
+          platforms: linux/amd64,linux/arm64
+          load: false
+          sbom: true
+          provenance: mode=max,version=v1
 
-      - name: Build for arm64 and push to Docker Hub
+      # Required because multiplatform images can't be loaded directly
+      - name: Build for amd64 only to extract SBOM
         id: docker_build_arm64
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}-arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          platforms: linux/arm64
+          # Do not push, just for the docker run in the next line
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.IMAGE_NAME }}:stable
+          # Should pull from the step before, so this one should be all cached
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
           load: true
+          # Note: no sbom or provenance, we need to produce the simplest image form
+          # so that the load will actually succeed
 
       - name: fetch app SBOM
         run: docker run --rm --entrypoint tar "$IMAGE_ID" -c boms | tar -xv
@@ -425,13 +423,6 @@ jobs:
           path: './boms/*'
           include-hidden-files: true
           if-no-files-found: error
-
-      - # Temp fix for large cache bug
-        # https://github.com/docker/build-push-action/issues/252
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   sbom_combiner:
     name: SBOM combiner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,124 @@
-ARG         NODE_VERSION=24.16.0
+# NPM: Base image with latest npm (in native host's platform)
+FROM --platform=$BUILDPLATFORM docker.io/library/node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS build-npm-base
+WORKDIR /build
 
-# The base image with updates applied
-FROM        node:$NODE_VERSION-alpine AS base-node
-RUN         apk -U upgrade
-WORKDIR     /app
-COPY        .npmrc /app/.npmrc
-RUN         NPM_CONFIG_USERCONFIG=/app/.npmrc npm i -g npm@latest
-RUN         chown -R node:node /app
-USER        node
+# Copy over NPM config and enforce usage across all tool calls
+# Contains configuration regarding supply chain
+COPY .npmrc /.npmrc
+ENV NPM_CONFIG_USERCONFIG=/.npmrc
 
-
-# Build the front and back-end.  This needs devDependencies which do not
-# need to be included in the final image
-FROM        base-node AS build
-RUN         mkdir -p boms td.server td.vue td.vue/src/service/schema/api_json
-
-COPY        package-lock.json package.json /app/
-COPY        ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
-COPY        ./td.vue/.npmrc ./td.vue/package-lock.json ./td.vue/package.json ./td.vue/
-
-COPY        ./td.server/.babelrc ./td.server/
-COPY        ./td.server/src/ ./td.server/src/
-COPY        ./td.vue/src/ ./td.vue/src/
-COPY        ./td.vue/public/ ./td.vue/public/
-COPY        ./td.vue/*.config.js ./td.vue/
-
-RUN         npm clean-install --ignore-scripts
-RUN         cd td.server && npm clean-install
-RUN         cd td.vue && npm clean-install
-RUN         npm run build
-RUN         cd td.server && npm run make-sbom
-RUN         cp td.server/sbom.json        boms/threat-dragon-server-bom.json && \
-            cp td.server/sbom.xml         boms/threat-dragon-server-bom.xml  && \
-            cp td.vue/dist/.sbom/bom.json boms/threat-dragon-site-bom.json   && \
-            cp td.vue/dist/.sbom/bom.xml  boms/threat-dragon-site-bom.xml
+# Install latest npm
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/usr/share/man \
+    npm i -g npm@latest
 
 
-FROM        ruby:4.0-slim-bookworm AS build-docs
-RUN         apt-get update \
-            && apt-get install -y --no-install-recommends \
-            build-essential \
-            && rm -rf /var/lib/apt/lists/*
-WORKDIR     /td.docs
-COPY        docs/Gemfile Gemfile
-COPY        docs/Gemfile.lock Gemfile.lock
-RUN         bundle install
-COPY        docs/ .
-RUN         bundle exec jekyll build -b docs/
+# NPM: Stage 1: install dev-dependencies and build dist bundle
+FROM build-npm-base AS build-npm-stage1
+
+COPY package-lock.json package.json ./
+
+COPY ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
+
+COPY ./td.vue/.npmrc ./td.vue/package-lock.json ./td.vue/package.json ./td.vue/
+COPY ./td.vue/src/plugins ./td.vue/src/plugins
+
+RUN npm clean-install --ignore-scripts && \
+    cd td.server && npm clean-install && cd .. && \
+    cd td.vue && npm clean-install
+
+# For some reason, the build also wants Electron...
+# Pre-download here to make it cacheable
+RUN cd td.vue && node node_modules/electron/install.js
+
+COPY ./td.server/.babelrc ./td.server/
+COPY ./td.server/index.js ./td.server/
+COPY ./td.server/src/ ./td.server/src/
+
+COPY ./td.vue/src/ ./td.vue/src/
+COPY ./td.vue/public/ ./td.vue/public/
+COPY ./td.vue/*.config.js ./td.vue/
+
+RUN mkdir -p td.vue/src/service/schema/api_json && \
+    npm run build && \
+    cd td.server && \
+    npm run make-sbom
+
+# Prepare directory structure to copy in one go to final image
+RUN mkdir -p target target/td.server target/boms && \
+    # Server
+    cp td.server/index.js ./target/td.server/index.js && \
+    mv td.server/dist ./target/td.server/dist && \
+    # Frontend
+    cp -R td.vue/dist ./target/dist && \
+    # SBOMs
+    cp td.server/sbom.json        ./target/boms/threat-dragon-server-bom.json && \
+    cp td.server/sbom.xml         ./target/boms/threat-dragon-server-bom.xml && \
+    cp td.vue/dist/.sbom/bom.json ./target/boms/threat-dragon-site-bom.json && \
+    cp td.vue/dist/.sbom/bom.xml  ./target/boms/threat-dragon-site-bom.xml && \
+    rm -R ./target/dist/.sbom
 
 
-# Build the final, production image.
-FROM        base-node
-COPY        --chown=node:node --from=build-docs /td.docs/_site /app/docs
-COPY        --chown=node:node --from=build /app/boms /app/boms
+# NPM: Stage 2: install runtime-only dependencies for the server
+# This stage is kept as minimal as possible to ensure aggressive caching
+# Should only be rebuilt when the package.json or package-lock.json change,
+# and not the TD source code itself
+FROM build-npm-base AS build-npm-stage2
 
-COPY        --chown=node:node ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
-RUN         cd td.server && npm clean-install --omit dev --ignore-scripts
-COPY        --chown=node:node --from=build /app/td.server/dist ./td.server/dist
-COPY        --chown=node:node --from=build /app/td.vue/dist ./dist
-COPY        --chown=node:node ./td.server/index.js ./td.server/index.js
+COPY package-lock.json package.json ./
+COPY ./td.server/.npmrc ./td.server/package-lock.json ./td.server/package.json ./td.server/
 
-HEALTHCHECK --interval=10s --timeout=2s --start-period=2s CMD ["/nodejs/bin/node", "./td.server/dist/healthcheck.js"]
-CMD         ["td.server/index.js"]
+RUN cd td.server && \
+    npm clean-install --omit=dev --ignore-scripts
+
+
+# Build Docs
+FROM --platform=$BUILDPLATFORM docker.io/library/ruby:4.0.5@sha256:bd5075f77ac998fa5b61e37842717d1a29482b0e02ab74e2a2a8ae371d121b32 AS build-docs
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=tmpfs,target=/var/lib/dpkg \
+    --mount=type=tmpfs,target=/var/cache \
+    --mount=type=tmpfs,target=/var/log \
+    apt-get update && \
+    apt-get install -y --no-install-recommends build-essential
+
+WORKDIR /build
+
+COPY docs/Gemfile docs/Gemfile.lock ./
+RUN bundle install
+
+COPY docs/ .
+RUN bundle exec jekyll build -b ./docs/
+
+
+FROM docker.io/library/node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS final
+
+# Copy over NPM config and enforce usage across all tool calls
+# Contains configuration regarding supply chain
+COPY .npmrc /.npmrc
+ENV NPM_CONFIG_USERCONFIG=/.npmrc
+
+# Install latest npm to shut up trivy
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/usr/share/man \
+    npm i -g npm@latest
+
+WORKDIR /app
+
+# Copy things into here with --link, ensuring that the layers stay independent.
+# This allows re-using the docs layer when the app itself changes and the docs didn't.
+# Copy everything with --chown=0:0 because the app does not need to write anything to these files.
+
+# App
+COPY --from=build-npm-stage2 --link --chown=0:0 /build/td.server/node_modules ./td.server/node_modules
+COPY --from=build-npm-stage1 --link --chown=0:0 /build/target .
+
+# Docs
+COPY --from=build-docs --link --chown=0:0 /build/_site ./docs
+
+# Use numeric ids to ensure kubernetes can verify non-root with runAsNonRoot:true
+USER 1000
+
+HEALTHCHECK --interval=10s --timeout=2s --start-period=2s CMD ["node", "/app/td.server/dist/healthcheck.js"]
+ENTRYPOINT ["node", "/app/td.server/index.js"]

--- a/td.server/package-lock.json
+++ b/td.server/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@gitbeaker/rest": "^43.8.0",
+        "@googleapis/drive": "^20.2.0",
         "axios": "^1.16.0",
         "bitbucket": "^2.11.0",
         "dotenv": "^16.0.3",
         "express": "^5.0.1",
         "express-rate-limit": "^8.5.1",
-        "googleapis": ">=171.4.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "octonode": "^0.10.2",
@@ -1977,6 +1977,18 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@googleapis/drive": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-20.2.0.tgz",
+      "integrity": "sha512-6xPjqqLl34jBXWYMO34ywLVQsT8FgH948x8YI9o6Tdqs7+n4QRyvkC+BcvVQaAPNc+pyqsvZAXcbdMEcGgDUGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2019,7 +2031,9 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -2036,7 +2050,9 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -2048,7 +2064,9 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -2060,13 +2078,17 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -2083,7 +2105,9 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2098,7 +2122,9 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -2465,6 +2491,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3036,6 +3063,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3045,6 +3073,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3336,6 +3365,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4062,6 +4092,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4074,6 +4105,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -4272,6 +4304,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4611,7 +4644,9 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -4649,6 +4684,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -5798,27 +5834,17 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2",
-        "rimraf": "^5.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/gaxios/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/gaxios/node_modules/data-uri-to-buffer": {
@@ -5828,58 +5854,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/gaxios/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gaxios/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gaxios/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gaxios/node_modules/node-fetch": {
@@ -5898,33 +5872,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/gaxios/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gaxios/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gcp-metadata": {
@@ -6161,17 +6108,16 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
@@ -6185,19 +6131,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/googleapis": {
-      "version": "171.4.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
-      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.2.0",
-        "googleapis-common": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/googleapis-common": {
@@ -6241,19 +6174,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -6832,6 +6752,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7155,6 +7076,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -7337,7 +7259,9 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -7932,6 +7856,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9403,6 +9328,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/packageurl-js": {
@@ -9496,6 +9422,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9512,7 +9439,9 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9528,7 +9457,9 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -10911,6 +10842,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10923,6 +10855,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11421,6 +11354,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11436,7 +11370,9 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11509,6 +11445,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11522,7 +11459,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12422,6 +12361,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12633,7 +12573,9 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/td.server/package.json
+++ b/td.server/package.json
@@ -50,12 +50,12 @@
   "dependencies": {
     "@babel/runtime": "^7.29.2",
     "@gitbeaker/rest": "^43.8.0",
+    "@googleapis/drive": "^20.2.0",
     "axios": "^1.16.0",
     "bitbucket": "^2.11.0",
     "dotenv": "^16.0.3",
     "express": "^5.0.1",
     "express-rate-limit": "^8.5.1",
-    "googleapis": ">=171.4.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "octonode": "^0.10.2",

--- a/td.server/src/repositories/googledrive.js
+++ b/td.server/src/repositories/googledrive.js
@@ -1,15 +1,15 @@
+import { auth, drive } from "@googleapis/drive";
 import env from '../env/Env.js';
-import { google } from 'googleapis';
 
 const getClient = (accessToken) => {
-    const oauth2Client = new google.auth.OAuth2(env.get().config.GOOGLE_CLIENT_ID, env.get().config.GOOGLE_CLIENT_SECRET, env.get().config.GOOGLE_REDIRECT_URI);
+    const oauth2Client = new auth.OAuth2(env.get().config.GOOGLE_CLIENT_ID, env.get().config.GOOGLE_CLIENT_SECRET, env.get().config.GOOGLE_REDIRECT_URI);
     oauth2Client.setCredentials({ access_token: accessToken });
     return oauth2Client;
 };
 
 const getFolderDetailsAsync = async (folderId, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const res = await driveClient.files.get({
         fileId: folderId,
@@ -21,7 +21,7 @@ const getFolderDetailsAsync = async (folderId, accessToken) => {
 
 const listFilesInFolderAsync = async (folderId, pageToken, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const res = await driveClient.files.list({
         q: `'${folderId}' in parents and (mimeType='application/vnd.google-apps.folder' or mimeType='application/json')`,
@@ -38,7 +38,7 @@ const listFilesInFolderAsync = async (folderId, pageToken, accessToken) => {
 
 const getFolderParentIdAsync = async (folderId, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const res = await driveClient.files.get({
         fileId: folderId,
@@ -52,7 +52,7 @@ const getFolderParentIdAsync = async (folderId, accessToken) => {
 
 const getFileContentAsync = async (fileId, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const res = await driveClient.files.get({
         fileId: fileId,
@@ -64,7 +64,7 @@ const getFileContentAsync = async (fileId, accessToken) => {
 
 const createFileInFolderAsync = async (folderId, fileName, fileContent, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const fileMetadata = {
         name: fileName,
@@ -87,7 +87,7 @@ const createFileInFolderAsync = async (folderId, fileName, fileContent, accessTo
 
 const updateFileAsync = async (fileId, fileContent, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     const media = {
         mimeType: 'application/json',
@@ -105,7 +105,7 @@ const updateFileAsync = async (fileId, fileContent, accessToken) => {
 
 const deleteFileAsync = async (fileId, accessToken) => {
     const auth = getClient(accessToken);
-    const driveClient = google.drive({ version: 'v3', auth });
+    const driveClient = drive({ version: 'v3', auth });
 
     await driveClient.files.delete({
         fileId: fileId,

--- a/td.server/test/repositories/googledrive.spec.js
+++ b/td.server/test/repositories/googledrive.spec.js
@@ -1,7 +1,7 @@
+import * as driveapi from '@googleapis/drive';
 import { expect } from 'chai';
-import sinon from 'sinon';
-import { google } from 'googleapis';
 import googledrive from '../../src/repositories/googledrive';
+import sinon from 'sinon';
 
 describe('Google Drive Service', () => {
     let sandbox;
@@ -21,12 +21,12 @@ describe('Google Drive Service', () => {
             },
         };
 
-        oauth2ClientStub = sandbox.stub(google.auth, 'OAuth2');
+        oauth2ClientStub = sandbox.stub(driveapi.auth, 'OAuth2');
         oauth2ClientStub.returns({
             setCredentials: sinon.stub(),
         });
         
-        sandbox.stub(google, 'drive').returns(mockDriveClient);
+        sandbox.stub(driveapi, 'drive').returns(mockDriveClient);
     });
 
     afterEach(() => {


### PR DESCRIPTION
**Summary**:  

The current Dockerfile produces a rather huge image (~500 MB incl. node, ~340MB excl. node) and has a lot of layers.
Additionally, there are many dependencies in that Dockerfile that ensure that the build cache can't be used with the most efficiency.

This PR optimizes the Docker Image and pulls it down to 223 MB incl. node and 64MB excl. node.

Additionally, I enabled a multiplatform build for arm64 in addition to amd64.
This would produce one image with multiple platforms, making the second -arm64 image obsolete.

**Description for the changelog**:  

- Reworked Dockerfile to reduce image size and enhance cache usage
- Switched to use `@googleapis/drive` instead of global `googleapis` packages to reduce size
- Removed separate `-arm64` image and enabled multiplatform builds for amd64 and arm64
- Enabled SLSA provenance and Docker SBOMs for the images

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Might need a rebase on https://github.com/OWASP/threat-dragon/pull/1691 after that is merged.
