### PR TITLE
removing severity from local trivy script

### DIFF
--- a/scripts/td-trivy-check.sh
+++ b/scripts/td-trivy-check.sh
@@ -10,7 +10,7 @@ usage() {
 Usage: td-trivy-check.sh [options]
 
 Build the local Threat Dragon Docker image for linux/amd64 and scan it with
-Trivy using the same ignore file, fail level, and skip-files list used in CI.
+Trivy using the same ignore file and skip-files list used in CI.
 
 Options:
   --repo-dir PATH      Threat Dragon checkout. Defaults to TD_REPO_DIR,
@@ -124,7 +124,6 @@ docker run \
     "$trivy_image" \
     image \
     --exit-code 1 \
-    --severity CRITICAL,HIGH \
     --ignorefile /workspace/.trivyignore \
     --skip-files "$skip_files" \
     "$target_image"


### PR DESCRIPTION
**Summary**:  

The local trivy script was only failing on high and critical, but CI uses Trivy's defaults.
This made locally running trivy different from CI, leading to false negatives.

**Description for the changelog**:  

chore: local trivy script remove severities

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
