### PR TITLE
add accepted, transferred and avoided threat statuses

### DIFF
--- a/docs/usage/threats.md
+++ b/docs/usage/threats.md
@@ -43,11 +43,19 @@ All threats have the following properties:
 
 * Title is free form test, usually a short descriptive title
 * Type is a category selection determined by the diagram type (STRIDE / LINDDUN / PLOT4ai / CIA / CIA-DIE / Generic)
-* Status is one of N/A / Open / Mitigated
+* Status indicates whether a threat is N/A, Open, or has a selected treatment outcome
+  * N/A means the threat does not apply
+  * Open means the threat still requires a treatment decision
+  * Treatment outcomes are selected from the Mitigated dropdown:
+    * Mitigated: Controls reduce the risk.
+    * Accepted: The remaining risk is knowingly accepted.
+    * Transferred: Another party takes responsibility for the risk.
+    * Avoided: The risky activity is not pursued.
+    * Eliminated: The source of the threat is completely removed.
 * Score contains a free text field, often used to score the threat from 0.0 to 10.0 but can be any text or CVSS score
 * Severity is one of TBD / Low / Medium / High / Critical, similar to CVSS
 * Description of the threat and possible impact
-* Mitigations for the threat, probably a remediation from TAME (Transfer / Accept / Mitigate / Evade)
+* Mitigations describe controls, remediation, or reasoning for the selected treatment outcome.
 
 Here N/A stands for Not Applicable and TBD for To Be Defined (or Determined).
 Threat severity is used instead of 'Priority' - this [has been discussed][issue#197]

--- a/td.vue/src/assets/schema/threat-dragon-v2.schema.json
+++ b/td.vue/src/assets/schema/threat-dragon-v2.schema.json
@@ -358,7 +358,7 @@
                             "type": "string"
                           },
                           "status": {
-                            "description": "The threat status as NA, Open, Mitigated, Accepted, Transferred or Avoided",
+                            "description": "The threat status as NA, Open, Mitigated, Accepted, Transferred, Avoided or Eliminated",
                             "type": "string"
                           },
                           "threatId": {

--- a/td.vue/src/assets/schema/threat-dragon-v2.schema.json
+++ b/td.vue/src/assets/schema/threat-dragon-v2.schema.json
@@ -358,7 +358,7 @@
                             "type": "string"
                           },
                           "status": {
-                            "description": "The threat status as NA, Open or Mitigated",
+                            "description": "The threat status as NA, Open, Mitigated, Accepted, Transferred or Avoided",
                             "type": "string"
                           },
                           "threatId": {

--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -44,7 +44,7 @@
                     :title="statusResolved"
                 />
                 <font-awesome-icon
-                    v-if="statusResolved === 'Mitigated'"
+                    v-if="isStatusResolved"
                     icon="check"
                     class="threat-icon green-icon"
                     :title="statusResolved"
@@ -139,6 +139,7 @@
 
 <script>
 import { getGame } from '../service/threats/models/eop';
+import { isResolved } from '@/service/threats/status.js';
 
 export default {
     name: 'TdGraphThreats',
@@ -182,6 +183,7 @@ export default {
 
         idResolved() { return this.threatData.id; },
         statusResolved() { return this.threatData.status; },
+        isStatusResolved() { return isResolved(this.statusResolved); },
         severityResolved() { return this.threatData.severity; },
         descriptionResolved() { return this.threatData.description; },
         titleResolved() { return this.threatData.title; },

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -146,12 +146,23 @@
                             :label="$t('threats.properties.status')"
                             label-for="status"
                         >
-                            <td-form-radio-group
+                            <td-dropdown
                                 id="status"
-                                v-model="threat.status"
-                                :options="statuses"
-                                buttons
-                            ></td-form-radio-group>
+                                variant="secondary"
+                                :text="selectedStatusText"
+                            >
+                                <template #default="{ close }">
+                                    <button
+                                        v-for="status in statuses"
+                                        :key="status.value"
+                                        type="button"
+                                        class="td-dropdown-item"
+                                        @click="threat.status = status.value; close()"
+                                    >
+                                        {{ status.text }}
+                                    </button>
+                                </template>
+                            </td-dropdown>
                         </b-form-group>
                     </b-col>
 
@@ -270,13 +281,15 @@ import threatModels from '@/service/threats/models/index.js';
 import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
+import TdDropdown from '@/components/Dropdown.vue';
 import { getGame, getAllGames } from '../service/threats/models/eop';
 
 export default {
     name: 'TdThreatEditDialog',
     components: {
         TdFormRadioGroup,
-        TdFormSelect
+        TdFormSelect,
+        TdDropdown
     },
     computed: {
         ...mapState({
@@ -301,6 +314,9 @@ export default {
         },
         statuses() {
             return getStatusOptions((key) => this.$t(key));
+        },
+        selectedStatusText() {
+            return this.statuses.find((status) => status.value === this.threat.status)?.text || '';
         },
         priorities() {
             return [

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -267,6 +267,7 @@ import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
 import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
+import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
 import { getGame, getAllGames } from '../service/threats/models/eop';
@@ -299,17 +300,7 @@ export default {
             return res;
         },
         statuses() {
-            return [
-                {
-                    value: 'NotApplicable',
-                    text: this.$t('threats.status.notApplicable'),
-                },
-                { value: 'Open', text: this.$t('threats.status.open') },
-                {
-                    value: 'Mitigated',
-                    text: this.$t('threats.status.mitigated'),
-                },
-            ];
+            return getStatusOptions((key) => this.$t(key));
         },
         priorities() {
             return [

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -146,23 +146,10 @@
                             :label="$t('threats.properties.status')"
                             label-for="status"
                         >
-                            <td-dropdown
+                            <td-threat-status-selector
                                 id="status"
-                                variant="secondary"
-                                :text="selectedStatusText"
-                            >
-                                <template #default="{ close }">
-                                    <button
-                                        v-for="status in statuses"
-                                        :key="status.value"
-                                        type="button"
-                                        class="td-dropdown-item"
-                                        @click="threat.status = status.value; close()"
-                                    >
-                                        {{ status.text }}
-                                    </button>
-                                </template>
-                            </td-dropdown>
+                                v-model="threat.status"
+                            ></td-threat-status-selector>
                         </b-form-group>
                     </b-col>
 
@@ -278,10 +265,9 @@ import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
 import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
-import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
-import TdDropdown from '@/components/Dropdown.vue';
+import TdThreatStatusSelector from '@/components/ThreatStatusSelector.vue';
 import { getGame, getAllGames } from '../service/threats/models/eop';
 
 export default {
@@ -289,7 +275,7 @@ export default {
     components: {
         TdFormRadioGroup,
         TdFormSelect,
-        TdDropdown
+        TdThreatStatusSelector
     },
     computed: {
         ...mapState({
@@ -311,12 +297,6 @@ export default {
             }, this);
             if (!res.includes(this.threat.type)) res.push(this.threat.type);
             return res;
-        },
-        statuses() {
-            return getStatusOptions((key) => this.$t(key));
-        },
-        selectedStatusText() {
-            return this.statuses.find((status) => status.value === this.threat.status)?.text || '';
         },
         priorities() {
             return [

--- a/td.vue/src/components/ThreatStatusSelector.vue
+++ b/td.vue/src/components/ThreatStatusSelector.vue
@@ -1,0 +1,93 @@
+<template>
+    <div :id="id" class="btn-group td-threat-status-selector">
+        <td-form-radio-group
+            :id="`${id}-primary`"
+            :value="value"
+            :options="primaryOptions"
+            buttons
+            @input="selectStatus"
+        ></td-form-radio-group>
+        <td-dropdown
+            class="td-treatment-dropdown"
+            :class="{ active: treatmentSelected }"
+            variant="secondary"
+            :text="selectedTreatmentText"
+        >
+            <template #default="{ close }">
+                <button
+                    v-for="status in treatmentOptions"
+                    :key="status.value"
+                    type="button"
+                    class="td-dropdown-item"
+                    @click="selectStatus(status.value); close()"
+                >
+                    {{ status.text }}
+                </button>
+            </template>
+        </td-dropdown>
+    </div>
+</template>
+
+<script>
+import {
+    getPrimaryStatusOptions,
+    getTreatmentStatusOptions,
+    isResolved
+} from '@/service/threats/status.js';
+import TdDropdown from '@/components/Dropdown.vue';
+import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
+
+export default {
+    name: 'TdThreatStatusSelector',
+    components: {
+        TdDropdown,
+        TdFormRadioGroup
+    },
+    model: {
+        prop: 'value',
+        event: 'input'
+    },
+    props: {
+        id: {
+            type: String,
+            default: 'status'
+        },
+        value: {
+            type: String,
+            default: ''
+        }
+    },
+    computed: {
+        primaryOptions() {
+            return getPrimaryStatusOptions((key) => this.$t(key));
+        },
+        treatmentOptions() {
+            return getTreatmentStatusOptions((key) => this.$t(key));
+        },
+        treatmentSelected() {
+            return isResolved(this.value);
+        },
+        selectedTreatmentText() {
+            return this.treatmentOptions.find((status) => status.value === this.value)?.text
+                || this.treatmentOptions[0].text;
+        }
+    },
+    methods: {
+        selectStatus(status) {
+            this.$emit('input', status);
+            this.$emit('change', status);
+        }
+    }
+};
+</script>
+
+<style lang="scss" scoped>
+.td-threat-status-selector :deep(.bv-no-focus-ring) {
+    display: inline-flex;
+}
+
+.td-treatment-dropdown.active :deep(.td-dropdown-toggle) {
+    background-color: #5a6268;
+    border-color: #545b62;
+}
+</style>

--- a/td.vue/src/components/ThreatSuggestDialog.vue
+++ b/td.vue/src/components/ThreatSuggestDialog.vue
@@ -25,19 +25,7 @@
                     <b-col md=5>
                         <b-form-group id="status-group" class="float-left" :label="$t('threats.properties.status')"
                             label-for="status">
-                            <td-dropdown id="status" variant="secondary" :text="selectedStatusText">
-                                <template #default="{ close }">
-                                    <button
-                                        v-for="status in statuses"
-                                        :key="status.value"
-                                        type="button"
-                                        class="td-dropdown-item"
-                                        @click="threat.status = status.value; close()"
-                                    >
-                                        {{ status.text }}
-                                    </button>
-                                </template>
-                            </td-dropdown>
+                            <td-threat-status-selector id="status" v-model="threat.status"></td-threat-status-selector>
                         </b-form-group>
                     </b-col>
 
@@ -105,10 +93,9 @@ import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
 import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
-import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
-import TdDropdown from '@/components/Dropdown.vue';
+import TdThreatStatusSelector from '@/components/ThreatStatusSelector.vue';
 import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
 import { v4 as uuidv4 } from 'uuid';
 export default {
@@ -116,7 +103,7 @@ export default {
     components: {
         TdFormRadioGroup,
         TdFormSelect,
-        TdDropdown
+        TdThreatStatusSelector
     },
     computed: {
         ...mapState({
@@ -133,12 +120,6 @@ export default {
                 res.push(this.$t(type));
             }, this);
             return res;
-        },
-        statuses() {
-            return getStatusOptions((key) => this.$t(key));
-        },
-        selectedStatusText() {
-            return this.statuses.find((status) => status.value === this.threat.status)?.text || '';
         },
         priorities() {
             return [

--- a/td.vue/src/components/ThreatSuggestDialog.vue
+++ b/td.vue/src/components/ThreatSuggestDialog.vue
@@ -94,6 +94,7 @@ import { CELL_DATA_UPDATED } from '@/store/actions/cell.js';
 import tmActions from '@/store/actions/threatmodel.js';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import threatModels from '@/service/threats/models/index.js';
+import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
 import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
@@ -121,11 +122,7 @@ export default {
             return res;
         },
         statuses() {
-            return [
-                { value: 'NotApplicable', text: this.$t('threats.status.notApplicable') },
-                { value: 'Open', text: this.$t('threats.status.open') },
-                { value: 'Mitigated', text: this.$t('threats.status.mitigated') }
-            ];
+            return getStatusOptions((key) => this.$t(key));
         },
         priorities() {
             return [

--- a/td.vue/src/components/ThreatSuggestDialog.vue
+++ b/td.vue/src/components/ThreatSuggestDialog.vue
@@ -25,8 +25,19 @@
                     <b-col md=5>
                         <b-form-group id="status-group" class="float-left" :label="$t('threats.properties.status')"
                             label-for="status">
-                            <td-form-radio-group id="status" v-model="threat.status" :options="statuses"
-                                buttons></td-form-radio-group>
+                            <td-dropdown id="status" variant="secondary" :text="selectedStatusText">
+                                <template #default="{ close }">
+                                    <button
+                                        v-for="status in statuses"
+                                        :key="status.value"
+                                        type="button"
+                                        class="td-dropdown-item"
+                                        @click="threat.status = status.value; close()"
+                                    >
+                                        {{ status.text }}
+                                    </button>
+                                </template>
+                            </td-dropdown>
                         </b-form-group>
                     </b-col>
 
@@ -97,13 +108,15 @@ import threatModels from '@/service/threats/models/index.js';
 import { getStatusOptions } from '@/service/threats/status.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
+import TdDropdown from '@/components/Dropdown.vue';
 import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
 import { v4 as uuidv4 } from 'uuid';
 export default {
     name: 'TdThreatSuggest',
     components: {
         TdFormRadioGroup,
-        TdFormSelect
+        TdFormSelect,
+        TdDropdown
     },
     computed: {
         ...mapState({
@@ -123,6 +136,9 @@ export default {
         },
         statuses() {
             return getStatusOptions((key) => this.$t(key));
+        },
+        selectedStatusText() {
+            return this.statuses.find((status) => status.value === this.threat.status)?.text || '';
         },
         priorities() {
             return [

--- a/td.vue/src/components/printed-report/ExecutiveSummary.vue
+++ b/td.vue/src/components/printed-report/ExecutiveSummary.vue
@@ -39,6 +39,10 @@
                     <th>{{ $t('report.threatStats.avoided') }}</th>
                     <td class="td-summary-avoided">{{ threatsAvoided }}</td>
                 </tr>
+                <tr v-if="threatsEliminated" >
+                    <th>{{ $t('report.threatStats.eliminated') }}</th>
+                    <td class="td-summary-eliminated">{{ threatsEliminated }}</td>
+                </tr>
                 <tr>
                     <th>{{ $t('report.threatStats.notMitigated') }}</th>
                     <td class="td-summary-not-mitigated">{{ threatsOpen }}</td>
@@ -121,6 +125,11 @@ export default {
         threatsAvoided: function () {
             return this.threats
                 .filter(threat => threat.status === 'Avoided')
+                .length;
+        },
+        threatsEliminated: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Eliminated')
                 .length;
         },
         threatsOpen: function () {

--- a/td.vue/src/components/printed-report/ExecutiveSummary.vue
+++ b/td.vue/src/components/printed-report/ExecutiveSummary.vue
@@ -27,6 +27,18 @@
                     <th>{{ $t('report.threatStats.notApplicable') }}</th>
                     <td class="td-summary-not-applicable">{{ threatsNa }}</td>
                 </tr>
+                <tr v-if="threatsAccepted" >
+                    <th>{{ $t('report.threatStats.accepted') }}</th>
+                    <td class="td-summary-accepted">{{ threatsAccepted }}</td>
+                </tr>
+                <tr v-if="threatsTransferred" >
+                    <th>{{ $t('report.threatStats.transferred') }}</th>
+                    <td class="td-summary-transferred">{{ threatsTransferred }}</td>
+                </tr>
+                <tr v-if="threatsAvoided" >
+                    <th>{{ $t('report.threatStats.avoided') }}</th>
+                    <td class="td-summary-avoided">{{ threatsAvoided }}</td>
+                </tr>
                 <tr>
                     <th>{{ $t('report.threatStats.notMitigated') }}</th>
                     <td class="td-summary-not-mitigated">{{ threatsOpen }}</td>
@@ -94,6 +106,21 @@ export default {
         threatsNa: function () {
             return this.threats
                 .filter(threat => threat.status === 'NotApplicable')
+                .length;
+        },
+        threatsAccepted: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Accepted')
+                .length;
+        },
+        threatsTransferred: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Transferred')
+                .length;
+        },
+        threatsAvoided: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Avoided')
                 .length;
         },
         threatsOpen: function () {

--- a/td.vue/src/components/printed-report/ReportEntity.vue
+++ b/td.vue/src/components/printed-report/ReportEntity.vue
@@ -159,7 +159,10 @@ export default {
             return ({
                 'NotApplicable': this.$t('threats.status.notApplicable'),
                 'Open': this.$t('threats.status.open'),
-                'Mitigated': this.$t('threats.status.mitigated')
+                'Mitigated': this.$t('threats.status.mitigated'),
+                'Accepted': this.$t('threats.status.accepted'),
+                'Transferred': this.$t('threats.status.transferred'),
+                'Avoided': this.$t('threats.status.avoided')
             })[status] ?? 'Unknown';
         }
     }

--- a/td.vue/src/components/printed-report/ReportEntity.vue
+++ b/td.vue/src/components/printed-report/ReportEntity.vue
@@ -162,7 +162,8 @@ export default {
                 'Mitigated': this.$t('threats.status.mitigated'),
                 'Accepted': this.$t('threats.status.accepted'),
                 'Transferred': this.$t('threats.status.transferred'),
-                'Avoided': this.$t('threats.status.avoided')
+                'Avoided': this.$t('threats.status.avoided'),
+                'Eliminated': this.$t('threats.status.eliminated')
             })[status] ?? 'Unknown';
         }
     }

--- a/td.vue/src/components/report/DiagramDetail.vue
+++ b/td.vue/src/components/report/DiagramDetail.vue
@@ -63,6 +63,7 @@
 import TdPrintReportEntity from '@/components/printed-report/ReportEntity.vue';
 import TdReadOnlyDiagram from '@/components/ReadOnlyDiagram.vue';
 import TdReportEntity from '@/components/report/ReportEntity.vue';
+import { isResolved } from '@/service/threats/status.js';
 
 export default {
     name: 'TdDiagramDetail',
@@ -99,7 +100,7 @@ export default {
             return this.diagram.cells
                 .filter(x => !!x.data && !!x.data.threats
                     && (this.showOutOfScope || !x.data.outOfScope)
-                    && (this.showEmpty || x.data.threats.some(y => this.showMitigated || y.status.toLowerCase() !== 'mitigated')));
+                    && (this.showEmpty || x.data.threats.some(y => this.showMitigated || !isResolved(y.status))));
         }
     },
 };

--- a/td.vue/src/components/report/ExecutiveSummary.vue
+++ b/td.vue/src/components/report/ExecutiveSummary.vue
@@ -56,6 +56,15 @@ export default {
             if (this.threatsNa) {
                 totalStats.push({ metric: this.$t('report.threatStats.notApplicable'), total: this.threatsNa });
             }
+            if (this.threatsAccepted) {
+                totalStats.push({ metric: this.$t('report.threatStats.accepted'), total: this.threatsAccepted });
+            }
+            if (this.threatsTransferred) {
+                totalStats.push({ metric: this.$t('report.threatStats.transferred'), total: this.threatsTransferred });
+            }
+            if (this.threatsAvoided) {
+                totalStats.push({ metric: this.$t('report.threatStats.avoided'), total: this.threatsAvoided });
+            }
             if (this.openTbd) {
                 openStats.push({ metric: this.$t('report.threatStats.openTbd'), total: this.openTbd });
             }
@@ -75,6 +84,21 @@ export default {
         threatsNa: function () {
             return this.threats
                 .filter(threat => threat.status === 'NotApplicable')
+                .length;
+        },
+        threatsAccepted: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Accepted')
+                .length;
+        },
+        threatsTransferred: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Transferred')
+                .length;
+        },
+        threatsAvoided: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Avoided')
                 .length;
         },
         threatsOpen: function () {

--- a/td.vue/src/components/report/ExecutiveSummary.vue
+++ b/td.vue/src/components/report/ExecutiveSummary.vue
@@ -65,6 +65,9 @@ export default {
             if (this.threatsAvoided) {
                 totalStats.push({ metric: this.$t('report.threatStats.avoided'), total: this.threatsAvoided });
             }
+            if (this.threatsEliminated) {
+                totalStats.push({ metric: this.$t('report.threatStats.eliminated'), total: this.threatsEliminated });
+            }
             if (this.openTbd) {
                 openStats.push({ metric: this.$t('report.threatStats.openTbd'), total: this.openTbd });
             }
@@ -99,6 +102,11 @@ export default {
         threatsAvoided: function () {
             return this.threats
                 .filter(threat => threat.status === 'Avoided')
+                .length;
+        },
+        threatsEliminated: function () {
+            return this.threats
+                .filter(threat => threat.status === 'Eliminated')
                 .length;
         },
         threatsOpen: function () {

--- a/td.vue/src/components/report/ReportEntity.vue
+++ b/td.vue/src/components/report/ReportEntity.vue
@@ -166,7 +166,8 @@ export default {
                 'Mitigated': this.$t('threats.status.mitigated'),
                 'Accepted': this.$t('threats.status.accepted'),
                 'Transferred': this.$t('threats.status.transferred'),
-                'Avoided': this.$t('threats.status.avoided')
+                'Avoided': this.$t('threats.status.avoided'),
+                'Eliminated': this.$t('threats.status.eliminated')
             })[status] ?? 'Unknown';
         }
     }

--- a/td.vue/src/components/report/ReportEntity.vue
+++ b/td.vue/src/components/report/ReportEntity.vue
@@ -163,7 +163,10 @@ export default {
             return ({
                 'NotApplicable': this.$t('threats.status.notApplicable'),
                 'Open': this.$t('threats.status.open'),
-                'Mitigated': this.$t('threats.status.mitigated')
+                'Mitigated': this.$t('threats.status.mitigated'),
+                'Accepted': this.$t('threats.status.accepted'),
+                'Transferred': this.$t('threats.status.transferred'),
+                'Avoided': this.$t('threats.status.avoided')
             })[status] ?? 'Unknown';
         }
     }

--- a/td.vue/src/i18n/ar.js
+++ b/td.vue/src/i18n/ar.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'غير قابل للتطبيق',
             open: 'مفتوح',
-            mitigated: 'تم التخفيف'
+            mitigated: 'تم التخفيف',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'سيتم الإعلان عنها',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'إجمالي التهديدات',
             mitigated: 'الإجمالي المُخفف',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'الإجمالي غير المُخفف',
             openCritical: 'مفتوح / الأولوية الحرجة',

--- a/td.vue/src/i18n/de.js
+++ b/td.vue/src/i18n/de.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Offen',
-            mitigated: 'Abgeschwächt'
+            mitigated: 'Abgeschwächt',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: '',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Bedrohungen insgesamt',
             mitigated: 'Bedrohungen abgeschwächt',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Nicht abgeschwächt',
             openCritical: 'Offen / Kritische Priorität',

--- a/td.vue/src/i18n/el.js
+++ b/td.vue/src/i18n/el.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'Δεν έχει εφαρμογή',
             open: 'Ανοιχτή',
-            mitigated: 'Καλύφθηκε'
+            mitigated: 'Καλύφθηκε',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Σύνολο απειλών',
             mitigated: 'Σύνολο μετριασμένων',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Μη μετριασμένες',
             openCritical: 'Ανοιχτές / Κρίσιμη Προτεραιότητα',

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -471,7 +471,10 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Open',
-            mitigated: 'Mitigated'
+            mitigated: 'Mitigated',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +505,9 @@ const messages = {
         threatStats: {
             total: 'Total Threats',
             mitigated: 'Total Mitigated',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Total Open',
             openCritical: 'Open / Critical Severity',

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -474,7 +474,8 @@ const messages = {
             mitigated: 'Mitigated',
             accepted: 'Accepted',
             transferred: 'Transferred',
-            avoided: 'Avoided'
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -508,6 +509,7 @@ const messages = {
             accepted: 'Total Accepted',
             transferred: 'Total Transferred',
             avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Total Open',
             openCritical: 'Open / Critical Severity',

--- a/td.vue/src/i18n/es.js
+++ b/td.vue/src/i18n/es.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Abierto',
-            mitigated: 'Mitigado'
+            mitigated: 'Mitigado',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'Por confirmar',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Total amenazas ',
             mitigated: 'Total amenazas mitigadas',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'No Mitigadas',
             openCritical: 'Abierto / Crítica Prioridad',

--- a/td.vue/src/i18n/fi.js
+++ b/td.vue/src/i18n/fi.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Avoin',
-            mitigated: 'Hallittu'
+            mitigated: 'Hallittu',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Uhkia yhteensä',
             mitigated: 'Hallittuja uhkia',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Hallitsemattomia uhkia',
             openCritical: 'Avoin / Kriittinen tärkeys',

--- a/td.vue/src/i18n/fr.js
+++ b/td.vue/src/i18n/fr.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Ouvrir',
-            mitigated: 'Mitigé'
+            mitigated: 'Mitigé',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'à venir',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Menaces Totales',
             mitigated: 'Menaces Totales Mitigées',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Menaces Totales Non-Mitigées',
             openCritical:'Ouvert / Critique Priorité',

--- a/td.vue/src/i18n/hi.js
+++ b/td.vue/src/i18n/hi.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'लागू नहीं',
             open: 'खुला',
-            mitigated: 'शमन'
+            mitigated: 'शमन',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'टीबीए',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'कुल खतरे',
             mitigated: 'कुल शमन',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'कम नहीं किया गया',
             openCritical: 'ओपन / महत्वपूर्ण प्राथमिकता',

--- a/td.vue/src/i18n/id.js
+++ b/td.vue/src/i18n/id.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Terbuka',
-            mitigated: 'Diredam'
+            mitigated: 'Diredam',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Total Ancaman',
             mitigated: 'Total Diredam',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Belum Diredam',
             openCritical: 'Terbuka / Prioritas Kritis',

--- a/td.vue/src/i18n/ja.js
+++ b/td.vue/src/i18n/ja.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: '未対応',
-            mitigated: '解決済み'
+            mitigated: '解決済み',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: '未定',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: '脅威総数',
             mitigated: '対策済みの脅威',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: '未対策の脅威',
             openCritical: '未対応 / 最優先事項',

--- a/td.vue/src/i18n/ms.js
+++ b/td.vue/src/i18n/ms.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'T/A',
             open: 'Buka',
-            mitigated: 'Ditangani'
+            mitigated: 'Ditangani',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Jumlah Ancaman',
             mitigated: 'Jumlah Ditangani',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Belum Ditangani',
             openCritical: 'Buka / Keutamaan Kritikal',

--- a/td.vue/src/i18n/pt-br.js
+++ b/td.vue/src/i18n/pt-br.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Aberta',
-            mitigated: 'Mitigada'
+            mitigated: 'Mitigada',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'A definir',
@@ -502,6 +506,10 @@ const messages = {
         threatStats : {
             total: 'Ameaças totais',
             mitigated: 'Total Mitigada',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Não Aplicável',
             notMitigated : 'Não Mitigada',
             openCritical : 'Aberta / Severidade Crítica',

--- a/td.vue/src/i18n/pt.js
+++ b/td.vue/src/i18n/pt.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Aberta',
-            mitigated: 'Mitigada'
+            mitigated: 'Mitigada',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'Por definir',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Total de Ameaças',
             mitigated: 'Total Mitigadas',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Não Aplicáveis',
             notMitigated: 'Total Abertas',
             openCritical: 'Abertas / Severidade Crítica',

--- a/td.vue/src/i18n/ru.js
+++ b/td.vue/src/i18n/ru.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Open',
-            mitigated: 'Mitigated'
+            mitigated: 'Mitigated',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Total Threats',
             mitigated: 'Total Mitigated',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Total Open',
             openCritical: 'Open / Critical Severity',

--- a/td.vue/src/i18n/uk.js
+++ b/td.vue/src/i18n/uk.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: 'N/A',
             open: 'Open',
-            mitigated: 'Mitigated'
+            mitigated: 'Mitigated',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: 'TBD',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: 'Total Threats',
             mitigated: 'Total Mitigated',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: 'Total Not Applicable',
             notMitigated: 'Total Open',
             openCritical: 'Open / Critical Severity',

--- a/td.vue/src/i18n/zh.js
+++ b/td.vue/src/i18n/zh.js
@@ -471,7 +471,11 @@ const messages = {
         status: {
             notApplicable: '不适用',
             open: '未解决',
-            mitigated: '缓解'
+            mitigated: '缓解',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         },
         severity: {
             tbd: '待定',
@@ -502,6 +506,10 @@ const messages = {
         threatStats: {
             total: '威胁总数',
             mitigated: '已缓解总数',
+            accepted: 'Total Accepted',
+            transferred: 'Total Transferred',
+            avoided: 'Total Avoided',
+            eliminated: 'Total Eliminated',
             notApplicable: '不适用总计',
             notMitigated: '未缓解',
             openCritical: '未解决/关键优先级',

--- a/td.vue/src/service/migration/tmBom/diagrams/threats/threats.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/threats/threats.js
@@ -19,7 +19,16 @@ export const defaults = {likelihood: 'certain', riskLevelBand: 'high', source: '
 
 const convertImpact = {TBD: 'negligible', Low: 'minor', Medium: 'moderate', High: 'major', Critical: 'severe'};
 const convertPriority = {TBD: 'none', Low: 'low', Medium: 'medium', High: 'high', Critical: 'critical'};
-const convertControlStatus = {NotApplicable: 'wont_do', Open: 'under_review', Mitigated: 'active'};
+// TM-BOM has no native risk-treatment concept, so the accepted/transferred/avoided
+// statuses are mapped to the nearest valid control-status from the TM-BOM schema
+const convertControlStatus = {
+    NotApplicable: 'wont_do',
+    Open: 'under_review',
+    Mitigated: 'active',
+    Accepted: 'assumed',
+    Transferred: 'approved',
+    Avoided: 'retired'
+};
 
 const convert = (model) => { 
     let vulns = {

--- a/td.vue/src/service/migration/tmBom/diagrams/threats/threats.js
+++ b/td.vue/src/service/migration/tmBom/diagrams/threats/threats.js
@@ -19,15 +19,14 @@ export const defaults = {likelihood: 'certain', riskLevelBand: 'high', source: '
 
 const convertImpact = {TBD: 'negligible', Low: 'minor', Medium: 'moderate', High: 'major', Critical: 'severe'};
 const convertPriority = {TBD: 'none', Low: 'low', Medium: 'medium', High: 'high', Critical: 'critical'};
-// TM-BOM has no native risk-treatment concept, so the accepted/transferred/avoided
-// statuses are mapped to the nearest valid control-status from the TM-BOM schema
 const convertControlStatus = {
     NotApplicable: 'wont_do',
     Open: 'under_review',
     Mitigated: 'active',
     Accepted: 'assumed',
     Transferred: 'approved',
-    Avoided: 'retired'
+    Avoided: 'retired',
+    Eliminated: 'retired'
 };
 
 const convert = (model) => { 

--- a/td.vue/src/service/threats/index.js
+++ b/td.vue/src/service/threats/index.js
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import models from './models/index.js';
+import { isOpen, isResolved } from './status.js';
 import { tc } from '../../i18n/index.js';
 import store from '@/store/index.js';
 
@@ -132,7 +133,7 @@ export const createNewTypedThreat = function (modelType, cellType,number) {
 };
 
 const hasOpenThreats = (data) => !!data && !!data.threats &&
-    data.threats.filter(x => x.status.toLowerCase() === 'open').length > 0;
+    data.threats.filter(x => isOpen(x.status)).length > 0;
 
 const filter = (diagrams, filters) => {
     return diagrams
@@ -152,7 +153,7 @@ const filterForDiagram = (data, filters) => {
         return [];
     }
 
-    return data.threats.filter(x => filters.showMitigated || x.status.toLowerCase() !== 'mitigated');
+    return data.threats.filter(x => filters.showMitigated || !isResolved(x.status));
 };
 
 export default {

--- a/td.vue/src/service/threats/status.js
+++ b/td.vue/src/service/threats/status.js
@@ -1,68 +1,49 @@
-/**
- * Single source of truth for threat status values and their semantics.
- *
- * Stored `value` strings are persisted into saved threat-model JSON, so they are
- * stable identifiers and must not be renamed. The human-readable labels come
- * from i18n (see STATUS_TRANSLATION_KEYS) and can be changed freely.
- *
- * "Resolved" statuses are those that represent a decided risk-treatment outcome
- * (the threat is no longer open): Mitigated, Accepted, Transferred, Avoided.
- */
-export const THREAT_STATUS = {
-    NOT_APPLICABLE: 'NotApplicable',
-    OPEN: 'Open',
-    MITIGATED: 'Mitigated',
-    ACCEPTED: 'Accepted',
-    TRANSFERRED: 'Transferred',
-    AVOIDED: 'Avoided'
+export const threatStatus = {
+    notApplicable: 'NotApplicable',
+    open: 'Open',
+    mitigated: 'Mitigated',
+    accepted: 'Accepted',
+    transferred: 'Transferred',
+    avoided: 'Avoided',
+    eliminated: 'Eliminated'
 };
 
-export const STATUS_TRANSLATION_KEYS = {
-    [THREAT_STATUS.NOT_APPLICABLE]: 'threats.status.notApplicable',
-    [THREAT_STATUS.OPEN]: 'threats.status.open',
-    [THREAT_STATUS.MITIGATED]: 'threats.status.mitigated',
-    [THREAT_STATUS.ACCEPTED]: 'threats.status.accepted',
-    [THREAT_STATUS.TRANSFERRED]: 'threats.status.transferred',
-    [THREAT_STATUS.AVOIDED]: 'threats.status.avoided'
+const statusTranslationKeys = {
+    [threatStatus.notApplicable]: 'threats.status.notApplicable',
+    [threatStatus.open]: 'threats.status.open',
+    [threatStatus.mitigated]: 'threats.status.mitigated',
+    [threatStatus.accepted]: 'threats.status.accepted',
+    [threatStatus.transferred]: 'threats.status.transferred',
+    [threatStatus.avoided]: 'threats.status.avoided',
+    [threatStatus.eliminated]: 'threats.status.eliminated'
 };
 
-export const STATUS_ORDER = [
-    THREAT_STATUS.NOT_APPLICABLE,
-    THREAT_STATUS.OPEN,
-    THREAT_STATUS.MITIGATED,
-    THREAT_STATUS.ACCEPTED,
-    THREAT_STATUS.TRANSFERRED,
-    THREAT_STATUS.AVOIDED
+export const primaryStatuses = [
+    threatStatus.notApplicable,
+    threatStatus.open
 ];
 
-export const RESOLVED_STATUSES = [
-    THREAT_STATUS.MITIGATED,
-    THREAT_STATUS.ACCEPTED,
-    THREAT_STATUS.TRANSFERRED,
-    THREAT_STATUS.AVOIDED
+export const treatmentStatuses = [
+    threatStatus.mitigated,
+    threatStatus.accepted,
+    threatStatus.transferred,
+    threatStatus.avoided,
+    threatStatus.eliminated
 ];
 
 const lower = (status) => (status || '').toLowerCase();
+const getOptions = (statuses, translate) =>
+    statuses.map((value) => ({ value, text: translate(statusTranslationKeys[value]) }));
 
-export const isOpen = (status) => lower(status) === lower(THREAT_STATUS.OPEN);
-
+export const isOpen = (status) => lower(status) === lower(threatStatus.open);
 export const isResolved = (status) =>
-    RESOLVED_STATUSES.some((resolved) => lower(resolved) === lower(status));
-
-/**
- * Builds the option list for the status dropdowns.
- * @param {(key: string) => string} translate - i18n translate function
- * @returns {{ value: string, text: string }[]}
- */
-export const getStatusOptions = (translate) =>
-    STATUS_ORDER.map((value) => ({ value, text: translate(STATUS_TRANSLATION_KEYS[value]) }));
+    treatmentStatuses.some((resolved) => lower(resolved) === lower(status));
+export const getPrimaryStatusOptions = (translate) => getOptions(primaryStatuses, translate);
+export const getTreatmentStatusOptions = (translate) => getOptions(treatmentStatuses, translate);
 
 export default {
-    THREAT_STATUS,
-    STATUS_TRANSLATION_KEYS,
-    STATUS_ORDER,
-    RESOLVED_STATUSES,
+    getPrimaryStatusOptions,
+    getTreatmentStatusOptions,
     isOpen,
-    isResolved,
-    getStatusOptions
+    isResolved
 };

--- a/td.vue/src/service/threats/status.js
+++ b/td.vue/src/service/threats/status.js
@@ -1,0 +1,68 @@
+/**
+ * Single source of truth for threat status values and their semantics.
+ *
+ * Stored `value` strings are persisted into saved threat-model JSON, so they are
+ * stable identifiers and must not be renamed. The human-readable labels come
+ * from i18n (see STATUS_TRANSLATION_KEYS) and can be changed freely.
+ *
+ * "Resolved" statuses are those that represent a decided risk-treatment outcome
+ * (the threat is no longer open): Mitigated, Accepted, Transferred, Avoided.
+ */
+export const THREAT_STATUS = {
+    NOT_APPLICABLE: 'NotApplicable',
+    OPEN: 'Open',
+    MITIGATED: 'Mitigated',
+    ACCEPTED: 'Accepted',
+    TRANSFERRED: 'Transferred',
+    AVOIDED: 'Avoided'
+};
+
+export const STATUS_TRANSLATION_KEYS = {
+    [THREAT_STATUS.NOT_APPLICABLE]: 'threats.status.notApplicable',
+    [THREAT_STATUS.OPEN]: 'threats.status.open',
+    [THREAT_STATUS.MITIGATED]: 'threats.status.mitigated',
+    [THREAT_STATUS.ACCEPTED]: 'threats.status.accepted',
+    [THREAT_STATUS.TRANSFERRED]: 'threats.status.transferred',
+    [THREAT_STATUS.AVOIDED]: 'threats.status.avoided'
+};
+
+export const STATUS_ORDER = [
+    THREAT_STATUS.NOT_APPLICABLE,
+    THREAT_STATUS.OPEN,
+    THREAT_STATUS.MITIGATED,
+    THREAT_STATUS.ACCEPTED,
+    THREAT_STATUS.TRANSFERRED,
+    THREAT_STATUS.AVOIDED
+];
+
+export const RESOLVED_STATUSES = [
+    THREAT_STATUS.MITIGATED,
+    THREAT_STATUS.ACCEPTED,
+    THREAT_STATUS.TRANSFERRED,
+    THREAT_STATUS.AVOIDED
+];
+
+const lower = (status) => (status || '').toLowerCase();
+
+export const isOpen = (status) => lower(status) === lower(THREAT_STATUS.OPEN);
+
+export const isResolved = (status) =>
+    RESOLVED_STATUSES.some((resolved) => lower(resolved) === lower(status));
+
+/**
+ * Builds the option list for the status dropdowns.
+ * @param {(key: string) => string} translate - i18n translate function
+ * @returns {{ value: string, text: string }[]}
+ */
+export const getStatusOptions = (translate) =>
+    STATUS_ORDER.map((value) => ({ value, text: translate(STATUS_TRANSLATION_KEYS[value]) }));
+
+export default {
+    THREAT_STATUS,
+    STATUS_TRANSLATION_KEYS,
+    STATUS_ORDER,
+    RESOLVED_STATUSES,
+    isOpen,
+    isResolved,
+    getStatusOptions
+};

--- a/td.vue/tests/e2e/desktop/support/diagram.js
+++ b/td.vue/tests/e2e/desktop/support/diagram.js
@@ -12,7 +12,8 @@ const diagramView = {
         closeButton: 'button.btn.btn-secondary',
         editThreatTitle: '#threat-edit #title',
         editThreatMitigation: '#threat-edit #mitigation',
-        statusMitigatedButton: '//div[@id="status"]//label[contains(normalize-space(), "Mitigated")]',
+        statusDropdownToggle: '//div[@id="status"]//button[contains(@class, "td-dropdown-toggle")]',
+        statusMitigatedItem: '//div[@id="status"]//button[contains(@class, "td-dropdown-item") and normalize-space()="Mitigated"]',
         applyButton: '//div[@id="threat-edit"]//button[normalize-space()="Apply"]'
     }
 };
@@ -62,15 +63,27 @@ const createMitigatedThreat = async (title, mitigation) => {
     const browser = getBrowser();
     const titleInput = await browser.$(diagramView.selectors.editThreatTitle);
     const mitigationInput = await browser.$(diagramView.selectors.editThreatMitigation);
-    const mitigatedButton = await browser.$(diagramView.selectors.statusMitigatedButton);
+    const statusToggle = await browser.$(diagramView.selectors.statusDropdownToggle);
     const applyButton = await browser.$(diagramView.selectors.applyButton);
 
     await titleInput.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
     await titleInput.clearValue();
     await titleInput.setValue(title);
     await mitigationInput.setValue(mitigation);
-    await mitigatedButton.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
-    await mitigatedButton.click();
+
+    // open the status dropdown and choose Mitigated
+    await statusToggle.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
+    await statusToggle.click();
+    const mitigatedItem = await browser.$(diagramView.selectors.statusMitigatedItem);
+    await mitigatedItem.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
+    await mitigatedItem.click();
+
+    // confirm the dropdown now reflects the chosen status before applying
+    await browser.waitUntil(
+        async () => (await statusToggle.getText()).includes('Mitigated'),
+        { timeout: UI_WAIT_TIMEOUT_MS, timeoutMsg: 'Timed out waiting for the status to update to Mitigated' }
+    );
+
     await applyButton.waitForDisplayed({ timeout: UI_WAIT_TIMEOUT_MS });
     await applyButton.click();
 

--- a/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
+++ b/td.vue/tests/e2e/specs/threatmodel/vue3-regressions.cy.js
@@ -119,8 +119,9 @@ describe('Regressions discovered during vue3 migration', () => {
         cy.contains('.threat-card a', 'Unauthorised access').click();
         withinVisibleModal(() => {
             selectAlternateThreatType();
-            cy.get('#status input[type="radio"]').check('Mitigated', { force: true });
-            cy.get('#status input[type="radio"][value="Mitigated"]').should('be.checked');
+            cy.get('#status button.td-dropdown-toggle').click();
+            cy.get('#status .td-dropdown-menu').contains('button', 'Mitigated').click();
+            cy.get('#status button.td-dropdown-toggle').should('contain', 'Mitigated');
             cy.get('#severity input[type="radio"]').check('Low', { force: true });
             cy.get('#severity input[type="radio"][value="Low"]').should('be.checked');
         });
@@ -136,8 +137,9 @@ describe('Regressions discovered during vue3 migration', () => {
         cy.contains('a.new-threat-by-type', 'New Threat by Type').click();
         withinVisibleModal(() => {
             selectAlternateThreatType();
-            cy.get('#status input[type="radio"]').check('Mitigated', { force: true });
-            cy.get('#status input[type="radio"][value="Mitigated"]').should('be.checked');
+            cy.get('#status button.td-dropdown-toggle').click();
+            cy.get('#status .td-dropdown-menu').contains('button', 'Mitigated').click();
+            cy.get('#status button.td-dropdown-toggle').should('contain', 'Mitigated');
             cy.get('#severity input[type="radio"]').check('Low', { force: true });
             cy.get('#severity input[type="radio"][value="Low"]').should('be.checked');
         });

--- a/td.vue/tests/unit/components/graphThreats.spec.js
+++ b/td.vue/tests/unit/components/graphThreats.spec.js
@@ -106,6 +106,13 @@ describe('components/GraphThreats.vue', () => {
             expect(wrapper.find('.threat-icon.green-icon').exists()).toEqual(true);
         });
 
+        it('displays a green check for eliminated', () => {
+            const propsData = getDefaultPropsData();
+            propsData.status = 'Eliminated';
+            wrapper = getWrapper(propsData);
+            expect(wrapper.find('.threat-icon.green-icon').exists()).toEqual(true);
+        });
+
         it('displays a darkred circle for critical severity', () => {
             const propsData = getDefaultPropsData();
             propsData.severity = 'Critical';

--- a/td.vue/tests/unit/components/graphThreats.spec.js
+++ b/td.vue/tests/unit/components/graphThreats.spec.js
@@ -85,6 +85,27 @@ describe('components/GraphThreats.vue', () => {
             expect(wrapper.find('.threat-icon.gray-icon').exists()).toEqual(true);
         });
 
+        it('displays a green check for accepted', () => {
+            const propsData = getDefaultPropsData();
+            propsData.status = 'Accepted';
+            wrapper = getWrapper(propsData);
+            expect(wrapper.find('.threat-icon.green-icon').exists()).toEqual(true);
+        });
+
+        it('displays a green check for transferred', () => {
+            const propsData = getDefaultPropsData();
+            propsData.status = 'Transferred';
+            wrapper = getWrapper(propsData);
+            expect(wrapper.find('.threat-icon.green-icon').exists()).toEqual(true);
+        });
+
+        it('displays a green check for avoided', () => {
+            const propsData = getDefaultPropsData();
+            propsData.status = 'Avoided';
+            wrapper = getWrapper(propsData);
+            expect(wrapper.find('.threat-icon.green-icon').exists()).toEqual(true);
+        });
+
         it('displays a darkred circle for critical severity', () => {
             const propsData = getDefaultPropsData();
             propsData.severity = 'Critical';

--- a/td.vue/tests/unit/components/printed-report/executiveSummary.spec.js
+++ b/td.vue/tests/unit/components/printed-report/executiveSummary.spec.js
@@ -114,4 +114,23 @@ describe('components/printed-report/ExecutiveSummary.vue', () => {
         expect(wrapper.find('.td-summary-open-unknown').text())
             .toEqual('1');
     });
+
+    it('counts the accepted threats', () => {
+        setup({ summary: '', threats: [{ status: 'Accepted', severity: 'High' }, { status: 'Open', severity: 'Low' }] });
+        expect(wrapper.find('.td-summary-accepted').text()).toEqual('1');
+    });
+
+    it('counts the transferred threats', () => {
+        setup({ summary: '', threats: [{ status: 'Transferred', severity: 'High' }, { status: 'Transferred', severity: 'Low' }] });
+        expect(wrapper.find('.td-summary-transferred').text()).toEqual('2');
+    });
+
+    it('counts the avoided threats', () => {
+        setup({ summary: '', threats: [{ status: 'Avoided', severity: 'High' }] });
+        expect(wrapper.find('.td-summary-avoided').text()).toEqual('1');
+    });
+
+    it('omits the accepted row when there are no accepted threats', () => {
+        expect(wrapper.find('.td-summary-accepted').exists()).toEqual(false);
+    });
 });

--- a/td.vue/tests/unit/components/printed-report/executiveSummary.spec.js
+++ b/td.vue/tests/unit/components/printed-report/executiveSummary.spec.js
@@ -130,6 +130,11 @@ describe('components/printed-report/ExecutiveSummary.vue', () => {
         expect(wrapper.find('.td-summary-avoided').text()).toEqual('1');
     });
 
+    it('counts the eliminated threats', () => {
+        setup({ summary: '', threats: [{ status: 'Eliminated', severity: 'High' }] });
+        expect(wrapper.find('.td-summary-eliminated').text()).toEqual('1');
+    });
+
     it('omits the accepted row when there are no accepted threats', () => {
         expect(wrapper.find('.td-summary-accepted').exists()).toEqual(false);
     });

--- a/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
@@ -166,4 +166,20 @@ describe('components/printed-report/ReportEntity.vue', () => {
     it('shows the threat mitigation for t3', () => {
         expect(tableHasCellWithText('No need to do things')).toEqual(true);
     });
+
+    it('translates the accepted status', () => {
+        expect(wrapper.vm.translateStatus('Accepted')).toEqual('threats.status.accepted');
+    });
+
+    it('translates the transferred status', () => {
+        expect(wrapper.vm.translateStatus('Transferred')).toEqual('threats.status.transferred');
+    });
+
+    it('translates the avoided status', () => {
+        expect(wrapper.vm.translateStatus('Avoided')).toEqual('threats.status.avoided');
+    });
+
+    it('falls back to Unknown for an unrecognised status', () => {
+        expect(wrapper.vm.translateStatus('Bogus')).toEqual('Unknown');
+    });
 });

--- a/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/printed-report/reportEntity.spec.js
@@ -179,6 +179,10 @@ describe('components/printed-report/ReportEntity.vue', () => {
         expect(wrapper.vm.translateStatus('Avoided')).toEqual('threats.status.avoided');
     });
 
+    it('translates eliminated status', () => {
+        expect(wrapper.vm.translateStatus('Eliminated')).toEqual('threats.status.eliminated');
+    });
+
     it('falls back to Unknown for an unrecognised status', () => {
         expect(wrapper.vm.translateStatus('Bogus')).toEqual('Unknown');
     });

--- a/td.vue/tests/unit/components/report/executiveSummary.spec.js
+++ b/td.vue/tests/unit/components/report/executiveSummary.spec.js
@@ -87,6 +87,30 @@ describe('components/report/ExecutiveSummary.vue', () => {
             .toEqual(2);
     });
 
+    it('counts the accepted threats', () => {
+        const ctx = { threats: [{ status: 'Accepted' }, { status: 'Open' }] };
+        expect(TdExecutiveSummary.computed.threatsAccepted.call(ctx)).toEqual(1);
+    });
+
+    it('counts the transferred threats', () => {
+        const ctx = { threats: [{ status: 'Transferred' }, { status: 'Transferred' }] };
+        expect(TdExecutiveSummary.computed.threatsTransferred.call(ctx)).toEqual(2);
+    });
+
+    it('counts the avoided threats', () => {
+        const ctx = { threats: [{ status: 'Avoided' }] };
+        expect(TdExecutiveSummary.computed.threatsAvoided.call(ctx)).toEqual(1);
+    });
+
+    it('includes a row for accepted threats when present', () => {
+        setup({ summary: '', threats: [{ status: 'Accepted', severity: 'High' }] });
+        expect(wrapper.vm.tableRows.some(r => r.metric === 'report.threatStats.accepted')).toEqual(true);
+    });
+
+    it('omits the accepted row when there are none', () => {
+        expect(wrapper.vm.tableRows.some(r => r.metric === 'report.threatStats.accepted')).toEqual(false);
+    });
+
     it('gets the data test id from the row item', () => {
         const item = { metric: 'foo' };
         const res = wrapper.vm.getDataTestId(item);

--- a/td.vue/tests/unit/components/report/executiveSummary.spec.js
+++ b/td.vue/tests/unit/components/report/executiveSummary.spec.js
@@ -102,6 +102,11 @@ describe('components/report/ExecutiveSummary.vue', () => {
         expect(TdExecutiveSummary.computed.threatsAvoided.call(ctx)).toEqual(1);
     });
 
+    it('counts the eliminated threats', () => {
+        const ctx = { threats: [{ status: 'Eliminated' }] };
+        expect(TdExecutiveSummary.computed.threatsEliminated.call(ctx)).toEqual(1);
+    });
+
     it('includes a row for accepted threats when present', () => {
         setup({ summary: '', threats: [{ status: 'Accepted', severity: 'High' }] });
         expect(wrapper.vm.tableRows.some(r => r.metric === 'report.threatStats.accepted')).toEqual(true);
@@ -109,6 +114,11 @@ describe('components/report/ExecutiveSummary.vue', () => {
 
     it('omits the accepted row when there are none', () => {
         expect(wrapper.vm.tableRows.some(r => r.metric === 'report.threatStats.accepted')).toEqual(false);
+    });
+
+    it('includes a row for eliminated threats when present', () => {
+        setup({ summary: '', threats: [{ status: 'Eliminated', severity: 'High' }] });
+        expect(wrapper.vm.tableRows.some(r => r.metric === 'report.threatStats.eliminated')).toEqual(true);
     });
 
     it('gets the data test id from the row item', () => {

--- a/td.vue/tests/unit/components/report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/report/reportEntity.spec.js
@@ -120,6 +120,10 @@ describe('components/report/ReportEntity.vue', () => {
             expect(wrapper.vm.translateStatus('Avoided')).toEqual('threats.status.avoided');
         });
 
+        it('translates eliminated status', () => {
+            expect(wrapper.vm.translateStatus('Eliminated')).toEqual('threats.status.eliminated');
+        });
+
         it('falls back to Unknown for an unrecognised status', () => {
             expect(wrapper.vm.translateStatus('Bogus')).toEqual('Unknown');
         });

--- a/td.vue/tests/unit/components/report/reportEntity.spec.js
+++ b/td.vue/tests/unit/components/report/reportEntity.spec.js
@@ -96,10 +96,32 @@ describe('components/report/ReportEntity.vue', () => {
             propsData.outOfScope = true;
             setup(propsData);
         });
-        
+
         it('has a table with the threats', () => {
             expect(wrapper.findComponent(BTable).exists())
                 .toEqual(true);
+        });
+    });
+
+    describe('translateStatus', () => {
+        beforeEach(() => {
+            setup(getData());
+        });
+
+        it('translates the accepted status', () => {
+            expect(wrapper.vm.translateStatus('Accepted')).toEqual('threats.status.accepted');
+        });
+
+        it('translates the transferred status', () => {
+            expect(wrapper.vm.translateStatus('Transferred')).toEqual('threats.status.transferred');
+        });
+
+        it('translates the avoided status', () => {
+            expect(wrapper.vm.translateStatus('Avoided')).toEqual('threats.status.avoided');
+        });
+
+        it('falls back to Unknown for an unrecognised status', () => {
+            expect(wrapper.vm.translateStatus('Bogus')).toEqual('Unknown');
         });
     });
 });

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -5,7 +5,7 @@ import Vuex from 'vuex';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
-import TdDropdown from '@/components/Dropdown.vue';
+import TdThreatStatusSelector from '@/components/ThreatStatusSelector.vue';
 import TdThreatEditDialog from '@/components/ThreatEditDialog.vue';
 
 describe('components/ThreatEditDialog.vue', () => {
@@ -89,21 +89,12 @@ describe('components/ThreatEditDialog.vue', () => {
             expect(input.exists()).toEqual(true);
         });
 
-        it('has a status dropdown', () => {
-            const dropdown = wrapper.findAllComponents(TdDropdown)
+        it('has a threat status selector', () => {
+            const selector = wrapper.findAllComponents(TdThreatStatusSelector)
                 .filter(x => x.attributes('id') === 'status')
                 .at(0);
 
-            expect(dropdown.exists()).toEqual(true);
-        });
-
-        it('shows the selected status as the dropdown text', () => {
-            expect(wrapper.vm.selectedStatusText).toEqual('threats.status.open');
-        });
-
-        it('shows empty dropdown text for an unknown status', () => {
-            wrapper.vm.threat.status = 'Bogus';
-            expect(wrapper.vm.selectedStatusText).toEqual('');
+            expect(selector.exists()).toEqual(true);
         });
 
         it('has a score input', () => {

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -5,6 +5,7 @@ import Vuex from 'vuex';
 import dataChanged from '@/service/x6/graph/data-changed.js';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 import TdFormSelect from '@/components/FormSelect.vue';
+import TdDropdown from '@/components/Dropdown.vue';
 import TdThreatEditDialog from '@/components/ThreatEditDialog.vue';
 
 describe('components/ThreatEditDialog.vue', () => {
@@ -88,12 +89,21 @@ describe('components/ThreatEditDialog.vue', () => {
             expect(input.exists()).toEqual(true);
         });
 
-        it('has a status input', () => {
-            const input = wrapper.findAllComponents(TdFormRadioGroup)
+        it('has a status dropdown', () => {
+            const dropdown = wrapper.findAllComponents(TdDropdown)
                 .filter(x => x.attributes('id') === 'status')
                 .at(0);
 
-            expect(input.exists()).toEqual(true);
+            expect(dropdown.exists()).toEqual(true);
+        });
+
+        it('shows the selected status as the dropdown text', () => {
+            expect(wrapper.vm.selectedStatusText).toEqual('threats.status.open');
+        });
+
+        it('shows empty dropdown text for an unknown status', () => {
+            wrapper.vm.threat.status = 'Bogus';
+            expect(wrapper.vm.selectedStatusText).toEqual('');
         });
 
         it('has a score input', () => {

--- a/td.vue/tests/unit/components/threatStatusSelector.spec.js
+++ b/td.vue/tests/unit/components/threatStatusSelector.spec.js
@@ -1,0 +1,81 @@
+import { mount, shallowMount } from '@vue/test-utils';
+
+import TdDropdown from '@/components/Dropdown.vue';
+import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
+import TdThreatStatusSelector from '@/components/ThreatStatusSelector.vue';
+
+describe('components/ThreatStatusSelector.vue', () => {
+    const getWrapper = (value, propsData = {}) => shallowMount(TdThreatStatusSelector, {
+        propsData: {
+            value,
+            ...propsData
+        },
+        mocks: {
+            $t: key => key
+        }
+    });
+
+    it('renders primary statuses as radio buttons', () => {
+        const radioGroup = getWrapper('Open').findComponent(TdFormRadioGroup);
+        expect(radioGroup.props('options')).toEqual([
+            { value: 'NotApplicable', text: 'threats.status.notApplicable' },
+            { value: 'Open', text: 'threats.status.open' }
+        ]);
+    });
+
+    it('renders treatments in a dropdown', () => {
+        const dropdown = getWrapper('Open').findComponent(TdDropdown);
+        expect(dropdown.exists()).toEqual(true);
+    });
+
+    it('shows Mitigated as the default treatment text', () => {
+        expect(getWrapper('Open').findComponent(TdDropdown).props('text'))
+            .toEqual('threats.status.mitigated');
+    });
+
+    it('shows the selected treatment text', () => {
+        expect(getWrapper('Eliminated').findComponent(TdDropdown).props('text'))
+            .toEqual('threats.status.eliminated');
+    });
+
+    it('marks the treatment dropdown active for resolved statuses', () => {
+        expect(getWrapper('Accepted').findComponent(TdDropdown).classes()).toContain('active');
+    });
+
+    it('does not mark the treatment dropdown active for primary statuses', () => {
+        expect(getWrapper('Open').findComponent(TdDropdown).classes()).not.toContain('active');
+    });
+
+    it('uses status as the default id', () => {
+        expect(getWrapper('Open').attributes('id')).toEqual('status');
+    });
+
+    it('supports a custom id', () => {
+        expect(getWrapper('Open', { id: 'suggested-status' }).attributes('id')).toEqual('suggested-status');
+    });
+
+    it('emits input when a primary status is selected', () => {
+        const wrapper = getWrapper('Mitigated');
+        wrapper.findComponent(TdFormRadioGroup).vm.$emit('input', 'Open');
+        expect(wrapper.emitted('input')[0]).toEqual(['Open']);
+    });
+
+    it('emits input and change when a status is selected', () => {
+        const wrapper = getWrapper('Open');
+        wrapper.vm.selectStatus('Avoided');
+        expect(wrapper.emitted('input')[0]).toEqual(['Avoided']);
+        expect(wrapper.emitted('change')[0]).toEqual(['Avoided']);
+    });
+
+    it('selects a treatment from the dropdown menu', async () => {
+        const wrapper = mount(TdThreatStatusSelector, {
+            propsData: { value: 'Open' },
+            mocks: { $t: key => key }
+        });
+
+        await wrapper.find('.td-dropdown-toggle').trigger('click');
+        await wrapper.findAll('.td-dropdown-item').at(4).trigger('click');
+
+        expect(wrapper.emitted('input')[0]).toEqual(['Eliminated']);
+    });
+});

--- a/td.vue/tests/unit/components/threatSuggestDialog.spec.js
+++ b/td.vue/tests/unit/components/threatSuggestDialog.spec.js
@@ -1,0 +1,49 @@
+import { BootstrapVue } from 'bootstrap-vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import TdDropdown from '@/components/Dropdown.vue';
+import TdThreatSuggestDialog from '@/components/ThreatSuggestDialog.vue';
+
+describe('components/ThreatSuggestDialog.vue', () => {
+    let localVue, wrapper;
+
+    const getStore = () => new Vuex.Store({
+        state: {
+            cell: { ref: { data: { type: 'tm.Process', threats: [] } } },
+            threatmodel: {
+                selectedDiagram: { diagramType: 'STRIDE' },
+                data: { detail: { threatTop: 0 } }
+            }
+        },
+        actions: { CELL_DATA_UPDATED: () => {} }
+    });
+
+    beforeEach(() => {
+        localVue = createLocalVue();
+        localVue.use(Vuex);
+        localVue.use(BootstrapVue);
+        wrapper = shallowMount(TdThreatSuggestDialog, {
+            localVue,
+            mocks: { $t: key => key },
+            store: getStore()
+        });
+    });
+
+    it('renders the status as a dropdown', () => {
+        const dropdown = wrapper.findAllComponents(TdDropdown)
+            .filter(x => x.attributes('id') === 'status')
+            .at(0);
+
+        expect(dropdown.exists()).toEqual(true);
+    });
+
+    it('shows the selected status as the dropdown text', () => {
+        wrapper.vm.threat = { status: 'Mitigated' };
+        expect(wrapper.vm.selectedStatusText).toEqual('threats.status.mitigated');
+    });
+
+    it('shows empty dropdown text when no status is selected', () => {
+        expect(wrapper.vm.selectedStatusText).toEqual('');
+    });
+});

--- a/td.vue/tests/unit/components/threatSuggestDialog.spec.js
+++ b/td.vue/tests/unit/components/threatSuggestDialog.spec.js
@@ -1,12 +1,21 @@
-import { BootstrapVue } from 'bootstrap-vue';
+import { BButton, BFormInput, BFormTextarea, BootstrapVue } from 'bootstrap-vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
-import TdDropdown from '@/components/Dropdown.vue';
+import dataChanged from '@/service/x6/graph/data-changed.js';
+import threatModels from '@/service/threats/models/index.js';
+import { GetContextSuggestions } from '@/service/threats/oats/context-generator.js';
+import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
+import TdFormSelect from '@/components/FormSelect.vue';
+import TdThreatStatusSelector from '@/components/ThreatStatusSelector.vue';
 import TdThreatSuggestDialog from '@/components/ThreatSuggestDialog.vue';
 
+jest.mock('@/service/threats/oats/context-generator.js', () => ({
+    GetContextSuggestions: jest.fn()
+}));
+
 describe('components/ThreatSuggestDialog.vue', () => {
-    let localVue, wrapper;
+    let localVue, mockStore, wrapper;
 
     const getStore = () => new Vuex.Store({
         state: {
@@ -19,31 +28,318 @@ describe('components/ThreatSuggestDialog.vue', () => {
         actions: { CELL_DATA_UPDATED: () => {} }
     });
 
+    const getWrapper = () => {
+        mockStore = getStore();
+        wrapper = shallowMount(TdThreatSuggestDialog, {
+            localVue,
+            mocks: { $t: key => key },
+            store: mockStore
+        });
+        jest.spyOn(wrapper.vm.$refs.editModal, 'show').mockImplementation(() => {});
+        jest.spyOn(wrapper.vm.$refs.editModal, 'hide').mockImplementation(() => {});
+        return wrapper;
+    };
+
     beforeEach(() => {
         localVue = createLocalVue();
         localVue.use(Vuex);
         localVue.use(BootstrapVue);
-        wrapper = shallowMount(TdThreatSuggestDialog, {
-            localVue,
-            mocks: { $t: key => key },
-            store: getStore()
-        });
+        GetContextSuggestions.mockReset();
+        wrapper = getWrapper();
     });
 
-    it('renders the status as a dropdown', () => {
-        const dropdown = wrapper.findAllComponents(TdDropdown)
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders the threat status selector', () => {
+        const selector = wrapper.findAllComponents(TdThreatStatusSelector)
             .filter(x => x.attributes('id') === 'status')
             .at(0);
 
-        expect(dropdown.exists()).toEqual(true);
+        expect(selector.exists()).toEqual(true);
     });
 
-    it('shows the selected status as the dropdown text', () => {
-        wrapper.vm.threat = { status: 'Mitigated' };
-        expect(wrapper.vm.selectedStatusText).toEqual('threats.status.mitigated');
+    it('updates fields from the form controls', () => {
+        const inputs = wrapper.findAllComponents(BFormInput);
+        inputs.at(0).vm.$emit('input', 'title');
+        inputs.at(1).vm.$emit('input', 'score');
+        wrapper.findComponent(TdFormSelect).vm.$emit('input', 'type');
+        wrapper.findComponent(TdThreatStatusSelector).vm.$emit('input', 'Accepted');
+        wrapper.findComponent(TdFormRadioGroup).vm.$emit('input', 'High');
+        const textareas = wrapper.findAllComponents(BFormTextarea);
+        textareas.at(0).vm.$emit('input', 'description');
+        textareas.at(1).vm.$emit('input', 'mitigation');
+
+        expect(wrapper.vm.threat).toEqual(expect.objectContaining({
+            title: 'title',
+            score: 'score',
+            type: 'type',
+            status: 'Accepted',
+            severity: 'High',
+            description: 'description',
+            mitigation: 'mitigation'
+        }));
     });
 
-    it('shows empty dropdown text when no status is selected', () => {
-        expect(wrapper.vm.selectedStatusText).toEqual('');
+    it('connects the modal footer buttons to dialog actions', async () => {
+        const acceptSuggestion = jest.spyOn(wrapper.vm, 'acceptSuggestion').mockImplementation(() => {});
+        const previous = jest.spyOn(wrapper.vm, 'previous').mockImplementation(() => {});
+        const next = jest.spyOn(wrapper.vm, 'next').mockImplementation(() => {});
+        const hideModal = jest.spyOn(wrapper.vm, 'hideModal').mockImplementation(() => {});
+
+        const buttons = wrapper.findAllComponents(BButton);
+        await buttons.at(0).trigger('click');
+        await buttons.at(1).trigger('click');
+        await buttons.at(2).trigger('click');
+        await buttons.at(3).trigger('click');
+
+        expect([
+            acceptSuggestion,
+            previous,
+            next,
+            hideModal
+        ].every(method => method.mock.calls.length === 1)).toEqual(true);
+    });
+
+    it('lists translated threat types', () => {
+        expect(wrapper.vm.threatTypes.length).toBeGreaterThan(0);
+    });
+
+    it('returns no threat types without a threat', () => {
+        const context = { cellRef: mockStore.state.cell.ref, threat: null, modelType: 'STRIDE' };
+        expect(TdThreatSuggestDialog.computed.threatTypes.call(context)).toEqual([]);
+    });
+
+    it('returns no threat types without a cell', () => {
+        const context = { cellRef: null, threat: {}, modelType: 'STRIDE' };
+        expect(TdThreatSuggestDialog.computed.threatTypes.call(context)).toEqual([]);
+    });
+
+    it('returns no threat types without a model type', () => {
+        const context = { cellRef: mockStore.state.cell.ref, threat: {}, modelType: null };
+        expect(TdThreatSuggestDialog.computed.threatTypes.call(context)).toEqual([]);
+    });
+
+    it('provides severity priorities', () => {
+        expect(wrapper.vm.priorities).toHaveLength(5);
+    });
+
+    it('uses the next threat number in the modal title', () => {
+        expect(wrapper.vm.modalTitle).toEqual('threats.newThreat #1');
+    });
+
+    it('shows suggestions by threat type', () => {
+        wrapper.vm.showModal('type');
+        expect(wrapper.vm.suggestions).toHaveLength(wrapper.vm.threatTypes.length);
+    });
+
+    it('selects the first threat-type suggestion', () => {
+        wrapper.vm.showModal('type');
+        expect(wrapper.vm.threat).toEqual(wrapper.vm.suggestions[0]);
+    });
+
+    it('shows the suggestion modal', () => {
+        wrapper.vm.showModal('type');
+        expect(wrapper.vm.$refs.editModal.show).toHaveBeenCalled();
+    });
+
+    it('shows context suggestions', () => {
+        GetContextSuggestions.mockReturnValue([{
+            title: 'Context threat',
+            type: 'custom.type',
+            description: 'description',
+            mitigation: 'mitigation'
+        }]);
+
+        wrapper.vm.showModal('context');
+
+        expect(wrapper.vm.suggestions[0].title).toEqual('Context threat');
+    });
+
+    it('adds a new context suggestion type', () => {
+        GetContextSuggestions.mockReturnValue([{
+            title: 'Context threat',
+            type: 'custom.type',
+            description: 'description',
+            mitigation: 'mitigation'
+        }]);
+
+        wrapper.vm.showModal('context');
+
+        expect(wrapper.vm.types).toContain('custom.type');
+    });
+
+    it('does not add an empty context suggestion type', () => {
+        GetContextSuggestions.mockReturnValue([{
+            title: 'Context threat',
+            type: '',
+            description: 'description',
+            mitigation: 'mitigation'
+        }]);
+
+        wrapper.vm.showModal('context');
+
+        expect(wrapper.vm.types).not.toContain('');
+    });
+
+    it('does not duplicate an existing context suggestion type', () => {
+        const existingType = wrapper.vm.threatTypes[0];
+        GetContextSuggestions.mockReturnValue([{
+            title: 'Context threat',
+            type: existingType,
+            description: 'description',
+            mitigation: 'mitigation'
+        }]);
+
+        wrapper.vm.showModal('context');
+
+        expect(wrapper.vm.types.filter(type => type === existingType)).toHaveLength(1);
+    });
+
+    it('clears the dialog state when hiding', () => {
+        wrapper.vm.suggestions = [{ title: 'threat' }];
+        wrapper.vm.types = ['type'];
+        wrapper.vm.index = 2;
+        wrapper.vm.hideModal();
+        expect(wrapper.vm.suggestions).toEqual([]);
+    });
+
+    it('hides the modal', () => {
+        wrapper.vm.hideModal();
+        expect(wrapper.vm.$refs.editModal.hide).toHaveBeenCalled();
+    });
+
+    it('advances to the next suggestion', () => {
+        wrapper.vm.suggestions = [{ title: 'one' }, { title: 'two' }];
+        wrapper.vm.threat = wrapper.vm.suggestions[0];
+        wrapper.vm.next();
+        expect(wrapper.vm.threat.title).toEqual('two');
+    });
+
+    it('hides after the final suggestion', () => {
+        wrapper.vm.suggestions = [{ title: 'one' }];
+        wrapper.vm.next();
+        expect(wrapper.vm.$refs.editModal.hide).toHaveBeenCalled();
+    });
+
+    it('returns to the previous suggestion', () => {
+        wrapper.vm.suggestions = [{ title: 'one' }, { title: 'two' }];
+        wrapper.vm.index = 1;
+        wrapper.vm.previous();
+        expect(wrapper.vm.threat.title).toEqual('one');
+    });
+
+    it('stays on the first suggestion', () => {
+        wrapper.vm.suggestions = [{ title: 'one' }];
+        wrapper.vm.previous();
+        expect(wrapper.vm.index).toEqual(0);
+    });
+
+    it('accepts a suggestion', () => {
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: wrapper.vm.threatTypes[0],
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.state.cell.ref.data.threats).toHaveLength(1);
+    });
+
+    it('creates a threat frequency map when accepting a suggestion', () => {
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: wrapper.vm.threatTypes[0],
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.state.cell.ref.data.threatFrequency).toBeDefined();
+    });
+
+    it('keeps a missing frequency map when the model has none', () => {
+        jest.spyOn(threatModels, 'getFrequencyMapByElement').mockReturnValue(null);
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: 'custom',
+            modelType: 'custom',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.state.cell.ref.data.threatFrequency).toBeUndefined();
+    });
+
+    it('increments an existing matching frequency', () => {
+        mockStore.state.cell.ref.data.threatFrequency = { spoofing: 0, tampering: 0 };
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: 'threats.model.stride.spoofing',
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.state.cell.ref.data.threatFrequency.spoofing).toEqual(1);
+    });
+
+    it('marks the cell as having open threats', () => {
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: wrapper.vm.threatTypes[0],
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.state.cell.ref.data.hasOpenThreats).toEqual(true);
+    });
+
+    it('dispatches updates when accepting a suggestion', () => {
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: wrapper.vm.threatTypes[0],
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+    });
+
+    it('updates graph styles when accepting a suggestion', () => {
+        mockStore.dispatch = jest.fn();
+        dataChanged.updateStyleAttrs = jest.fn();
+        wrapper.vm.threat = {
+            type: wrapper.vm.threatTypes[0],
+            modelType: 'STRIDE',
+            status: 'Open'
+        };
+        wrapper.vm.suggestions = [wrapper.vm.threat, { title: 'next' }];
+
+        wrapper.vm.acceptSuggestion();
+
+        expect(dataChanged.updateStyleAttrs).toHaveBeenCalledWith(mockStore.state.cell.ref);
     });
 });

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/threats/threats.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/threats/threats.spec.js
@@ -81,6 +81,10 @@ describe('service/migration/tmBom/diagrams/threats/threats.js', () => {
         it('maps Avoided to the retired control status', () => {
             expect(threats.convert(buildModel('Avoided')).controls[0].status).toEqual('retired');
         });
+
+        it('maps Eliminated to the retired control status', () => {
+            expect(threats.convert(buildModel('Eliminated')).controls[0].status).toEqual('retired');
+        });
     });
 
     describe('merge/import TM-BOM threats', () => {

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/threats/threats.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/threats/threats.spec.js
@@ -63,6 +63,26 @@ describe('service/migration/tmBom/diagrams/threats/threats.js', () => {
         });
     });
 
+    describe('convert/export risk-treatment statuses', () => {
+        const buildModel = (status) => ({
+            detail: { diagrams: [{ cells: [{ data: { threats: [
+                { id: 'a', title: 't', description: 'd', status, severity: 'High', score: '5' }
+            ] } }] }] }
+        });
+
+        it('maps Accepted to the assumed control status', () => {
+            expect(threats.convert(buildModel('Accepted')).controls[0].status).toEqual('assumed');
+        });
+
+        it('maps Transferred to the approved control status', () => {
+            expect(threats.convert(buildModel('Transferred')).controls[0].status).toEqual('approved');
+        });
+
+        it('maps Avoided to the retired control status', () => {
+            expect(threats.convert(buildModel('Avoided')).controls[0].status).toEqual('retired');
+        });
+    });
+
     describe('merge/import TM-BOM threats', () => {
         let tdThreats = threats.merge(tmBomModel);
 

--- a/td.vue/tests/unit/service/threats/index.spec.js
+++ b/td.vue/tests/unit/service/threats/index.spec.js
@@ -1,4 +1,5 @@
 import threats, { createNewTypedThreat } from '@/service/threats/index.js';
+import store from '@/store/index.js';
 
 describe('service/threats/index.js', () => {
     describe('create new default typed threat', () => {
@@ -145,6 +146,55 @@ describe('service/threats/index.js', () => {
             expect(threat.modelType).toEqual('EOP');
         });
     });
+
+    describe('create new typed threat branches', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('normalizes DIE to CIADIE', () => {
+            expect(createNewTypedThreat('DIE').modelType).toEqual('CIADIE');
+        });
+
+        it('normalizes generic to the default model', () => {
+            expect(createNewTypedThreat('generic').modelType).toEqual('default');
+        });
+
+        it('uses the PLOT4ai actor type', () => {
+            expect(createNewTypedThreat('PLOT4ai', 'tm.Actor').type).toEqual('Accessibility');
+        });
+
+        it('uses the STRIDE actor type', () => {
+            expect(createNewTypedThreat('STRIDE', 'tm.Actor').type).toEqual('Spoofing');
+        });
+
+        it('uses the STRIDE process type', () => {
+            expect(createNewTypedThreat('STRIDE', 'tm.Process').type).toEqual('Spoofing');
+        });
+
+        it('uses the default type for an unknown model', () => {
+            expect(createNewTypedThreat('unknown').type).toEqual('Spoofing');
+        });
+
+        it('selects the least frequent threat type', () => {
+            jest.spyOn(store, 'get').mockReturnValue({
+                state: {
+                    cell: {
+                        ref: {
+                            data: {
+                                threatFrequency: {
+                                    spoofing: 3,
+                                    tampering: 1
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            expect(createNewTypedThreat('STRIDE', 'tm.Process').type).toEqual('Tampering');
+        });
+    });
     describe('hasOpenThreats', () => {
         it('returns false if there is no data', () => {
             expect(threats.hasOpenThreats(null))
@@ -178,12 +228,13 @@ describe('service/threats/index.js', () => {
                 .toEqual(true);
         });
 
-        it('returns false if the only threats are accepted, transferred or avoided', () => {
+        it('returns false if the only threats are resolved treatments', () => {
             const data = {
                 threats: [
                     { status: 'Accepted' },
                     { status: 'Transferred' },
-                    { status: 'Avoided' }
+                    { status: 'Avoided' },
+                    { status: 'Eliminated' }
                 ]
             };
             expect(threats.hasOpenThreats(data))
@@ -329,13 +380,14 @@ describe('service/threats/index.js', () => {
             expect(res).toHaveLength(1);
         });
 
-        it('hides accepted, transferred and avoided threats when showMitigated is false', () => {
+        it('hides resolved treatment threats when showMitigated is false', () => {
             const data = {
                 threats: [
                     { status: 'Open' },
                     { status: 'Accepted' },
                     { status: 'Transferred' },
                     { status: 'Avoided' },
+                    { status: 'Eliminated' },
                     { status: 'NotApplicable' }
                 ]
             };
@@ -343,16 +395,17 @@ describe('service/threats/index.js', () => {
             expect(res.map(x => x.status)).toEqual(['Open', 'NotApplicable']);
         });
 
-        it('shows accepted, transferred and avoided threats when showMitigated is true', () => {
+        it('shows resolved treatment threats when showMitigated is true', () => {
             const data = {
                 threats: [
                     { status: 'Accepted' },
                     { status: 'Transferred' },
-                    { status: 'Avoided' }
+                    { status: 'Avoided' },
+                    { status: 'Eliminated' }
                 ]
             };
             const res = threats.filterForDiagram(data, { showMitigated: true });
-            expect(res).toHaveLength(3);
+            expect(res).toHaveLength(4);
         });
     });
 

--- a/td.vue/tests/unit/service/threats/index.spec.js
+++ b/td.vue/tests/unit/service/threats/index.spec.js
@@ -177,6 +177,18 @@ describe('service/threats/index.js', () => {
             expect(threats.hasOpenThreats(data))
                 .toEqual(true);
         });
+
+        it('returns false if the only threats are accepted, transferred or avoided', () => {
+            const data = {
+                threats: [
+                    { status: 'Accepted' },
+                    { status: 'Transferred' },
+                    { status: 'Avoided' }
+                ]
+            };
+            expect(threats.hasOpenThreats(data))
+                .toEqual(false);
+        });
     });
 
     /**
@@ -315,6 +327,32 @@ describe('service/threats/index.js', () => {
             };
             const res = threats.filterForDiagram(data, { showMitigated: false });
             expect(res).toHaveLength(1);
+        });
+
+        it('hides accepted, transferred and avoided threats when showMitigated is false', () => {
+            const data = {
+                threats: [
+                    { status: 'Open' },
+                    { status: 'Accepted' },
+                    { status: 'Transferred' },
+                    { status: 'Avoided' },
+                    { status: 'NotApplicable' }
+                ]
+            };
+            const res = threats.filterForDiagram(data, { showMitigated: false });
+            expect(res.map(x => x.status)).toEqual(['Open', 'NotApplicable']);
+        });
+
+        it('shows accepted, transferred and avoided threats when showMitigated is true', () => {
+            const data = {
+                threats: [
+                    { status: 'Accepted' },
+                    { status: 'Transferred' },
+                    { status: 'Avoided' }
+                ]
+            };
+            const res = threats.filterForDiagram(data, { showMitigated: true });
+            expect(res).toHaveLength(3);
         });
     });
 

--- a/td.vue/tests/unit/service/threats/status.spec.js
+++ b/td.vue/tests/unit/service/threats/status.spec.js
@@ -1,113 +1,73 @@
 import {
-    THREAT_STATUS,
-    STATUS_ORDER,
-    RESOLVED_STATUSES,
+    threatStatus,
+    primaryStatuses,
+    treatmentStatuses,
     isOpen,
     isResolved,
-    getStatusOptions
+    getPrimaryStatusOptions,
+    getTreatmentStatusOptions
 } from '@/service/threats/status.js';
 
 describe('service/threats/status.js', () => {
-    describe('THREAT_STATUS constants', () => {
-        it('exposes the legacy statuses with their stored values', () => {
-            expect(THREAT_STATUS.NOT_APPLICABLE).toEqual('NotApplicable');
-            expect(THREAT_STATUS.OPEN).toEqual('Open');
-            expect(THREAT_STATUS.MITIGATED).toEqual('Mitigated');
-        });
-
-        it('exposes the new risk-treatment statuses', () => {
-            expect(THREAT_STATUS.ACCEPTED).toEqual('Accepted');
-            expect(THREAT_STATUS.TRANSFERRED).toEqual('Transferred');
-            expect(THREAT_STATUS.AVOIDED).toEqual('Avoided');
+    it('exposes stable stored status values', () => {
+        expect(threatStatus).toEqual({
+            notApplicable: 'NotApplicable',
+            open: 'Open',
+            mitigated: 'Mitigated',
+            accepted: 'Accepted',
+            transferred: 'Transferred',
+            avoided: 'Avoided',
+            eliminated: 'Eliminated'
         });
     });
 
-    describe('STATUS_ORDER', () => {
-        it('lists all six statuses', () => {
-            expect(STATUS_ORDER).toHaveLength(6);
-        });
-
-        it('keeps Open as the second option', () => {
-            expect(STATUS_ORDER[1]).toEqual('Open');
-        });
+    it('keeps NotApplicable and Open as primary statuses', () => {
+        expect(primaryStatuses).toEqual(['NotApplicable', 'Open']);
     });
 
-    describe('RESOLVED_STATUSES', () => {
-        it('contains Mitigated, Accepted, Transferred and Avoided', () => {
-            expect(RESOLVED_STATUSES).toEqual(['Mitigated', 'Accepted', 'Transferred', 'Avoided']);
-        });
-
-        it('does not contain Open', () => {
-            expect(RESOLVED_STATUSES).not.toContain('Open');
-        });
-
-        it('does not contain NotApplicable', () => {
-            expect(RESOLVED_STATUSES).not.toContain('NotApplicable');
-        });
+    it('lists all treatment statuses as resolved', () => {
+        expect(treatmentStatuses).toEqual([
+            'Mitigated',
+            'Accepted',
+            'Transferred',
+            'Avoided',
+            'Eliminated'
+        ]);
     });
 
-    describe('isOpen', () => {
-        it('is true for Open', () => {
-            expect(isOpen('Open')).toEqual(true);
-        });
-
-        it('is case insensitive', () => {
-            expect(isOpen('open')).toEqual(true);
-        });
-
-        it('is false for Mitigated', () => {
-            expect(isOpen('Mitigated')).toEqual(false);
-        });
-
-        it('is false for undefined', () => {
-            expect(isOpen(undefined)).toEqual(false);
-        });
+    it.each(['Open', 'open'])('recognizes %s as open', (status) => {
+        expect(isOpen(status)).toEqual(true);
     });
 
-    describe('isResolved', () => {
-        it('is true for Mitigated', () => {
-            expect(isResolved('Mitigated')).toEqual(true);
-        });
-
-        it('is true for Accepted', () => {
-            expect(isResolved('Accepted')).toEqual(true);
-        });
-
-        it('is true for Transferred', () => {
-            expect(isResolved('Transferred')).toEqual(true);
-        });
-
-        it('is true for Avoided', () => {
-            expect(isResolved('Avoided')).toEqual(true);
-        });
-
-        it('is case insensitive', () => {
-            expect(isResolved('avoided')).toEqual(true);
-        });
-
-        it('is false for Open', () => {
-            expect(isResolved('Open')).toEqual(false);
-        });
-
-        it('is false for NotApplicable', () => {
-            expect(isResolved('NotApplicable')).toEqual(false);
-        });
-
-        it('is false for an empty status', () => {
-            expect(isResolved('')).toEqual(false);
-        });
+    it.each(['Mitigated', undefined])('does not recognize %s as open', (status) => {
+        expect(isOpen(status)).toEqual(false);
     });
 
-    describe('getStatusOptions', () => {
-        const options = getStatusOptions((key) => key);
+    it.each(['Mitigated', 'Accepted', 'Transferred', 'Avoided', 'Eliminated', 'eliminated'])(
+        'recognizes %s as resolved',
+        (status) => {
+            expect(isResolved(status)).toEqual(true);
+        }
+    );
 
-        it('returns one option per status', () => {
-            expect(options).toHaveLength(6);
-        });
+    it.each(['Open', 'NotApplicable', ''])('does not recognize %s as resolved', (status) => {
+        expect(isResolved(status)).toEqual(false);
+    });
 
-        it('maps each value to its translation key via the translate function', () => {
-            const accepted = options.find((o) => o.value === 'Accepted');
-            expect(accepted.text).toEqual('threats.status.accepted');
-        });
+    it('builds translated primary status options', () => {
+        expect(getPrimaryStatusOptions((key) => key)).toEqual([
+            { value: 'NotApplicable', text: 'threats.status.notApplicable' },
+            { value: 'Open', text: 'threats.status.open' }
+        ]);
+    });
+
+    it('builds translated treatment status options', () => {
+        expect(getTreatmentStatusOptions((key) => key)).toEqual([
+            { value: 'Mitigated', text: 'threats.status.mitigated' },
+            { value: 'Accepted', text: 'threats.status.accepted' },
+            { value: 'Transferred', text: 'threats.status.transferred' },
+            { value: 'Avoided', text: 'threats.status.avoided' },
+            { value: 'Eliminated', text: 'threats.status.eliminated' }
+        ]);
     });
 });

--- a/td.vue/tests/unit/service/threats/status.spec.js
+++ b/td.vue/tests/unit/service/threats/status.spec.js
@@ -1,0 +1,113 @@
+import {
+    THREAT_STATUS,
+    STATUS_ORDER,
+    RESOLVED_STATUSES,
+    isOpen,
+    isResolved,
+    getStatusOptions
+} from '@/service/threats/status.js';
+
+describe('service/threats/status.js', () => {
+    describe('THREAT_STATUS constants', () => {
+        it('exposes the legacy statuses with their stored values', () => {
+            expect(THREAT_STATUS.NOT_APPLICABLE).toEqual('NotApplicable');
+            expect(THREAT_STATUS.OPEN).toEqual('Open');
+            expect(THREAT_STATUS.MITIGATED).toEqual('Mitigated');
+        });
+
+        it('exposes the new risk-treatment statuses', () => {
+            expect(THREAT_STATUS.ACCEPTED).toEqual('Accepted');
+            expect(THREAT_STATUS.TRANSFERRED).toEqual('Transferred');
+            expect(THREAT_STATUS.AVOIDED).toEqual('Avoided');
+        });
+    });
+
+    describe('STATUS_ORDER', () => {
+        it('lists all six statuses', () => {
+            expect(STATUS_ORDER).toHaveLength(6);
+        });
+
+        it('keeps Open as the second option', () => {
+            expect(STATUS_ORDER[1]).toEqual('Open');
+        });
+    });
+
+    describe('RESOLVED_STATUSES', () => {
+        it('contains Mitigated, Accepted, Transferred and Avoided', () => {
+            expect(RESOLVED_STATUSES).toEqual(['Mitigated', 'Accepted', 'Transferred', 'Avoided']);
+        });
+
+        it('does not contain Open', () => {
+            expect(RESOLVED_STATUSES).not.toContain('Open');
+        });
+
+        it('does not contain NotApplicable', () => {
+            expect(RESOLVED_STATUSES).not.toContain('NotApplicable');
+        });
+    });
+
+    describe('isOpen', () => {
+        it('is true for Open', () => {
+            expect(isOpen('Open')).toEqual(true);
+        });
+
+        it('is case insensitive', () => {
+            expect(isOpen('open')).toEqual(true);
+        });
+
+        it('is false for Mitigated', () => {
+            expect(isOpen('Mitigated')).toEqual(false);
+        });
+
+        it('is false for undefined', () => {
+            expect(isOpen(undefined)).toEqual(false);
+        });
+    });
+
+    describe('isResolved', () => {
+        it('is true for Mitigated', () => {
+            expect(isResolved('Mitigated')).toEqual(true);
+        });
+
+        it('is true for Accepted', () => {
+            expect(isResolved('Accepted')).toEqual(true);
+        });
+
+        it('is true for Transferred', () => {
+            expect(isResolved('Transferred')).toEqual(true);
+        });
+
+        it('is true for Avoided', () => {
+            expect(isResolved('Avoided')).toEqual(true);
+        });
+
+        it('is case insensitive', () => {
+            expect(isResolved('avoided')).toEqual(true);
+        });
+
+        it('is false for Open', () => {
+            expect(isResolved('Open')).toEqual(false);
+        });
+
+        it('is false for NotApplicable', () => {
+            expect(isResolved('NotApplicable')).toEqual(false);
+        });
+
+        it('is false for an empty status', () => {
+            expect(isResolved('')).toEqual(false);
+        });
+    });
+
+    describe('getStatusOptions', () => {
+        const options = getStatusOptions((key) => key);
+
+        it('returns one option per status', () => {
+            expect(options).toHaveLength(6);
+        });
+
+        it('maps each value to its translation key via the translate function', () => {
+            const accepted = options.find((o) => o.value === 'Accepted');
+            expect(accepted.text).toEqual('threats.status.accepted');
+        });
+    });
+});


### PR DESCRIPTION
**Summary**:  
Right now a threat can only be N/A, Open or Mitigated. This adds three more statuses, Accepted, Transferred and Avoided, so the standard risk treatment options can be recorded directly instead of being written into the mitigation text (the three-tier demo model currently fakes "transferred"/"accepted" as free text while leaving the status as Mitigated).

The three new statuses are treated as resolved: they don't mark a diagram element as having open threats, they're hidden by the "show mitigated" toggle in the report, and they're counted as resolved in the report summaries. I moved the status values and the open/resolved logic into one small helper so they're defined in a single place, and mapped the new statuses to the nearest TM-BOM control status on export.

closes #1242
<!--
What existing issue does the pull request solve?
Add "closes #xxxx", where xxxx is the issue number
You must have been assigned the issue before submitting the pull request
and provide enough information so that others can review your changes
-->

**Description for the changelog**:  
Add Accepted, Transferred and Avoided risk treatment statuses for threats
<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Claude Code`
  - LLMs and versions: `Claude Opus 4.8`
  - Prompts: `I used Claude Code to implement the change. I picked and scoped the issue, chose the status names (Accepted/Transferred/Avoided) and the "treat as resolved" behaviour, then reviewed the diff and ran the tests before submitting. The model wrote the implementation and unit tests.`
