### PR TITLE
Readme: fix CI and release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 </p>
 
 [![GitHub license](https://img.shields.io/github/license/owasp/threat-dragon.svg)](license.txt)
-[![Build status](https://github.com/OWASP/threat-dragon/actions/workflows/push.yaml/badge.svg?event=push)][build]
-[![GitHub release](https://img.shields.io/github/v/release/owasp/threat-dragon.svg)][latest]
+[![Build status](https://img.shields.io/github/check-runs/OWASP/threat-dragon/main?label=CI)][build]
+[![GitHub release](https://img.shields.io/github/v/release/owasp/threat-dragon?sort=semver)][latest]
 [![OWASP Lab](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://owasp.org/projects/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9266/badge)][practices]
 


### PR DESCRIPTION
**Summary**:  

Closes #1702 

The push.yaml/svg path was returning a 404. I updated the CI badge to be an img shields badge, similar to others.

Screenshot of README before changes:
<img width="1244" height="477" alt="image" src="https://github.com/user-attachments/assets/d6488ae2-685d-4753-8d5c-f3de6cfe4a82" />


**Description for the changelog**:  

bugfix: update readme ci and release badges

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Testing locally is difficult, I'm not sure if there's a way of really emulating GitHub's markdown rendering.
I had the robots help me with an approximation of what it would look like (not used to make changes, just testing):
<img width="929" height="637" alt="image" src="https://github.com/user-attachments/assets/71bb2482-f9b5-4f3c-aaa8-1829ad4fd25a" />

I don't expect the formatting to change on the main page, I only updated the urls. I think this is an artifact of my slopified test harness. :laughing: 