### PR TITLE
Skip GitLab e2e tests in CI

### DIFF
--- a/td.vue/e2e.ci.config.js
+++ b/td.vue/e2e.ci.config.js
@@ -21,6 +21,7 @@ if (useMockServer) {
 const excludeSpecPattern = [ 'tests/e2e/specs/smokes/*.cy.js', 'tests/e2e/specs/visual/*.cy.js' ];
 if (!useMockServer) {
     excludeSpecPattern.push('tests/e2e/specs/pagination/*.cy.js');
+    excludeSpecPattern.push('tests/e2e/specs/gitlab/*.cy.js');
 }
 
 module.exports = defineConfig({


### PR DESCRIPTION
**Summary**:  

Closes #1704 

In CI, we set `CI_MOCK_ENABLED=false` to use a docker backend.
The GitLab e2e tests are a mock backend.
I did not exclude the GitLab tests when `CI_MOCK_ENABLED=false`

**Description for the changelog**:  

chore: fix gitlab e2e tests in CI

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I think at some point we should have the mocked backends run in CI (or maybe they do elsewhere?).
But this follows the existing pattern and will resolve the failing CI issue.