### PR TITLE
add optional/configurable /.well-known/security.txt

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -155,6 +155,7 @@ Trisqel
 trivy
 Trivy
 TSV
+txt
 UI
 Uncheck
 unpatched

--- a/docs/configure/configure.md
+++ b/docs/configure/configure.md
@@ -204,6 +204,12 @@ for example `http://localhost:3000/`, but not in 'production' mode.
 | `REPO_SEARCH_QUERY` | Provides search string if repo search enabled | |
 | `REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in the repo | |
 | `SERVER_API_PROTOCOL` | Protocol between server and front-end: `http` / `https` | `https` |
+| `SECURITY_TXT_ENABLED` | Optional `/.well-known/security.txt` | `false` |
+| `SECURITY_TXT_CONTACT` | Required if enabled - comma separated contact methods in priority order | |
+| `SECURITY_TXT_POLICY` | Optional policy URL for security.txt | |
+| `SECURITY_TXT_CANONICAL` | Optional canonical URL for the security.txt | |
+| `SECURITY_TXT_PREFERRED_LANGUAGES` | Optional languages supported by the security team | |
+| `SECURITY_TXT_EXPIRES` | Required if enabled - a valid RFC3339 ISO.8601-2, recommended to be no more than 1 year in the future | |
 
 __Note__ : the JWT refresh signing key should be different from the JWT signing key as they are different tokens.
 A JWT is used as the refresh token because it is tamper resistant and provides user context.

--- a/example.env
+++ b/example.env
@@ -39,3 +39,17 @@ APP_TLS_KEY_PATH=/path/to/privatekey.pem
 # LOCALES_ALLOWED is a JSON array of allowed locale codes, when empty no restrictions are applied
 LOCALES_ALLOWED='[]'
 LOCALE_DEFAULT=en
+
+# RFC 9116 security.txt implementation (optional)
+# If enabled, contact and expires are required
+SECURITY_TXT_ENABLED=true
+# You can have multiple contacts by providing a comma separated list
+# These should be in order of preference
+SECURITY_TXT_CONTACT=mailto:someone@somewhere.com, https://example.com/security-contact-form, tel:+1-555-555-5555
+SECURITY_TXT_POLICY=https://github.com/OWASP/threat-dragon/security/policy
+SECURITY_TXT_CANONICAL=https://threat-dragon.example.com/.well-known/security.txt
+SECURITY_TXT_PREFERRED_LANGUAGES=en
+# Expires must be a valid RFC3339 ISO.8601-2 date
+# It's RECOMMENDED to not have the expiration > 1 year in the future
+SECURITY_TXT_EXPIRES=2028-01-01T00:00:00Z
+

--- a/td.server/src/config/env.config.js
+++ b/td.server/src/config/env.config.js
@@ -2,8 +2,9 @@ import BitbucketEnv from '../env/Bitbucket.js';
 import EncryptionEnv from '../env/Encryption.js';
 import env from '../env/Env.js';
 import GithubEnv from '../env/Github.js';
-import GitlabEnv from "../env/Gitlab";
+import GitlabEnv from '../env/Gitlab';
 import GoogleEnv from '../env/Google.js';
+import SecurityTxtEnv from '../env/SecurityTxt.js';
 import ThreatDragonEnv from '../env/ThreatDragon.js';
 
 const tryLoadDotEnv = () => {
@@ -11,6 +12,7 @@ const tryLoadDotEnv = () => {
     const gitlab = new GitlabEnv();
     const bitbucket = new BitbucketEnv();
     const encryption = new EncryptionEnv();
+    const securityTxt = new SecurityTxtEnv();
     const threatDragon = new ThreatDragonEnv();
     const google = new GoogleEnv();
     env.get().addProvider(github);
@@ -19,6 +21,7 @@ const tryLoadDotEnv = () => {
     env.get().addProvider(bitbucket);
     env.get().addProvider(threatDragon);
     env.get().addProvider(google);
+    env.get().addProvider(securityTxt);
     env.get().hydrate();
 };
 

--- a/td.server/src/config/routes.config.js
+++ b/td.server/src/config/routes.config.js
@@ -7,6 +7,7 @@ import decodeRepoPaths from './decodeRepoPaths.config.js';
 import googleProviderThreatmodelController from '../controllers/googleProviderThreatmodelController.js';
 import healthcheck from '../controllers/healthz.js';
 import homeController from '../controllers/homecontroller.js';
+import metadataController from '../controllers/metadataController.js';
 import templateController from '../controllers/templateController.js';
 import threatmodelController from '../controllers/threatmodelcontroller.js';
 
@@ -21,6 +22,8 @@ const unauthRoutes = (router) => {
     router.get('/', homeController.index);
 
     router.get('/healthz', healthcheck.healthz);
+    router.get('/security.txt', metadataController.legacySecurityTxtRedirect);
+    router.get('/.well-known/security.txt', metadataController.securityTxt);
     router.get('/api/config', configController.config);
     router.get('/api/threatmodel/organisation', threatmodelController.organisation);
     

--- a/td.server/src/controllers/metadataController.js
+++ b/td.server/src/controllers/metadataController.js
@@ -1,0 +1,50 @@
+import env from '../env/Env.js';
+import errors from './errors.js';
+import loggerHelper from '../helpers/logger.helper';
+
+const getSecurityTxt = (config) => {
+  // Contact and expires are required
+  // security.txt must be in `key: value` format
+  // All other fields are optional
+  const parts = [];
+
+  // You are allowed multiple contacts. This implementation
+  // allows a CSV, and we will honor the order.
+  const contacts = config.SECURITY_TXT_CONTACT.split(',');
+  parts.push(...contacts.map((x) => `Contact: ${x.trim()}`));
+  parts.push(`Expires: ${config.SECURITY_TXT_EXPIRES}`);
+  
+  if (config.SECURITY_TXT_POLICY) {
+    parts.push(`Policy: ${config.SECURITY_TXT_POLICY}`);
+  }
+
+  if (config.SECURITY_TXT_CANONICAL) {
+    parts.push(`Canonical: ${config.SECURITY_TXT_CANONICAL}`);
+  }
+
+  if (config.SECURITY_TXT_PREFERRED_LANGUAGES) {
+    parts.push(`Preferred-Languages: ${config.SECURITY_TXT_PREFERRED_LANGUAGES}`);
+  }
+
+  return parts.join('\n');
+};
+
+const securityTxt = (_req, res) => {
+  const config = env.get().config;
+  if (!config.SECURITY_TXT_ENABLED) {
+    return errors.notFound('File not found', res, loggerHelper.get('controllers/metadataController.js'));
+  }
+
+  // RFC 9116 states that /.well-known/security.txt must return a 200
+  // with Content-Type: text/plain; charset=utf-8
+  res.set('Content-Type', 'text/plain; charset=utf-8');
+  return res.status(200).send(getSecurityTxt(config));
+};
+
+const legacySecurityTxtRedirect = (_req, res) => res.redirect('/.well-known/security.txt');
+
+export default {
+  legacySecurityTxtRedirect,
+  securityTxt
+};
+

--- a/td.server/src/env/SecurityTxt.js
+++ b/td.server/src/env/SecurityTxt.js
@@ -1,0 +1,86 @@
+import { Env } from './Env.js';
+import loggerHelper from '../helpers/logger.helper.js';
+
+/**
+ * Config to generate an RFC 1196 compliant /.well-known/security.txt
+ * @see https://datatracker.ietf.org/doc/rfc9116/
+ */
+class SecurityTxtEnv extends Env {
+    constructor () {
+        super('SecurityTxt');
+        this.logger = loggerHelper.get('env/SecurityTxt.js');
+    }
+
+    get prefix () {
+        return 'SECURITY_TXT_';
+    }
+
+    // Overriding the base implementation to apply conditional logic for when fields
+    // are required. CONTACT and EXPIRES are the minimum required according to the RFC
+    _loadConfig() {
+      // Create the config object - remember config has full property names including prefix
+      const config = super._loadConfig();
+      // If not enabled, there is no need for the conditional logic
+      if (!config.SECURITY_TXT_ENABLED || config.SECURITY_TXT_ENABLED.toLowerCase() === 'false') {
+        return config;
+      }
+
+      const contactVal = config.SECURITY_TXT_CONTACT;
+      const expiresVal = config.SECURITY_TXT_EXPIRES;
+
+      const hasContact = contactVal && contactVal.length;
+      const hasExpires = expiresVal && expiresVal.length;
+
+      if (!hasContact || !hasExpires) {
+        const errMsg = 'When SECURITY_TXT_ENABLED is set to true, both SECURITY_TXT_CONTACT and SECURITY_TXT_EXPIRES are required';
+        this.logger.error(errMsg);
+        throw new Error(errMsg);
+      }
+
+      this._validateExpiresDate(expiresVal);
+
+
+      return config;
+    }
+
+    _validateExpiresDate(expiresVal) {
+      // According to the RFC, expires must be a valid RFC3339 ISO.8601-2 date
+      // We are not doing that complete validation here. We are simply 
+      // checking that the date parses
+      const expires = new Date(expiresVal);
+      if (isNaN(expires.getTime())) {
+        const errMsg = 'SECURITY_TXT_EXPIRES must be a valid date';
+        this.logger.error(errMsg);
+        throw new Error(errMsg);
+      }
+
+      // A date in the past means it is invalid and needs to be updated.
+      // This must be a warning and not a hard failure - a hard failure
+      // would prevent restarts in a production environment
+      if (expires <= new Date()) {
+        this.logger.warn('Your security.txt has expired. SECURITY_TXT_EXPIRES date is in the past');
+      }
+      
+      // it is RECOMMENDED that expires be no more than 1 year in the future
+      const oneYearFromNow = new Date();
+      oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
+      if (expires >= oneYearFromNow) {
+        this.logger.info('Your security.txt expiration date is more than one year in the future.');
+        this.logger.info('RFC 1196 recommends an expiration of less than a year');
+      }
+    }
+
+    get properties () {
+        return [
+            { key: 'ENABLED', required: false, defaultValue: false },
+            { key: 'CONTACT', required: false },
+            { key: 'EXPIRES', required: false },
+            { key: 'POLICY', required: false },
+            { key: 'CANONICAL', required: false },
+            { key: 'PREFERRED_LANGUAGES', required: false }
+        ];
+    }
+}
+
+export default SecurityTxtEnv;
+

--- a/td.server/test/config/routes.config.spec.js
+++ b/td.server/test/config/routes.config.spec.js
@@ -10,6 +10,7 @@ import { getMockApp } from '../mocks/express.mocks.js';
 import googleProviderThreatmodelController from '../../src/controllers/googleProviderThreatmodelController.js';
 import healthcheck from '../../src/controllers/healthz.js';
 import homeController from '../../src/controllers/homecontroller.js';
+import metadataController from '../../src/controllers/metadataController.js';
 import routeConfig from '../../src/config/routes.config.js';
 import threatmodelController from '../../src/controllers/threatmodelcontroller.js';
 
@@ -53,6 +54,23 @@ describe('config/routes.config.js routes', () => {
         it('routes GET /api/config', () => {
             expect(mockRouter.get).to.have.been.calledWith('/api/config', configcontroller.config);
         });
+    });
+
+    describe('security.txt', () => {
+        it('redirects /security.txt to /.well-known/security.txt', () => {
+            expect(mockRouter.get).to.have.been.calledWith(
+                '/security.txt',
+                metadataController.legacySecurityTxtRedirect
+            );
+        });
+
+        it('routes /.well-known/security.txt', () => {
+            expect(mockRouter.get).to.have.been.calledWith(
+                '/.well-known/security.txt',
+                metadataController.securityTxt
+            );
+        });
+
     });
 
     describe('login/logout', () => {
@@ -201,21 +219,21 @@ describe('config/routes.config.js routes', () => {
                 googleProviderThreatmodelController.folders
             );
         });
-    
+
         it('routes POST /api/googleproviderthreatmodel/:folder/create', () => {
             expect(mockRouter.post).to.have.been.calledWith(
                 '/api/googleproviderthreatmodel/:folder/create',
                 googleProviderThreatmodelController.create
             );
         });
-    
+
         it('routes PUT /api/googleproviderthreatmodel/:file/update', () => {
             expect(mockRouter.put).to.have.been.calledWith(
                 '/api/googleproviderthreatmodel/:file/update',
                 googleProviderThreatmodelController.update
             );
         });
-    
+
         it('routes GET /api/googleproviderthreatmodel/:file/data', () => {
             expect(mockRouter.get).to.have.been.calledWith(
                 '/api/googleproviderthreatmodel/:file/data',
@@ -223,7 +241,7 @@ describe('config/routes.config.js routes', () => {
             );
         });
     });
-    
+
 
     it('adds bearer token middleware', () => {
         expect(mockRouter.use).to.have.been.calledWith(bearer.middleware);

--- a/td.server/test/controllers/metadataController.spec.js
+++ b/td.server/test/controllers/metadataController.spec.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { getMockRequest, getMockResponse } from '../mocks/express.mocks.js';
+import env from '../../src/env/Env.js';
+import errors from '../../src/controllers/errors.js';
+import metadataController from '../../src/controllers/metadataController.js';
+
+describe('controllers/metadataController.js', () => {
+    let mockRequest, mockResponse;
+
+    beforeEach(() => {
+        mockRequest = getMockRequest();
+        mockResponse = getMockResponse();
+        mockResponse.set = sinon.stub().returns(mockResponse);
+    });
+
+    describe('securityTxt', () => {
+        it('returns not found when security.txt is not enabled', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: false
+                }
+            });
+            sinon.stub(errors, 'notFound');
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(errors.notFound).to.have.been.calledWith('File not found', mockResponse);
+        });
+
+        it('sets the text content type when security.txt is enabled', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: true,
+                    SECURITY_TXT_CONTACT: 'mailto:someone@somewhere.com',
+                    SECURITY_TXT_EXPIRES: '2026-12-31T00:00:00.000Z'
+                }
+            });
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(mockResponse.set).to.have.been.calledWith('Content-Type', 'text/plain; charset=utf-8');
+        });
+
+        it('returns security.txt with required values', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: true,
+                    SECURITY_TXT_CONTACT: 'mailto:someone@somewhere.com',
+                    SECURITY_TXT_EXPIRES: '2026-12-31T00:00:00.000Z'
+                }
+            });
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(mockResponse.send).to.have.been.calledWith(
+                [
+                    'Contact: mailto:someone@somewhere.com',
+                    'Expires: 2026-12-31T00:00:00.000Z'
+                ].join('\n')
+            );
+        });
+
+        it('returns security.txt with optional values', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: true,
+                    SECURITY_TXT_CONTACT: 'mailto:someone@somewhere.com',
+                    SECURITY_TXT_EXPIRES: '2026-12-31T00:00:00.000Z',
+                    SECURITY_TXT_POLICY: 'https://example.com/policy',
+                    SECURITY_TXT_CANONICAL: 'https://example.com/.well-known/security.txt',
+                    SECURITY_TXT_PREFERRED_LANGUAGES: 'en,es'
+                }
+            });
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(mockResponse.send).to.have.been.calledWith(
+                [
+                    'Contact: mailto:someone@somewhere.com',
+                    'Expires: 2026-12-31T00:00:00.000Z',
+                    'Policy: https://example.com/policy',
+                    'Canonical: https://example.com/.well-known/security.txt',
+                    'Preferred-Languages: en,es'
+                ].join('\n')
+            );
+        });
+
+        it('returns multiple contacts in order', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: true,
+                    SECURITY_TXT_CONTACT: 'mailto:one@somewhere.com, mailto:two@somewhere.com',
+                    SECURITY_TXT_EXPIRES: '2026-12-31T00:00:00.000Z'
+                }
+            });
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(mockResponse.send).to.have.been.calledWith(
+                [
+                    'Contact: mailto:one@somewhere.com',
+                    'Contact: mailto:two@somewhere.com',
+                    'Expires: 2026-12-31T00:00:00.000Z'
+                ].join('\n')
+            );
+        });
+
+        it('sets the response status', () => {
+            sinon.stub(env, 'get').returns({
+                config: {
+                    SECURITY_TXT_ENABLED: true,
+                    SECURITY_TXT_CONTACT: 'mailto:someone@somewhere.com',
+                    SECURITY_TXT_EXPIRES: '2026-12-31T00:00:00.000Z'
+                }
+            });
+
+            metadataController.securityTxt(mockRequest, mockResponse);
+
+            expect(mockResponse.status).to.have.been.calledWith(200);
+        });
+    });
+
+    describe('legacySecurityTxtRedirect', () => {
+        it('redirects to the well-known security.txt', () => {
+            metadataController.legacySecurityTxtRedirect(mockRequest, mockResponse);
+
+            expect(mockResponse.redirect).to.have.been.calledWith('/.well-known/security.txt');
+        });
+    });
+});

--- a/td.server/test/env/SecurityTxt.spec.js
+++ b/td.server/test/env/SecurityTxt.spec.js
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Env } from '../../src/env/Env.js';
+import SecurityTxt from '../../src/env/SecurityTxt.js';
+
+describe('env/SecurityTxt.js', () => {
+    let logger, securityTxtEnv;
+
+    beforeEach(() => {
+        securityTxtEnv = new SecurityTxt();
+        logger = {
+            error: sinon.stub(),
+            info: sinon.stub(),
+            warn: sinon.stub()
+        };
+        securityTxtEnv.logger = logger;
+    });
+
+    it('extends Env', () => {
+        expect(securityTxtEnv).is.instanceOf(Env);
+    });
+
+    it('is named SecurityTxt', () => {
+        expect(securityTxtEnv.name).to.eq('SecurityTxt');
+    });
+
+    it('uses the SECURITY_TXT_ prefix', () => {
+        expect(securityTxtEnv.prefix).to.eq('SECURITY_TXT_');
+    });
+
+    it('has the optional property enabled', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'ENABLED')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('defaults enabled to false', () => {
+        const defaultVal = securityTxtEnv.properties
+            .find((x) => x.key === 'ENABLED')
+            .defaultValue;
+        expect(defaultVal).to.eq(false);
+    });
+
+    it('has the optional property contact', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'CONTACT')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+
+    it('has the optional property policy', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'POLICY')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has the optional property canonical', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'CANONICAL')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has the optional property preferred languages', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'PREFERRED_LANGUAGES')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    it('has the optional property expires', () => {
+        const isRequired = securityTxtEnv.properties
+            .find((x) => x.key === 'CONTACT')
+            .required;
+        expect(isRequired).to.be.false;
+    });
+
+    describe('_loadConfig() validation', () => {
+        const envVars = [
+            'ENABLED',
+            'CONTACT',
+            'POLICY',
+            'CANONICAL',
+            'PREFERRED_LANGUAGES',
+            'EXPIRES'
+        ];
+
+        const getConfigError = () => {
+            let e;
+            try {
+                securityTxtEnv._loadConfig();
+            } catch (err) {
+                e = err;
+            }
+            return e;
+        };
+
+        afterEach(() => {
+            envVars.forEach((env) => {
+                delete process.env[`SECURITY_TXT_${env}`];
+            });
+        });
+
+        it('does not throw when enabled is undefined', () => {
+            expect(getConfigError()).to.be.undefined;
+        });
+
+        it('does not throw when enabled is false', () => {
+            process.env.SECURITY_TXT_ENABLED = false;
+            expect(getConfigError()).to.be.undefined;
+        });
+
+        it('does not log when enabled is false', () => {
+            process.env.SECURITY_TXT_ENABLED = false;
+            securityTxtEnv._loadConfig();
+            expect(logger.error).not.to.have.been.called;
+        });
+
+        it('does not throw when enabled and required values are set', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            process.env.SECURITY_TXT_EXPIRES = new Date('2999-12-31').toISOString();
+            expect(getConfigError()).to.be.undefined;
+        });
+
+        it('throws when enabled but contact is undefined', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_EXPIRES = (new Date()).toISOString();
+            expect(getConfigError().message).to.contain('CONTACT');
+        });
+
+        it('logs when enabled but contact is undefined', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_EXPIRES = (new Date()).toISOString();
+            getConfigError();
+            expect(logger.error).to.have.been.calledWith(
+                'When SECURITY_TXT_ENABLED is set to true, both SECURITY_TXT_CONTACT and SECURITY_TXT_EXPIRES are required'
+            );
+        });
+
+        it('throws when enabled but expires is undefined', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            expect(getConfigError().message).to.contain('EXPIRE');
+        });
+
+        it('throws when expires is not a valid date string', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            process.env.SECURITY_TXT_EXPIRES = 'definitely not a date';
+            expect(getConfigError().message).to.contain('must be a valid date');
+        });
+
+        it('logs when expires is not a valid date string', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            process.env.SECURITY_TXT_EXPIRES = 'definitely not a date';
+            getConfigError();
+            expect(logger.error).to.have.been.calledWith(
+                'SECURITY_TXT_EXPIRES must be a valid date'
+            );
+        });
+
+        it('logs a warning when expires is in the past', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            process.env.SECURITY_TXT_EXPIRES = new Date('2020-01-01').toISOString();
+            securityTxtEnv._loadConfig();
+            expect(logger.warn).to.have.been.calledWith(
+                'Your security.txt has expired. SECURITY_TXT_EXPIRES date is in the past'
+            );
+        });
+
+        it('logs information when expires is more than a year away', () => {
+            process.env.SECURITY_TXT_ENABLED = true;
+            process.env.SECURITY_TXT_CONTACT = 'mailto:someone@somewhere.com';
+            process.env.SECURITY_TXT_EXPIRES = new Date('2999-12-31').toISOString();
+            securityTxtEnv._loadConfig();
+            expect(logger.info).to.have.been.calledWith(
+                'Your security.txt expiration date is more than one year in the future.'
+            );
+        });
+    });
+
+});


### PR DESCRIPTION
**Summary**:  

Closes  #1708 

Adds an optional/configurable security.txt to `/.well-known/security.txt`
This is technically compliant with [RFC 9116](https://datatracker.ietf.org/doc/rfc9116/), but not a _complete_ implementation. 

Where it's lacking:
- Omitted fields: Acknowledgements, Encryption, Hiring
- Only supports unsigned security.txt 

I opted to make this server-side only. While we could add this in td.vue - I really prefer to keep configuration/environment variables on the back-end as much as possible.

We should not default the security.txt to OWASP Threat Dragon's info - if Threat Dragon is deployed at a company and let's say it's accidentally exposed to the internet - it wouldn't make sense to provide our security policy. If companies choose to provide Threat Dragon's security info, they are free to do so! :smile: 

If enabled, both "Contacts" and "Expires" properties are required. All others are optional.

Contacts supports a comma separated list. When parsed, each gets a new line as per the spec. They should be sorted in priority order, and users are responsible for determining their own priority and contact methods. The parser respects the order of the CSV.

The "legacy" `/security.txt` route is a redirect to `/.well-known/security.txt`

If not configured, `/.well-known/security.txt` returns a 404

**Description for the changelog**:  

feat: add configurable `/.well-known/security.txt`

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `GPT-5.5`
  - Prompts: `Please get my tests up to 95%+ coverage against lines, branches, etc.`

**Other info**:  

My AI assistant only finished off my tests for me this time around. I got lazy towards the end. :laughing: 
