### PR TITLE
Fix push and release pipeline

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -175,6 +175,25 @@ jobs:
           sbom: true
           provenance: mode=max,version=v1
 
+      # Required because multiplatform images can't be loaded directly
+      - name: Build for amd64 only to extract SBOM
+        id: docker_build_amd64
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          # Do not push, just for the docker run in the next line
+          push: false
+          tags:  ${{ env.IMAGE_NAME }}
+          # Should pull from the step before, so this one should be all cached
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          load: true
+          # Note: no sbom or provenance, we need to produce the simplest image form
+          # so that the load will actually succeed
+
       - name: fetch app SBOMs
         run: docker run --rm --entrypoint tar "$IMAGE_ID" -c boms | tar -xv
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -394,7 +394,7 @@ jobs:
 
       # Required because multiplatform images can't be loaded directly
       - name: Build for amd64 only to extract SBOM
-        id: docker_build_arm64
+        id: docker_build_amd64
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./


### PR DESCRIPTION
**Summary**:  

In #1692 the Build & Release Pipeline was modified.
However, there were some things that did not work as intended.

To fix those, I added a amd64-only job like the release & PR pipelines have, just to extract the SBOMs. The build cache should re-use the layers built before, so nothing new should be built.

Additionally, I spotted a typo that would've stopped the release pipeline from working.

**Description for the changelog**:  

- Fixed Build & Release Pipeline (introduced in #1692)

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
