### PR TITLE
fix(dependabot): remove devEngines.packageManager from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,6 @@
   "engines": {
     "npm": ">=11.10.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": ">=11.10.0",
-      "onFail": "error"
-    }
-  },
   "homepage": "https://owasp.org/www-project-threat-dragon/",
   "repository": {
     "type": "git",

--- a/td.server/package.json
+++ b/td.server/package.json
@@ -30,13 +30,6 @@
   "engines": {
     "npm": ">=11.10.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": ">=11.10.0",
-      "onFail": "error"
-    }
-  },
   "homepage": "https://github.com/OWASP/www-project-threat-dragon/",
   "repository": {
     "type": "git",

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -55,13 +55,6 @@
   "engines": {
     "npm": ">=11.10.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": ">=11.10.0",
-      "onFail": "error"
-    }
-  },
   "homepage": "https://owasp.org/www-project-threat-dragon/",
   "buildState": "-latest",
   "repository": {


### PR DESCRIPTION


**Summary**:  

See https://github.com/nodejs/corepack/issues/729 for a similar issue.
Dependabot breaks when the package.json specifies a version range for the package manager instead of a specific pinned version.
As the Dockerfile for example already uses the latest npm, this should be redundant.

If you look here, Dependabot does not work:

- Overview: https://github.com/OWASP/threat-dragon/network/updates
- Latest run: https://github.com/OWASP/threat-dragon/network/updates/1400550406

**Description for the changelog**:  

- Fixed Dependabot for npm dependencies

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
