### PR TITLE
Create vertex on edges only on double click

### DIFF
--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -150,6 +150,49 @@ const cellSelected = (graph) => ({ cell }) => {
     dataChanged.setType(cell);
 };
 
+const cellDoubleClicked = ({ cell, x, y }) => {
+    // When cell.insertVertex is available, this is an edge.
+    if (cell?.insertVertex) {
+        const edgeView = cell.model.graph.findViewByCell(cell);
+
+        if (edgeView) {
+            // Search vertex that might have been clicked
+            let clickedVertex = null;
+
+            cell.getVertices().forEach((vertex, i) => {
+                const dX = vertex.x - x;
+                const dY = vertex.y - y;
+                const diff = Math.sqrt(dX * dX + dY * dY);
+
+                if (diff > 20) {
+                    return;
+                }
+
+                // Take the nearest one
+                if (clickedVertex && clickedVertex.diff < diff) {
+                    return;
+                }
+
+                clickedVertex = {
+                    vertex: i,
+                    diff: diff,
+                };
+            });
+
+            if (!clickedVertex) {
+                // Create a vertex when none exist
+                const previousVertexIndex = edgeView.getVertexIndex(x, y);
+                cell.insertVertex({ x, y }, previousVertexIndex);
+            } else {
+                // Delete the found vertex
+                cell.removeVertexAt(clickedVertex.vertex);
+            }
+
+            store.get().dispatch(THREATMODEL_MODIFIED);
+        }
+    }
+};
+
 const cellUnselected = ({ cell }) => {
     console.debug('cell unselected');
     mouseLeave({ cell });
@@ -166,7 +209,7 @@ const listen = (graph) => {
     graph.on('resize', canvasResized);
     graph.on('edge:change:vertices', edgeChangeVertices(graph));
     graph.on('edge:connected', edgeConnected(graph));
-    graph.on('edge:dblclick', cellSelected);
+    graph.on('edge:dblclick', cellDoubleClicked);
     graph.on('edge:move', cellSelected);
     graph.on('cell:mouseleave', mouseLeave);
     graph.on('cell:mouseenter', mouseEnter);
@@ -182,7 +225,7 @@ const removeListeners = (graph) => {
     graph.off('resize', canvasResized);
     graph.off('edge:change:vertices', edgeChangeVertices(graph));
     graph.off('edge:connected', edgeConnected(graph));
-    graph.off('edge:dblclick', cellSelected);
+    graph.off('edge:dblclick', cellDoubleClicked);
     graph.off('edge:move', cellSelected);
     graph.off('cell:mouseleave', mouseLeave);
     graph.off('cell:mouseenter', mouseEnter);

--- a/td.vue/src/service/x6/graph/graph.js
+++ b/td.vue/src/service/x6/graph/graph.js
@@ -32,6 +32,13 @@ const getEditGraph = (container, ctor = Graph) => {
             max: 3.2 // default value is 16
         },
         preventDefaultContextMenu: false,
+        interacting: {
+            // This will be handled manually to ensure only a double click can add vertices.
+            // This allows a single click to select a curve.
+            vertexAddable: false,
+            // Also handled manually to not interfere with the custom vertexAddable code
+            vertexDeletable: false,
+        },
         connecting: {
             allowBlank: true,
             allowLoop: true, // loops do not make sense in a threat model diagram, but allow anyway


### PR DESCRIPTION
**Summary**:  

Fixes https://github.com/OWASP/threat-dragon/issues/1721.
Split from https://github.com/OWASP/threat-dragon/pull/1718

Make sure single click only selects the edge, making sure no vertex is added by accident. This also re-enabled selection of edges when clicking on the line.

**Description for the changelog**:  

- Edges are now selected when clicking anywhere on the edge. Double-Clicking is now used to create new vertices

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
