### PR TITLE
Make behaviour of Trust Boundary Boxes more reasonable

### DIFF
--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -21,7 +21,7 @@ export const TrustBoundaryBox = Shape.Rect.define({
             text: '',
             textAnchor : 'bottom',
             textVerticalAnchor : 'top',
-            refX: '15%',
+            refX: '12',
             refY: '12'
         }
     }

--- a/td.vue/src/service/x6/shapes/trust-boundary-box.js
+++ b/td.vue/src/service/x6/shapes/trust-boundary-box.js
@@ -33,7 +33,12 @@ TrustBoundaryBox.prototype.setName = function (name) {
     this.setAttrByPath('label/text', name);
 };
 
-TrustBoundaryBox.prototype.updateStyle = function () {};
+TrustBoundaryBox.prototype.updateStyle = function () {
+    // After the node is dropped, make sure it can only be clicked
+    // on the boundary. This helps prevent accidental clicks in
+    // the middle of the box.
+    this.setAttrByPath('body/style/pointerEvents', 'stroke');
+};
 
 export default {
     name,


### PR DESCRIPTION
**Summary**:  

Fixes https://github.com/OWASP/threat-dragon/issues/1723.
Split from https://github.com/OWASP/threat-dragon/pull/1718

When accidentally mis-clicking to an empty space, the box gets selected.
To un-select it I have to scroll to somewhere where the box is not, click on an empty space, and return.
I can not select any other node inside the box until the box is deselected.

Additionally, the left margin of the box label seems a bit "random".
It is somehow floating, but not centered nor fixed to any edge.

**Description for the changelog**:  

- Trust Boundary Boxes will no longer get selected when clicking on an empty space inside the box. To select a box, click on the border.
- Aligned the label of Trust Boundary Boxes on the top left side of the box

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
