### PR TITLE
add OAUTH_FRONTEND_RETURN_URL config and shared oauth helper

### DIFF
--- a/docs/configure/bitbucket.md
+++ b/docs/configure/bitbucket.md
@@ -34,7 +34,8 @@ and 'test' alters the functionality from what is being tested.
 
 - `NODE_ENV='development'`
 
-Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+Note: with `NODE_ENV=development`, the OAuth redirect points to `http://localhost:8080` by default.
+If your frontend runs elsewhere, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL.
 
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.

--- a/docs/configure/bitbucket.md
+++ b/docs/configure/bitbucket.md
@@ -34,6 +34,8 @@ and 'test' alters the functionality from what is being tested.
 
 - `NODE_ENV='development'`
 
+Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.
 

--- a/docs/configure/configure.md
+++ b/docs/configure/configure.md
@@ -173,7 +173,7 @@ it depends on what repository access is required and whether running the desktop
 | `APP_TLS_CERT_PATH` | Locates the TLS certificate if TLS used | |
 | `APP_TLS_KEY_PATH` | Locates the TLS key if TLS used | |
 | `ENV_FILE` | The location of a dotenv file, if dotenv is used. Exported as it needs to be accessed before the dotenv file is read | `.env` |
-| `NODE_ENV` | Optional run mode: `production` enables rate limiting and relative OAuth redirects; `development` sets OAuth redirect to `http://localhost:8080`; `test` silences logging. Use `OAUTH_FRONTEND_RETURN_URL` to override the redirect instead of relying on this | `production` |
+| `NODE_ENV` | Optional run mode: `production`, `development` or `test` | `production` |
 | `LOCALES_ALLOWED` | Optional JSON array of allowed locale codes, e.g. `["en","es","fr"]`. When not set all locales will be available on the frontend | `[]` |
 | `LOCALE_DEFAULT` | Default locale code the server suggests, e.g. `pt`. When not set the server defaults to `en` | `en` |
 
@@ -204,7 +204,7 @@ for example `http://localhost:3000/`, but not in 'production' mode.
 | `REPO_SEARCH_QUERY` | Provides search string if repo search enabled | |
 | `REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in the repo | |
 | `SERVER_API_PROTOCOL` | Protocol between server and front-end: `http` / `https` | `https` |
-| `OAUTH_FRONTEND_RETURN_URL` | Optional override for the OAuth redirect URL. When set, takes precedence over `NODE_ENV` logic. Useful when running the frontend on a non-default host or port | |
+| `OAUTH_FRONTEND_RETURN_URL` | Optional OAuth redirect base URL, overrides the `NODE_ENV` default | |
 | `SECURITY_TXT_ENABLED` | Optional `/.well-known/security.txt` | `false` |
 | `SECURITY_TXT_CONTACT` | Required if enabled - comma separated contact methods in priority order | |
 | `SECURITY_TXT_POLICY` | Optional policy URL for security.txt | |

--- a/docs/configure/configure.md
+++ b/docs/configure/configure.md
@@ -173,7 +173,7 @@ it depends on what repository access is required and whether running the desktop
 | `APP_TLS_CERT_PATH` | Locates the TLS certificate if TLS used | |
 | `APP_TLS_KEY_PATH` | Locates the TLS key if TLS used | |
 | `ENV_FILE` | The location of a dotenv file, if dotenv is used. Exported as it needs to be accessed before the dotenv file is read | `.env` |
-| `NODE_ENV` | Optional run mode such as 'test', 'production' or 'development' | `production` |
+| `NODE_ENV` | Optional run mode: `production` enables rate limiting and relative OAuth redirects; `development` sets OAuth redirect to `http://localhost:8080`; `test` silences logging. Use `OAUTH_FRONTEND_RETURN_URL` to override the redirect instead of relying on this | `production` |
 | `LOCALES_ALLOWED` | Optional JSON array of allowed locale codes, e.g. `["en","es","fr"]`. When not set all locales will be available on the frontend | `[]` |
 | `LOCALE_DEFAULT` | Default locale code the server suggests, e.g. `pt`. When not set the server defaults to `en` | `en` |
 
@@ -204,6 +204,7 @@ for example `http://localhost:3000/`, but not in 'production' mode.
 | `REPO_SEARCH_QUERY` | Provides search string if repo search enabled | |
 | `REPO_ROOT_DIRECTORY` | Optional path where saved models are stored in the repo | |
 | `SERVER_API_PROTOCOL` | Protocol between server and front-end: `http` / `https` | `https` |
+| `OAUTH_FRONTEND_RETURN_URL` | Optional override for the OAuth redirect URL. When set, takes precedence over `NODE_ENV` logic. Useful when running the frontend on a non-default host or port | |
 | `SECURITY_TXT_ENABLED` | Optional `/.well-known/security.txt` | `false` |
 | `SECURITY_TXT_CONTACT` | Required if enabled - comma separated contact methods in priority order | |
 | `SECURITY_TXT_POLICY` | Optional policy URL for security.txt | |

--- a/docs/configure/github.md
+++ b/docs/configure/github.md
@@ -33,6 +33,8 @@ and 'test' alters the functionality from what is being tested.
 
 - `NODE_ENV='development'`
 
+Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.
 

--- a/docs/configure/github.md
+++ b/docs/configure/github.md
@@ -33,7 +33,9 @@ and 'test' alters the functionality from what is being tested.
 
 - `NODE_ENV='development'`
 
-Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to
+`http://localhost:8080`. If the frontend runs on a different host or port,
+set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
 
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.

--- a/docs/configure/google.md
+++ b/docs/configure/google.md
@@ -32,7 +32,8 @@ and 'test' alters the functionality in some subtle ways.
 
 - `NODE_ENV='development'`
 
-Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+Note: `NODE_ENV=development` hard-codes the OAuth redirect to `http://localhost:8080`.
+Set `OAUTH_FRONTEND_RETURN_URL` to override this if your frontend is on a different host or port.
 
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.

--- a/docs/configure/google.md
+++ b/docs/configure/google.md
@@ -32,6 +32,8 @@ and 'test' alters the functionality in some subtle ways.
 
 - `NODE_ENV='development'`
 
+Note: when `NODE_ENV` is set to `development`, the OAuth redirect is hard-coded to `http://localhost:8080`. If the frontend runs on a different host or port, set `OAUTH_FRONTEND_RETURN_URL` to the correct base URL instead.
+
 Server port number - this defaults to 3000, and it can be mapped to another port when running the docker command.
 So leave the server port at 3000 by not defining it, and it can then be mapped to external port 8080 using docker.
 

--- a/td.server/src/env/ThreatDragon.js
+++ b/td.server/src/env/ThreatDragon.js
@@ -22,7 +22,8 @@ class ThreatDragonEnv extends Env {
             { key: 'REPO_USE_SEARCH', required: false, defaultValue: false },
             { key: 'REPO_SEARCH_QUERY', required: false },
             { key: 'LOCALES_ALLOWED', required: false, defaultValue: '[]' },
-            { key: 'LOCALE_DEFAULT', required: false, defaultValue: 'en' }
+            { key: 'LOCALE_DEFAULT', required: false, defaultValue: 'en' },
+            { key: 'OAUTH_FRONTEND_RETURN_URL', required: false }
         ];
     }
 }

--- a/td.server/src/helpers/oauth.helper.js
+++ b/td.server/src/helpers/oauth.helper.js
@@ -1,0 +1,27 @@
+﻿/**
+ * @name oauth.helper.js
+ * @description Shared OAuth helper for return URL construction
+ */
+import env from '../env/Env.js';
+
+/**
+ * Gets the return URL for our application after OAuth login
+ * If OAUTH_FRONTEND_RETURN_URL is set, it takes precedence over NODE_ENV logic
+ * @param {string} code
+ * @returns {String}
+ */
+const getOauthReturnUrl = (code) => {
+    const returnPath = `/#/oauth-return?code=${code}`;
+    const configured = env.get().config.OAUTH_FRONTEND_RETURN_URL;
+    if (configured) {
+        return `${configured}${returnPath}`;
+    }
+    if (env.get().config.NODE_ENV === 'development') {
+        return `http://localhost:8080${returnPath}`;
+    }
+    return returnPath;
+};
+
+export default {
+    getOauthReturnUrl
+};

--- a/td.server/src/providers/bitbucket.js
+++ b/td.server/src/providers/bitbucket.js
@@ -5,6 +5,7 @@
 import axios from 'axios';
 
 import env from '../env/Env.js';
+import oauthHelper from '../helpers/oauth.helper.js';
 import repositories from '../repositories';
 
 const name = 'bitbucket';
@@ -38,18 +39,7 @@ const getOauthRedirectUrl = () => {
     return `${getBitbucketUrl()}/site/oauth2/authorize?scope=${scope}&response_type=code&client_id=${env.get().config.BITBUCKET_CLIENT_ID}`;
 };
 
-/**
- * Gets the return URL for our application, returning from bitbucket
- * @param {string} code
- * @returns {String}
- */
-const getOauthReturnUrl = (code) => {
-    let returnUrl = `/#/oauth-return?code=${code}`;
-    if (env.get().config.NODE_ENV === 'development') {
-        returnUrl = `http://localhost:8080${returnUrl}`;
-    }
-    return returnUrl;
-};
+const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**
  * Finishes the OAuth login, issues a JWT

--- a/td.server/src/providers/bitbucket.js
+++ b/td.server/src/providers/bitbucket.js
@@ -39,6 +39,11 @@ const getOauthRedirectUrl = () => {
     return `${getBitbucketUrl()}/site/oauth2/authorize?scope=${scope}&response_type=code&client_id=${env.get().config.BITBUCKET_CLIENT_ID}`;
 };
 
+/**
+ * Gets the return URL for our application, returning from bitbucket
+ * @param {string} code
+ * @returns {String}
+ */
 const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**

--- a/td.server/src/providers/github.js
+++ b/td.server/src/providers/github.js
@@ -42,6 +42,11 @@ const getOauthRedirectUrl = () => {
     return `${getGithubUrl()}/login/oauth/authorize?scope=${scope}&client_id=${env.get().config.GITHUB_CLIENT_ID}`;
 };
 
+/**
+ * Gets the return URL for our application, returning from github
+ * @param {string} code
+ * @returns {String}
+ */
 const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**

--- a/td.server/src/providers/github.js
+++ b/td.server/src/providers/github.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 
 import env from '../env/Env.js';
 import loggerHelper from '../helpers/logger.helper.js';
+import oauthHelper from '../helpers/oauth.helper.js';
 import repositories from '../repositories';
 
 const logger = loggerHelper.get('providers/github.js');
@@ -41,18 +42,7 @@ const getOauthRedirectUrl = () => {
     return `${getGithubUrl()}/login/oauth/authorize?scope=${scope}&client_id=${env.get().config.GITHUB_CLIENT_ID}`;
 };
 
-/**
- * Gets the return URL for our application, returning from github
- * @param {string} code
- * @returns {String}
- */
-const getOauthReturnUrl = (code) => {
-    let returnUrl = `/#/oauth-return?code=${code}`;
-    if (env.get().config.NODE_ENV === 'development') {
-        returnUrl = `http://localhost:8080${returnUrl}`;
-    }
-    return returnUrl;
-};
+const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**
  * Finishes the OAuth login, issues a JWT

--- a/td.server/src/providers/gitlab.js
+++ b/td.server/src/providers/gitlab.js
@@ -5,6 +5,7 @@
 import axios from 'axios';
 
 import env from '../env/Env.js';
+import oauthHelper from '../helpers/oauth.helper.js';
 import repositories from '../repositories';
 
 const name = 'gitlab';
@@ -30,18 +31,7 @@ const getOauthRedirectUrl = () => {
     return `${getGitlabUrl()}/oauth/authorize?scope=${scope}&redirect_uri=${env.get().config.GITLAB_REDIRECT_URI}&response_type=code&client_id=${env.get().config.GITLAB_CLIENT_ID}`;
 };
 
-/**
- * Gets the return URL for our application, returning from gitlab
- * @param {string} code
- * @returns {String}
- */
-const getOauthReturnUrl = (code) => {
-    let returnUrl = `/#/oauth-return?code=${code}`;
-    if (env.get().config.NODE_ENV === 'development') {
-        returnUrl = `http://localhost:8080${returnUrl}`;
-    }
-    return returnUrl;
-};
+const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**
  * Finishes the OAuth login, issues a JWT

--- a/td.server/src/providers/gitlab.js
+++ b/td.server/src/providers/gitlab.js
@@ -31,6 +31,11 @@ const getOauthRedirectUrl = () => {
     return `${getGitlabUrl()}/oauth/authorize?scope=${scope}&redirect_uri=${env.get().config.GITLAB_REDIRECT_URI}&response_type=code&client_id=${env.get().config.GITLAB_CLIENT_ID}`;
 };
 
+/**
+ * Gets the return URL for our application, returning from gitlab
+ * @param {string} code
+ * @returns {String}
+ */
 const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**

--- a/td.server/src/providers/google.js
+++ b/td.server/src/providers/google.js
@@ -4,6 +4,7 @@
  */
 import axios from 'axios';
 import env from '../env/Env.js';
+import oauthHelper from '../helpers/oauth.helper.js';
 
 const name = 'google';
 
@@ -23,18 +24,7 @@ const getOauthRedirectUrl = () => {
     return `https://accounts.google.com/o/oauth2/auth?response_type=code&scope=${scope}&client_id=${env.get().config.GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 };
 
-/**
- * Gets the return URL for our application, returning from Google
- * @param {string} code
- * @returns {String}
- */
-const getOauthReturnUrl = (code) => {
-    let returnUrl = `/#/oauth-return?code=${code}`;
-    if (env.get().config.NODE_ENV === 'development') {
-        returnUrl = `http://localhost:8080${returnUrl}`;
-    }
-    return returnUrl;
-};
+const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**
  * Finishes the OAuth login, issues a JWT

--- a/td.server/src/providers/google.js
+++ b/td.server/src/providers/google.js
@@ -24,6 +24,11 @@ const getOauthRedirectUrl = () => {
     return `https://accounts.google.com/o/oauth2/auth?response_type=code&scope=${scope}&client_id=${env.get().config.GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 };
 
+/**
+ * Gets the return URL for our application, returning from Google
+ * @param {string} code
+ * @returns {String}
+ */
 const getOauthReturnUrl = (code) => oauthHelper.getOauthReturnUrl(code);
 
 /**

--- a/td.server/test/env/ThreatDragon.spec.js
+++ b/td.server/test/env/ThreatDragon.spec.js
@@ -16,7 +16,8 @@ describe('env/ThreatDragon.js', () => {
         { key: 'REPO_USE_SEARCH', defaultValue: false },
         { key: 'REPO_SEARCH_QUERY', defaultValue: undefined },
         { key: 'LOCALES_ALLOWED', defaultValue: '[]' },
-        { key: 'LOCALE_DEFAULT', defaultValue: 'en' }
+        { key: 'LOCALE_DEFAULT', defaultValue: 'en' },
+        { key: 'OAUTH_FRONTEND_RETURN_URL', defaultValue: undefined }
     ];
 
     beforeEach(() => {

--- a/td.server/test/helpers/oauth.helper.spec.js
+++ b/td.server/test/helpers/oauth.helper.spec.js
@@ -1,0 +1,62 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+
+import env from '../../src/env/Env.js';
+import oauthHelper from '../../src/helpers/oauth.helper.js';
+
+describe('helpers/oauth.helper.js', () => {
+    const code = '1234-5678';
+
+    describe('getOauthReturnUrl', () => {
+        describe('with OAUTH_FRONTEND_RETURN_URL configured', () => {
+            beforeEach(() => {
+                sinon.stub(env, 'get').returns({
+                    config: {
+                        OAUTH_FRONTEND_RETURN_URL: 'https://my.app'
+                    }
+                });
+            });
+
+            it('uses the configured frontend return url', () => {
+                expect(oauthHelper.getOauthReturnUrl(code)).to
+                    .contain('https://my.app');
+            });
+
+            it('adds the code as a query param', () => {
+                expect(oauthHelper.getOauthReturnUrl(code)).to
+                    .contain(`code=${code}`);
+            });
+        });
+
+        describe('development', () => {
+            beforeEach(() => {
+                sinon.stub(env, 'get').returns({
+                    config: { NODE_ENV: 'development' }
+                });
+            });
+
+            it('returns an absolute url with the front-end port', () => {
+                const idx = oauthHelper.getOauthReturnUrl(code).indexOf('http://localhost:8080');
+                expect(idx).to.eq(0);
+            });
+        });
+
+        describe('production', () => {
+            beforeEach(() => {
+                sinon.stub(env, 'get').returns({
+                    config: { NODE_ENV: 'production' }
+                });
+            });
+
+            it('gives a relative url', () => {
+                const idx = oauthHelper.getOauthReturnUrl(code).indexOf('/#/oauth-return');
+                expect(idx).to.eq(0);
+            });
+
+            it('adds the code as a query param', () => {
+                expect(oauthHelper.getOauthReturnUrl(code)).to
+                    .contain(`code=${code}`);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary:

Fixes #1539

I was looking at the providers and noticed all four of them had the exact same getOauthReturnUrl function copied. also NODE_ENV=development silently hard-codes the redirect to localhost:8080 which breaks if you deploy anywhere else.

## Description for the changelog:
Add OAUTH_FRONTEND_RETURN_URL config and shared OAuth return URL helper

## Other info:

changes:
- added OAUTH_FRONTEND_RETURN_URL to ThreatDragon.js (optional, no default)
- moved shared redirect logic into oauth.helper.js
- updated all 4 providers to use it
- added tests
- updated docs to explain what NODE_ENV does to oauth redirects


## Declaration:  

-Thanks for submitting a pull request, please make sure:  

- [X] content meets the [license](../blob/main/license.txt) for this project
- [X] appropriate unit tests have been created and/or modified
- [X] you have considered any changes required for the functional tests
- [X] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [X] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

