### PR TITLE
chore: dependabot overrides action to use signed commits

### DIFF
--- a/.github/workflows/dependabot-force-package-json-overrides.yaml
+++ b/.github/workflows/dependabot-force-package-json-overrides.yaml
@@ -20,6 +20,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: lreading/dependabot-npm-force-overrides@a1c38a755edfdbaf02080e62069ba188773bd5bd # v1.0.1
+      - uses: lreading/dependabot-npm-force-overrides@b628c8f156b893d3afc176b01775a5964efb1ad6 # v1.1.0
         with:
           github-token: ${{ github.token }}
+          sign-commit: true
+          ssh-signing-key: ${{ secrets.DEPENDABOT_OVERRIDES_SSH_SIGNING_KEY }}
+          commit-user-name: lreading
+          commit-user-email: lreading@users.noreply.github.com


### PR DESCRIPTION
**Summary**:  

The action that enforces `package.json` overrides instead of `package-lock.json` only updates for dependency management creates commits on PRs opened by dependabot for the npm ecosystem when there is `package-lock.json` file changes only. Those commits are not signed.

I've updated the https://github.com/lreading/dependabot-npm-force-overrides action to allow for signed commits. This is done by adding a dependabot secret with the ssh signing key, and defining the author/key in the action.

This update will allow signed commits from that action (under my identity).

**Description for the changelog**:  

chore: dependabot package.json overrides use signed commits

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `gpt-5.5`
  - Prompts: `Update the dependabot-npm-force-overrides action to use the latest version, pinned, with a version comment tag. Add the necessary arguments to use signed commits.`

**Other info**:  

This is well below the 10 day minimum release threshold. I'm happy to let it sit for a while, however - I'm the author so my instinct is that it's more akin to first-party code. No strong preference, this isn't an emergency. :smile: 
