### PR TITLE
chore: fix lint warnings in td.server

### DIFF
--- a/td.server/src/controllers/metadataController.js
+++ b/td.server/src/controllers/metadataController.js
@@ -3,48 +3,48 @@ import errors from './errors.js';
 import loggerHelper from '../helpers/logger.helper';
 
 const getSecurityTxt = (config) => {
-  // Contact and expires are required
-  // security.txt must be in `key: value` format
-  // All other fields are optional
-  const parts = [];
+    // Contact and expires are required
+    // security.txt must be in `key: value` format
+    // All other fields are optional
+    const parts = [];
 
-  // You are allowed multiple contacts. This implementation
-  // allows a CSV, and we will honor the order.
-  const contacts = config.SECURITY_TXT_CONTACT.split(',');
-  parts.push(...contacts.map((x) => `Contact: ${x.trim()}`));
-  parts.push(`Expires: ${config.SECURITY_TXT_EXPIRES}`);
+    // You are allowed multiple contacts. This implementation
+    // allows a CSV, and we will honor the order.
+    const contacts = config.SECURITY_TXT_CONTACT.split(',');
+    parts.push(...contacts.map((x) => `Contact: ${x.trim()}`));
+    parts.push(`Expires: ${config.SECURITY_TXT_EXPIRES}`);
   
-  if (config.SECURITY_TXT_POLICY) {
-    parts.push(`Policy: ${config.SECURITY_TXT_POLICY}`);
-  }
+    if (config.SECURITY_TXT_POLICY) {
+        parts.push(`Policy: ${config.SECURITY_TXT_POLICY}`);
+    }
 
-  if (config.SECURITY_TXT_CANONICAL) {
-    parts.push(`Canonical: ${config.SECURITY_TXT_CANONICAL}`);
-  }
+    if (config.SECURITY_TXT_CANONICAL) {
+        parts.push(`Canonical: ${config.SECURITY_TXT_CANONICAL}`);
+    }
 
-  if (config.SECURITY_TXT_PREFERRED_LANGUAGES) {
-    parts.push(`Preferred-Languages: ${config.SECURITY_TXT_PREFERRED_LANGUAGES}`);
-  }
+    if (config.SECURITY_TXT_PREFERRED_LANGUAGES) {
+        parts.push(`Preferred-Languages: ${config.SECURITY_TXT_PREFERRED_LANGUAGES}`);
+    }
 
-  return parts.join('\n');
+    return parts.join('\n');
 };
 
 const securityTxt = (_req, res) => {
-  const config = env.get().config;
-  if (!config.SECURITY_TXT_ENABLED) {
-    return errors.notFound('File not found', res, loggerHelper.get('controllers/metadataController.js'));
-  }
+    const config = env.get().config;
+    if (!config.SECURITY_TXT_ENABLED) {
+        return errors.notFound('File not found', res, loggerHelper.get('controllers/metadataController.js'));
+    }
 
-  // RFC 9116 states that /.well-known/security.txt must return a 200
-  // with Content-Type: text/plain; charset=utf-8
-  res.set('Content-Type', 'text/plain; charset=utf-8');
-  return res.status(200).send(getSecurityTxt(config));
+    // RFC 9116 states that /.well-known/security.txt must return a 200
+    // with Content-Type: text/plain; charset=utf-8
+    res.set('Content-Type', 'text/plain; charset=utf-8');
+    return res.status(200).send(getSecurityTxt(config));
 };
 
 const legacySecurityTxtRedirect = (_req, res) => res.redirect('/.well-known/security.txt');
 
 export default {
-  legacySecurityTxtRedirect,
-  securityTxt
+    legacySecurityTxtRedirect,
+    securityTxt
 };
 

--- a/td.server/src/env/SecurityTxt.js
+++ b/td.server/src/env/SecurityTxt.js
@@ -18,56 +18,56 @@ class SecurityTxtEnv extends Env {
     // Overriding the base implementation to apply conditional logic for when fields
     // are required. CONTACT and EXPIRES are the minimum required according to the RFC
     _loadConfig() {
-      // Create the config object - remember config has full property names including prefix
-      const config = super._loadConfig();
-      // If not enabled, there is no need for the conditional logic
-      if (!config.SECURITY_TXT_ENABLED || config.SECURITY_TXT_ENABLED.toLowerCase() === 'false') {
+        // Create the config object - remember config has full property names including prefix
+        const config = super._loadConfig();
+        // If not enabled, there is no need for the conditional logic
+        if (!config.SECURITY_TXT_ENABLED || config.SECURITY_TXT_ENABLED.toLowerCase() === 'false') {
+            return config;
+        }
+
+        const contactVal = config.SECURITY_TXT_CONTACT;
+        const expiresVal = config.SECURITY_TXT_EXPIRES;
+
+        const hasContact = contactVal && contactVal.length;
+        const hasExpires = expiresVal && expiresVal.length;
+
+        if (!hasContact || !hasExpires) {
+            const errMsg = 'When SECURITY_TXT_ENABLED is set to true, both SECURITY_TXT_CONTACT and SECURITY_TXT_EXPIRES are required';
+            this.logger.error(errMsg);
+            throw new Error(errMsg);
+        }
+
+        this._validateExpiresDate(expiresVal);
+
+
         return config;
-      }
-
-      const contactVal = config.SECURITY_TXT_CONTACT;
-      const expiresVal = config.SECURITY_TXT_EXPIRES;
-
-      const hasContact = contactVal && contactVal.length;
-      const hasExpires = expiresVal && expiresVal.length;
-
-      if (!hasContact || !hasExpires) {
-        const errMsg = 'When SECURITY_TXT_ENABLED is set to true, both SECURITY_TXT_CONTACT and SECURITY_TXT_EXPIRES are required';
-        this.logger.error(errMsg);
-        throw new Error(errMsg);
-      }
-
-      this._validateExpiresDate(expiresVal);
-
-
-      return config;
     }
 
     _validateExpiresDate(expiresVal) {
-      // According to the RFC, expires must be a valid RFC3339 ISO.8601-2 date
-      // We are not doing that complete validation here. We are simply 
-      // checking that the date parses
-      const expires = new Date(expiresVal);
-      if (isNaN(expires.getTime())) {
-        const errMsg = 'SECURITY_TXT_EXPIRES must be a valid date';
-        this.logger.error(errMsg);
-        throw new Error(errMsg);
-      }
+        // According to the RFC, expires must be a valid RFC3339 ISO.8601-2 date
+        // We are not doing that complete validation here. We are simply 
+        // checking that the date parses
+        const expires = new Date(expiresVal);
+        if (isNaN(expires.getTime())) {
+            const errMsg = 'SECURITY_TXT_EXPIRES must be a valid date';
+            this.logger.error(errMsg);
+            throw new Error(errMsg);
+        }
 
-      // A date in the past means it is invalid and needs to be updated.
-      // This must be a warning and not a hard failure - a hard failure
-      // would prevent restarts in a production environment
-      if (expires <= new Date()) {
-        this.logger.warn('Your security.txt has expired. SECURITY_TXT_EXPIRES date is in the past');
-      }
+        // A date in the past means it is invalid and needs to be updated.
+        // This must be a warning and not a hard failure - a hard failure
+        // would prevent restarts in a production environment
+        if (expires <= new Date()) {
+            this.logger.warn('Your security.txt has expired. SECURITY_TXT_EXPIRES date is in the past');
+        }
       
-      // it is RECOMMENDED that expires be no more than 1 year in the future
-      const oneYearFromNow = new Date();
-      oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
-      if (expires >= oneYearFromNow) {
-        this.logger.info('Your security.txt expiration date is more than one year in the future.');
-        this.logger.info('RFC 1196 recommends an expiration of less than a year');
-      }
+        // it is RECOMMENDED that expires be no more than 1 year in the future
+        const oneYearFromNow = new Date();
+        oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
+        if (expires >= oneYearFromNow) {
+            this.logger.info('Your security.txt expiration date is more than one year in the future.');
+            this.logger.info('RFC 1196 recommends an expiration of less than a year');
+        }
     }
 
     get properties () {

--- a/td.server/src/repositories/googledrive.js
+++ b/td.server/src/repositories/googledrive.js
@@ -1,4 +1,4 @@
-import { auth, drive } from "@googleapis/drive";
+import { auth, drive } from '@googleapis/drive';
 import env from '../env/Env.js';
 
 const getClient = (accessToken) => {


### PR DESCRIPTION
**Summary**:  

There were some files in `td.server` that get mutated during the lint process.
We intentionally use the `--fix` flag for developer experience and AI integration, but this is a potential consequence of that.
This is a non-functional change.

**Description for the changelog**:  

chore: lint td.server

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I didn't do a git blame, but I do remember authoring these files recently... spare the g-drive one. :sweat_smile: Whoops!