### PR TITLE
feat: add release version and release date to threat models and printed report coversheet

### DIFF
--- a/td.vue/src/assets/schema/threat-dragon-v2.schema.json
+++ b/td.vue/src/assets/schema/threat-dragon-v2.schema.json
@@ -432,6 +432,14 @@
         }
       },
       "required": [ "contributors", "diagrams", "diagramTop", "reviewer", "threatTop" ]
+    },
+    "release_version": {
+      "description": "The release version of the model",
+      "type": "string"
+    },
+    "released_at": {
+      "description": "The release date of the model",
+      "type": "string"
     }
   },
   "required": [ "version", "summary", "detail" ]

--- a/td.vue/src/components/printed-report/Coversheet.vue
+++ b/td.vue/src/components/printed-report/Coversheet.vue
@@ -8,7 +8,8 @@
                 <li class="td-owner"><strong>{{ $t('threatmodel.owner') }}</strong>: {{ owner }}</li>
                 <li class="td-reviewer"><strong>{{ $t('threatmodel.reviewer') }}</strong>: {{ reviewer }}</li>
                 <li class="td-contributors"><strong>{{ $t('threatmodel.contributors') }}</strong>: {{ (contributors || []).join(', ') }}</li>
-                <li class="td-date-generated"><strong>{{ $t('report.dateGenerated') }}</strong>: {{ new Date().toDateString() }}</li>
+                <li v-if="releaseVersion" class="td-release-version"><strong>{{ $t('report.releaseVersion') }}</strong>: {{ releaseVersion }}</li>
+                <li class="td-release-date"><strong>{{ $t('report.releasedAt') }}</strong>: {{ releaseDate ? new Date(releaseDate).toDateString() : new Date().toDateString() }}</li>
             </ul>
         </div>
         <img
@@ -80,6 +81,14 @@ export default {
         branding: {
             type: Boolean,
             default: true
+        },
+        releaseVersion: {
+            type: String,
+            required: false
+        },
+        releaseDate: {
+            type: String,
+            required: false
         }
     }
 };

--- a/td.vue/src/i18n/en.js
+++ b/td.vue/src/i18n/en.js
@@ -184,6 +184,8 @@ const messages = {
         owner: 'Owner',
         reviewer: 'Reviewer',
         title: 'Title',
+        releaseVersion: 'Release version',
+        releasedAt: 'Release date',
         diagram: {
             diagrams: 'Diagrams',
             addNewDiagram: 'Add a new diagram...',
@@ -495,10 +497,11 @@ const messages = {
             showBranding: 'Threat Dragon logo'
         },
         title: 'Threat model report for',
-        dateGenerated: 'Date Generated',
         executiveSummary: 'Executive Summary',
         notProvided: 'Not provided',
         summary: 'Summary',
+        releaseVersion: 'Release Version',
+        releasedAt: 'Release Date',
         threatStats: {
             total: 'Total Threats',
             mitigated: 'Total Mitigated',

--- a/td.vue/src/views/NewThreatModel.vue
+++ b/td.vue/src/views/NewThreatModel.vue
@@ -28,6 +28,8 @@ export default {
             // Create blank model
             newTm = {
                 version: this.version,
+                release_version: '',
+                released_at: '',
                 summary: {
                     title: 'New Threat Model',
                     owner: '',

--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -152,6 +152,8 @@
                     :owner="model.summary.owner"
                     :reviewer="model.detail.reviewer"
                     :contributors="contributors"
+                    :releaseVersion="model.release_version"
+                    :releaseDate="model.released_at"
                     :branding="display.branding"
                 ></td-print-coversheet>
             </div>

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -55,6 +55,36 @@
                     </b-form-row>
 
                     <b-form-row>
+                        <b-col md=6>
+                            <b-form-group
+                                id="release-version-group"
+                                :label="$t('threatmodel.releaseVersion')"
+                                label-for="release-version">
+                                <b-form-input
+                                    id="release-version"
+                                    v-model="model.release_version"
+                                    @input="onModifyModel()"
+                                    type="text">
+                                </b-form-input>
+                            </b-form-group>
+                        </b-col>
+
+                        <b-col md=6>
+                            <b-form-group
+                                id="released-at-group"
+                                :label="$t('threatmodel.releasedAt')"
+                                label-for="released-at">
+                                <b-form-input
+                                    id="released-at"
+                                    v-model="model.released_at"
+                                    @input="onModifyModel()"
+                                    type="date">
+                                </b-form-input>
+                            </b-form-group>
+                        </b-col>
+                    </b-form-row>
+
+                    <b-form-row>
                         <b-col>
                             <b-form-group
                                 id="description-group"

--- a/td.vue/tests/e2e/desktop/specs/smokes.spec.js
+++ b/td.vue/tests/e2e/desktop/specs/smokes.spec.js
@@ -39,6 +39,14 @@ describe('Desktop smoke tests', function () {
         await titleInput.clearValue();
         await titleInput.setValue('Desktop smoke model');
 
+        const releaseVersionInput = await browser.$('#release-version');
+        await releaseVersionInput.waitForDisplayed();
+        await releaseVersionInput.setValue('1.0.0');
+
+        const releaseDateInput = await browser.$('#released-at');
+        await releaseDateInput.waitForDisplayed();
+        await releaseDateInput.setValue('2026-06-24');
+
         await browser.waitUntil(async () => {
             const parentCard = await browser.$('#parent-card');
             const header = await parentCard.getText();

--- a/td.vue/tests/e2e/fixtures/v2-model.json
+++ b/td.vue/tests/e2e/fixtures/v2-model.json
@@ -1,5 +1,7 @@
 {
   "version": "2.0.0",
+  "release_version": "",
+  "released_at": "",
   "summary": {
     "title": "Demo Threat Model",
     "owner": "Mike Goodwin",

--- a/td.vue/tests/e2e/fixtures/v2-new-model.json
+++ b/td.vue/tests/e2e/fixtures/v2-new-model.json
@@ -1,5 +1,7 @@
 {
   "version": "2.0.0",
+  "release_version": "",
+  "released_at": "",
   "summary": {
     "title": "New threat model",
     "owner": "",

--- a/td.vue/tests/e2e/specs/threatmodel/create.cy.js
+++ b/td.vue/tests/e2e/specs/threatmodel/create.cy.js
@@ -32,6 +32,26 @@ describe('create a new threat model', () => {
         cy.get('#contributors').should('be.visible');
     });
 
+    it('should have the release version field', () => {
+        cy.get('#release-version').should('be.visible');
+    });
+
+    it('should have the release date field', () => {
+        cy.get('#released-at').should('be.visible');
+    });
+
+    it('can edit the release version', () => {
+        cy.get('#release-version').should('be.visible')
+            .should('not.be', 'disabled')
+            .type('1.0.0');
+    });
+
+    it('can edit the release date', () => {
+        cy.get('#released-at').should('be.visible')
+            .should('not.be', 'disabled')
+            .type('2026-06-24');
+    });
+
     it('can add a new diagram', () => {
         cy.get('.add-diagram-link').click();
         cy.get('#diagram-group-0').should('be.visible');

--- a/td.vue/tests/e2e/specs/threatmodel/edit.cy.js
+++ b/td.vue/tests/e2e/specs/threatmodel/edit.cy.js
@@ -33,6 +33,14 @@ describe('editing threat models', () => {
             cy.get('#contributors').should('be.visible');
         });
 
+        it('has the release version field', () => {
+            cy.get('#release-version').should('be.visible');
+        });
+
+        it('has the release date field', () => {
+            cy.get('#released-at').should('be.visible');
+        });
+
         it('can add a new diagram', () => {
             cy.get('.add-diagram-link').click();
             cy.get('#diagram-group-0').should('be.visible');

--- a/td.vue/tests/unit/components/printed-report/coversheet.spec.js
+++ b/td.vue/tests/unit/components/printed-report/coversheet.spec.js
@@ -10,7 +10,9 @@ describe('components/printed-report/Coversheet.vue', () => {
         owner: 'Bob',
         reviewer: 'Marley',
         contributors: ['Alice', 'Babs'],
-        branding: true
+        branding: true,
+        releaseVersion: '',
+        releaseDate: ''
     });
 
     const setup = (data) => {
@@ -22,7 +24,9 @@ describe('components/printed-report/Coversheet.vue', () => {
                 owner: data.owner,
                 reviewer: data.reviewer,
                 contributors: data.contributors,
-                branding: data.branding
+                branding: data.branding,
+                releaseVersion: data.releaseVersion,
+                releaseDate: data.releaseDate
             },
             mocks: {
                 $t: key => key
@@ -55,9 +59,30 @@ describe('components/printed-report/Coversheet.vue', () => {
                 .toEqual(`threatmodel.contributors: ${summary.contributors.join(', ')}`);
         });
 
-        it('displays the date generated', () => {
-            expect(wrapper.find('.td-date-generated').text())
-                .toContain(`report.dateGenerated: `);
+        it('displays release date with fallback to generated date', () => {
+            const expectedDate = new Date().toDateString();
+            expect(wrapper.find('.td-release-date').text())
+                .toEqual(`report.releasedAt: ${expectedDate}`);
+        });
+
+        it('does not display release version when not provided', () => {
+            expect(wrapper.find('.td-release-version').exists())
+                .toEqual(false);
+        });
+
+        it('displays release version when provided', () => {
+            summary.releaseVersion = '1.0.0',
+            setup(summary);
+            expect(wrapper.find('.td-release-version').text())
+                .toEqual('report.releaseVersion: 1.0.0');
+        });
+
+        it('displays user-entered release date', () => {
+            summary.releaseDate = '2026-06-24';
+            setup(summary);
+            const expectedDate = new Date('2026-06-24').toDateString();
+            expect(wrapper.find('.td-release-date').text()) 
+                .toEqual(`report.releasedAt: ${expectedDate}`);
         });
 
         it('displays the brand image', () => {

--- a/td.vue/tests/unit/views/newThreatModel.spec.js
+++ b/td.vue/tests/unit/views/newThreatModel.spec.js
@@ -52,6 +52,20 @@ describe('NewThreatModel.vue', () => {
                 }
             });
         });
+
+        it('initialize the model with release_version as empty string', () => {
+            const callArgs = mockStore.dispatch.mock.calls.find(
+                call => call[0] === 'THREATMODEL_SELECTED'
+            );
+            expect(callArgs[1].release_version).toEqual('');
+        });
+
+        it('initialize the model with released_at as empty string', () => {
+            const callArgs = mockStore.dispatch.mock.calls.find(
+                call => call[0] === 'THREATMODEL_SELECTED'
+            );
+            expect(callArgs[1].released_at).toEqual('');
+        });
     });
 
     describe('git provider', () => {
@@ -99,6 +113,20 @@ describe('NewThreatModel.vue', () => {
                     threatmodel: 'New Threat Model'
                 }
             });
+        });
+
+        it('initialize the model with release_version as empty string', () => {
+            const callArgs = mockStore.dispatch.mock.calls.find(
+                call => call[0] === 'THREATMODEL_SELECTED'
+            );
+            expect(callArgs[1].release_version).toEqual('');
+        });
+
+        it('initialize the model with released_at as empty string', () => {
+            const callArgs = mockStore.dispatch.mock.calls.find(
+                call => call[0] === 'THREATMODEL_SELECTED'
+            );
+            expect(callArgs[1].released_at).toEqual('');
         });
     });
 });

--- a/td.vue/tests/unit/views/threatmodelEdit.spec.js
+++ b/td.vue/tests/unit/views/threatmodelEdit.spec.js
@@ -102,6 +102,14 @@ describe('views/ThreatmodelEdit.vue', () => {
         it('displays all diagrams', () => {
             expect(wrapper.findAll('.td-diagram')).toHaveLength(diagrams.length);
         });
+
+        it('has a release version input', () => {
+            expect(wrapper.find('#release-version').exists()).toEqual(true);
+        });
+
+        it('has a release date input', () => {
+            expect(wrapper.find('#released-at').exists()).toEqual(true);
+        });
     });
 
     describe('form actions', () => {


### PR DESCRIPTION
**Summary**:  

<!--
What existing issue does the pull request solve?
Add "closes #xxxx", where xxxx is the issue number
You must have been assigned the issue before submitting the pull request
and provide enough information so that others can review your changes
-->
closes #1621 

I have added release version and release date fields to threat models that are now exported to the PDF report.
The previous "Date Generated" is now replaced with "Release Date".
The release date falls back to the generated date if no date is provided.


**Description for the changelog**:  

<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->

add release version and release date fields to threat models and printed report coversheet

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

<!-- **Other info**:  -->

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
