### PR TITLE
Add llms.txt metadata

### DIFF
--- a/td.vue/public/llms.txt
+++ b/td.vue/public/llms.txt
@@ -2,7 +2,7 @@
 
 > OWASP Threat Dragon is a free, open-source threat modeling tool for creating data-flow diagrams and documenting threats and mitigations.
 
-Threat Dragon is an OWASP Production project. It supports web and desktop threat modeling workflows and can store models locally or through configured repository providers.
+Threat Dragon is an OWASP Production project. It is available as a web application and as desktop installers for Windows, macOS, and Linux.
 
 ## Project Links
 
@@ -20,28 +20,25 @@ Threat Dragon is an OWASP Production project. It supports web and desktop threat
 - Configuration: https://www.threatdragon.com/docs/configure/configure.html
 - Usage: https://www.threatdragon.com/docs/usage/getting-started.html
 - Development: https://www.threatdragon.com/docs/development/development.html
-- API: https://www.threatdragon.com/docs/development/api.html
 - Testing: https://www.threatdragon.com/docs/testing/testing.html
 
-## Supported Model And Integration Formats
+## Application Scope
 
-- Threat Dragon version 2 models
-- Legacy Threat Dragon version 1 models
-- Open Threat Model files
-- Threat Model BOM files
-- Organization template files
+Threat Dragon is used to:
 
-Threat Dragon can be configured to work with local files, GitHub, GitHub Enterprise, GitLab, Bitbucket, Bitbucket Enterprise, and Google Drive.
+- create threat model diagrams
+- list threats for elements in those diagrams
+- record mitigations and countermeasures
+- work with STRIDE, LINDDUN, CIA, CIA-DIE, PLOT4ai, and generic diagram types
 
-## AI And Automation Notes
+## Storage
 
-This file is metadata only. It does not add AI features, expose an API, provide MCP access, or grant access to threat models.
+According to the project documentation:
 
-Related optional tooling:
-
-- Threat Dragon AI Tool documentation: https://www.threatdragon.com/docs/usage/ai-tool.html
-- Threat Dragon AI Tool source: https://github.com/InfosecOTB/threat-dragon-ai-tool
+- the web application can store threat model files on the local filesystem
+- the web application can be configured for GitHub, GitHub Enterprise, Bitbucket, Bitbucket Enterprise, and GitLab
+- the desktop application stores model files on the local filesystem only
 
 ## Data Handling
 
-Do not assume access to private threat models, repository contents, provider tokens, or user data from this file. Threat model data is only available through the application flows and provider integrations configured by the user.
+This file is metadata only. It does not add AI features, expose an API, provide MCP access, or grant access to private threat models, repository contents, provider tokens, or user data.

--- a/td.vue/public/llms.txt
+++ b/td.vue/public/llms.txt
@@ -1,0 +1,47 @@
+# OWASP Threat Dragon
+
+> OWASP Threat Dragon is a free, open-source threat modeling tool for creating data-flow diagrams and documenting threats and mitigations.
+
+Threat Dragon is an OWASP Production project. It supports web and desktop threat modeling workflows and can store models locally or through configured repository providers.
+
+## Project Links
+
+- Website: https://owasp.org/www-project-threat-dragon/
+- Application: https://www.threatdragon.com/
+- Documentation: https://www.threatdragon.com/docs/
+- Source: https://github.com/OWASP/threat-dragon
+- Issues: https://github.com/OWASP/threat-dragon/issues
+- Security policy: https://github.com/OWASP/threat-dragon/blob/main/security.md
+- Contributing: https://github.com/OWASP/threat-dragon/blob/main/contributing.md
+
+## Documentation
+
+- Installation: https://www.threatdragon.com/docs/install/installation.html
+- Configuration: https://www.threatdragon.com/docs/configure/configure.html
+- Usage: https://www.threatdragon.com/docs/usage/getting-started.html
+- Development: https://www.threatdragon.com/docs/development/development.html
+- API: https://www.threatdragon.com/docs/development/api.html
+- Testing: https://www.threatdragon.com/docs/testing/testing.html
+
+## Supported Model And Integration Formats
+
+- Threat Dragon version 2 models
+- Legacy Threat Dragon version 1 models
+- Open Threat Model files
+- Threat Model BOM files
+- Organization template files
+
+Threat Dragon can be configured to work with local files, GitHub, GitHub Enterprise, GitLab, Bitbucket, Bitbucket Enterprise, and Google Drive.
+
+## AI And Automation Notes
+
+This file is metadata only. It does not add AI features, expose an API, provide MCP access, or grant access to threat models.
+
+Related optional tooling:
+
+- Threat Dragon AI Tool documentation: https://www.threatdragon.com/docs/usage/ai-tool.html
+- Threat Dragon AI Tool source: https://github.com/InfosecOTB/threat-dragon-ai-tool
+
+## Data Handling
+
+Do not assume access to private threat models, repository contents, provider tokens, or user data from this file. Threat model data is only available through the application flows and provider integrations configured by the user.

--- a/td.vue/public/llms.txt
+++ b/td.vue/public/llms.txt
@@ -1,44 +1,55 @@
 # OWASP Threat Dragon
 
-> OWASP Threat Dragon is a free, open-source threat modeling tool for creating data-flow diagrams and documenting threats and mitigations.
+> OWASP Threat Dragon is an OWASP threat modeling application for creating data-flow diagrams, recording threats, and documenting mitigations.
 
-Threat Dragon is an OWASP Production project. It is available as a web application and as desktop installers for Windows, macOS, and Linux.
+Use this file as a concise entry point for LLMs and coding agents. It points to public documentation and source files only. It is not an API endpoint, MCP server, or integration runtime, and it does not grant access to private threat models, provider tokens, repositories, Google Drive files, or user data.
 
-## Project Links
+Threat Dragon has a web application and desktop installers. The web application can store models locally or through configured providers. The desktop application stores model files on the local filesystem.
 
-- Website: https://owasp.org/www-project-threat-dragon/
-- Application: https://www.threatdragon.com/
-- Documentation: https://www.threatdragon.com/docs/
-- Source: https://github.com/OWASP/threat-dragon
-- Issues: https://github.com/OWASP/threat-dragon/issues
-- Security policy: https://github.com/OWASP/threat-dragon/blob/main/security.md
-- Contributing: https://github.com/OWASP/threat-dragon/blob/main/contributing.md
+## Core documentation
 
-## Documentation
+- [Getting started](https://www.threatdragon.com/docs/usage/getting-started.html): Create, open, save, and report on threat models in the web and desktop applications.
+- [Diagrams](https://www.threatdragon.com/docs/usage/diagrams.html): Model processes, data stores, actors, data flows, and trust boundaries.
+- [Threat categories](https://www.threatdragon.com/docs/usage/threat-categories.html): Threat Dragon supports STRIDE, LINDDUN, CIA, CIA-DIE, PLOT4ai, and Generic diagram types.
+- [Threats](https://www.threatdragon.com/docs/usage/threats.html): Add threats, severity, status, descriptions, and mitigations to diagram elements.
+- [Templates](https://www.threatdragon.com/docs/usage/templates.html): Create new models from templates and export existing models as templates.
 
-- Installation: https://www.threatdragon.com/docs/install/installation.html
-- Configuration: https://www.threatdragon.com/docs/configure/configure.html
-- Usage: https://www.threatdragon.com/docs/usage/getting-started.html
-- Development: https://www.threatdragon.com/docs/development/development.html
-- Testing: https://www.threatdragon.com/docs/testing/testing.html
+## Configuration and storage
 
-## Application Scope
+- [Configuration](https://www.threatdragon.com/docs/configure/configure.html): Environment variables and provider configuration for the web application.
+- [Local files](https://www.threatdragon.com/docs/configure/local.html): Local filesystem storage for web local sessions and desktop use.
+- [GitHub](https://www.threatdragon.com/docs/configure/github.html): GitHub and GitHub Enterprise configuration for repository-backed model storage.
+- [GitLab](https://www.threatdragon.com/docs/configure/gitlab.html): GitLab configuration for repository-backed model storage.
+- [Bitbucket](https://www.threatdragon.com/docs/configure/bitbucket.html): Bitbucket and Bitbucket Enterprise configuration for repository-backed model storage.
+- [Google Drive](https://www.threatdragon.com/docs/configure/google.html): Google Drive configuration for web application storage.
 
-Threat Dragon is used to:
+## Import, export, and schemas
 
-- create threat model diagrams
-- list threats for elements in those diagrams
-- record mitigations and countermeasures
-- work with STRIDE, LINDDUN, CIA, CIA-DIE, PLOT4ai, and generic diagram types
+- [Schema documentation](https://www.threatdragon.com/docs/development/schema.html): Threat Dragon v1 and v2 schemas, template format, TM-BOM notes, and Open Threat Model references.
+- [Threat Dragon v2 schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/threat-dragon-v2.schema.json): Current Threat Dragon model schema.
+- [Threat Dragon v1 schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/threat-dragon-v1.schema.json): Legacy Threat Dragon model schema; v1 imports are converted to v2 in the application.
+- [TM-BOM schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/threat-model.schema.json): Schema used by the TM-BOM validation and conversion code.
+- [Open Threat Model schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/open-threat-model.schema.json): Schema file present for Open Threat Model validation; current UI text says OTM import is not yet supported.
+- [Template schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/owasp-threat-dragon-template.schema.json): Schema used for Threat Dragon template files.
 
-## Storage
+## Development and API
 
-According to the project documentation:
+- [Development guide](https://www.threatdragon.com/docs/development/development.html): Local development setup and project structure.
+- [API documentation](https://www.threatdragon.com/docs/development/api.html): Minimal web application API for provider-backed threat models, Google Drive files, templates, authentication, configuration, and health checks.
+- [Testing](https://www.threatdragon.com/docs/testing/testing.html): Unit, end-to-end, and GitHub Actions testing guidance.
+- [Contributing](https://github.com/OWASP/threat-dragon/blob/main/contributing.md): Contribution rules, including the project's AI-use guidance.
+- [Security policy](https://github.com/OWASP/threat-dragon/blob/main/security.md): Security reporting process.
 
-- the web application can store threat model files on the local filesystem
-- the web application can be configured for GitHub, GitHub Enterprise, Bitbucket, Bitbucket Enterprise, and GitLab
-- the desktop application stores model files on the local filesystem only
+## Source entry points
 
-## Data Handling
+- [Vue application](https://github.com/OWASP/threat-dragon/tree/main/td.vue): Frontend and Electron desktop application.
+- [Server application](https://github.com/OWASP/threat-dragon/tree/main/td.server): Express server for the web application.
+- [Schema validation](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/service/schema/ajv.js): Runtime model validation for Threat Dragon, TM-BOM, Open Threat Model, and templates.
+- [TM-BOM migration](https://github.com/OWASP/threat-dragon/tree/main/td.vue/src/service/migration/tmBom): TM-BOM import/export conversion code.
+- [Open Threat Model migration](https://github.com/OWASP/threat-dragon/tree/main/td.vue/src/service/migration/otm): Open Threat Model conversion code.
+- [Threat category models](https://github.com/OWASP/threat-dragon/tree/main/td.vue/src/service/threats/models): STRIDE, LINDDUN, CIA, CIA-DIE, PLOT4ai, and related threat model logic.
 
-This file is metadata only. It does not add AI features, expose an API, provide MCP access, or grant access to private threat models, repository contents, provider tokens, or user data.
+## Optional
+
+- [Threat Dragon AI Tool](https://www.threatdragon.com/docs/usage/ai-tool.html): Optional external desktop tool that can generate STRIDE threats and mitigations for Threat Dragon JSON files. This is separate from Threat Dragon itself.
+- [llms.txt proposal](https://llmstxt.org/): Background and format guidance for this metadata file.


### PR DESCRIPTION
**Summary**:

Closes #1707.

Adds `td.vue/public/llms.txt` as metadata for OWASP Threat Dragon. The file follows the llmstxt.org structure with a project heading, short summary, context note, and curated link sections for core docs, configuration/storage, import-export schemas, API/development docs, source entry points, and the optional external Threat Dragon AI Tool.

This does not add application behavior, runtime API endpoints, MCP access, provider integration, authentication, or access to private threat models or user data.

**Description for the changelog**:

Add public `llms.txt` metadata for the Vue web app.

**Declaration**:

Thanks for submitting a pull request, please make sure:

- [x] content meets the [license](../blob/main/license.txt) for this project
- [ ] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: OpenAI Codex
  - LLMs and versions: GPT-5
  - Prompts: Asked an AI coding agent to prepare and revise a metadata-only `llms.txt` contribution for issue #1707, follow the llmstxt.org format, keep claims limited to public project documentation/source links, avoid adding AI functionality or access to private data, and verify the Vue build.

**Other info**:

No unit tests were changed because this is a static metadata file.

Verification performed:

- Checked issue #1707 and the llmstxt.org format description
- Checked linked documentation/source paths against the repository
- `npm run build` from `td.vue`
- Confirmed `td.vue/public/llms.txt` is copied unchanged to `td.vue/dist/llms.txt`
