### PR TITLE
Remove deprecated install input from setup-buildx-action

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -506,8 +506,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          install: true
 
       - name: Build for all supported architectures to test buildability
         id: docker_build

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -147,8 +147,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          install: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -366,8 +366,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          install: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0


### PR DESCRIPTION
**Summary**:  

closes #1729

Removed the `install: true` input from the `docker/setup-buildx-action` step in `pull_request.yaml`, `push.yaml`, and `release.yaml`. These workflows pin `setup-buildx-action` at v4.1.0, where the `install` input no longer exists, so passing it produced the "Unexpected input(s) 'install'" warning across the PR, CI, and release pipelines. The input was unused here — the build steps run through `docker/build-push-action` and select the builder explicitly via `builder: ${{ steps.buildx.outputs.name }}` — so removing it is behavior-neutral and clears the warning.

**Description for the changelog**:  

Remove deprecated `install` input from setup-buildx-action to clear the pipeline warning

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:

**Other info**:  

This is a CI configuration change only; no application code is affected, so no unit or functional test changes apply. Verification is that the PR, push, and release pipelines run without the buildx warning, visible in this PR's Actions run.