### PR TITLE
Fix Docker Healthcheck

### DIFF
--- a/td.server/src/healthcheck.js
+++ b/td.server/src/healthcheck.js
@@ -1,12 +1,11 @@
 // healthcheck is called periodically from within the docker container
 
-import env from 'env/Env.js';
-import loggerHelper from 'helpers/logger.helper.js';
+import loggerHelper from './helpers/logger.helper.js';
 
 const logger = loggerHelper.get('healthcheck.js');
 const http = require('http');
 
-const req = (env.get().config.SERVER_API_PROTOCOL || 'https') + '://localhost:' + (env.get().config.PORT || '3000') + '/healthz';
+const req = 'http://localhost:' + (process.env.PORT || '3000') + '/healthz';
 
 http.get(req, (res) => {
     const { statusCode } = res;


### PR DESCRIPTION
**Summary**:  

Closes #1791 

The Docker healthcheck has been failing for some time because it couldn't resolve the imports.
Because Env wasn't hydrated, it would have been helpful here, and we can just use `process.env` for the port.
The https check is unnecessary. If the protocol is HTTPS, that is only applied via a middleware redirect as opposed to creating an internal HTTPS server. Because this lives inside the docker image, it will _always_ be HTTP only.

**Description for the changelog**:  

bugfix: fix docker healthcheck

<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  
