### PR TITLE
Standardize checkout action version across all actions

### DIFF
--- a/.github/workflows/dependabot-force-package-json-overrides.yaml
+++ b/.github/workflows/dependabot-force-package-json-overrides.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0


### PR DESCRIPTION
**Summary**:  

Relates to #1805

When there are multiple versions of the same action, dependabot will pick the lowest version and standardize on that. When I added the dependabot npm overrides action, I didn't use the same version as everything else (v4 vs v6). Now, dependabot wants to downgrade everything to v4, which is the documented behavior.

By standardizing the checkout action version, dependabot will stop trying to downgrade our checkout action version. :) 

Dependabot behavior reference: https://github.com/dependabot/dependabot-core/pull/6082#issuecomment-1307699867

**Description for the changelog**:  

chore: bump checkout action version

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

I didn't use AI generated content, but I did ask ChatGPT what was going on, and it gave me the linked dependabot PR. 