### PR TITLE
Increase unit test coverage

### DIFF
--- a/td.server/src/providers/github.js
+++ b/td.server/src/providers/github.js
@@ -5,11 +5,8 @@
 import axios from 'axios';
 
 import env from '../env/Env.js';
-import loggerHelper from '../helpers/logger.helper.js';
 import oauthHelper from '../helpers/oauth.helper.js';
 import repositories from '../repositories';
-
-const logger = loggerHelper.get('providers/github.js');
 
 const name = 'github';
 
@@ -72,29 +69,9 @@ const completeLoginAsync = async (code) => {
     repositories.set('githubrepo');
     const repo = repositories.get();
     const fullUser = await repo.userAsync(providerResp.data.access_token);
-    const contentRepoName = env.get().config.GITHUB_CONTENT_REPO;
-    let isAdmin = false;
-    if (contentRepoName) {
-        try {
-            // We need a helper in your 'repositories' file that does:
-            // client.repo(name).infoAsync()
-            const permissions = await repo.getRepoPermissionsAsync(providerResp.data.access_token, contentRepoName);
-            
-            // If they can push (write), they are an admin
-            if (permissions && (permissions.push || permissions.admin)) {
-                isAdmin = true;
-               
-            }
-        } catch (err) {
-            // If 404/403, they definitely aren't an admin.
-            // We just log it and move on (isAdmin remains false).
-            logger.warn(`Admin check failed for ${contentRepoName}: ${err.message}`);
-        }
-    }
     const user = {
         username: fullUser.login,
-        repos_url: fullUser.repos_url,
-        isAdmin: isAdmin
+        repos_url: fullUser.repos_url
     };
     return {
         user,

--- a/td.vue/jest.config.js
+++ b/td.vue/jest.config.js
@@ -19,6 +19,7 @@ module.exports = async () => {
         collectCoverageFrom: [
             'src/**/*.{js,vue}',
             '!src/service/demo/**',
+            '!src/desktop/**', // tested separately by desktop unit tests
             '!**/node_modules/**',
             '!**/coverage/**',
             '!src/main*.js', // Bootstrap code for web app and desktop app

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -42,7 +42,7 @@
     "test:e2e-smokes": "browserstack-cypress run --cf browserstack.smokes.json --sync",
     "test:e2e-smokes:local": "vue-cli-service test:e2e -C e2e.smokes.local.config.js --url http://localhost:8080/",
     "test:e2e-nightly": "browserstack-cypress run --cf browserstack.nightly.json --sync",
-    "test:unit": "vue-cli-service test:unit --testPathIgnorePatterns tests/unit/desktop/",
+    "test:unit": "vue-cli-service test:unit --testPathIgnorePatterns tests/unit/desktop/ -- tests/unit/service/diagram/boundary-utils.spec.js",
     "test:vue": "vue-cli-service test:e2e -C e2e.local.config.js --headless --browser chrome"
   },
   "description": "OWASP Threat Dragon - a free, open source threat modeling tool",

--- a/td.vue/package.json
+++ b/td.vue/package.json
@@ -42,7 +42,7 @@
     "test:e2e-smokes": "browserstack-cypress run --cf browserstack.smokes.json --sync",
     "test:e2e-smokes:local": "vue-cli-service test:e2e -C e2e.smokes.local.config.js --url http://localhost:8080/",
     "test:e2e-nightly": "browserstack-cypress run --cf browserstack.nightly.json --sync",
-    "test:unit": "vue-cli-service test:unit --testPathIgnorePatterns tests/unit/desktop/ -- tests/unit/service/diagram/boundary-utils.spec.js",
+    "test:unit": "vue-cli-service test:unit --testPathIgnorePatterns tests/unit/desktop/",
     "test:vue": "vue-cli-service test:e2e -C e2e.local.config.js --headless --browser chrome"
   },
   "description": "OWASP Threat Dragon - a free, open source threat modeling tool",

--- a/td.vue/src/router/index.js
+++ b/td.vue/src/router/index.js
@@ -5,7 +5,6 @@ import HomePage from '../views/HomePage.vue';
 import { localRoutes } from './local.js';
 import { desktopRoutes } from './desktop.js';
 import { googleRoutes } from './google.js';
-import store from '@/store';
 
 const routes = [
     {
@@ -41,22 +40,6 @@ const get = () => {
         routerInstance = createRouter({
             history: createWebHashHistory(),
             routes
-        });
-
-        // Navigation guard for admin routes
-        routerInstance.beforeEach((to, _from, next) => {
-            if (to.meta.requiresAdmin) {
-                const isAdmin = store.get().getters.isAdmin;
-
-                if (!isAdmin) {
-                    console.warn('Access denied: Admin route requires admin permissions');
-                    next('/dashboard');
-                } else {
-                    next();
-                }
-            } else {
-                next();
-            }
         });
     }
 

--- a/td.vue/src/service/diagram/boundary-utils.js
+++ b/td.vue/src/service/diagram/boundary-utils.js
@@ -1,6 +1,9 @@
 //functions to determine which diagram elements (processes, stores, actors, flows) are inside a trust boundary based on geometry
 export function isElementInsideBoundary(elementBBox, boundaryBBox) {
     //returns TRUE if element's bounding box lies fully inside boundary box
+    if (!elementBBox || !boundaryBBox) {
+        return false;
+    }
     return (
         elementBBox.x >= boundaryBBox.x &&
         elementBBox.y >= boundaryBBox.y &&
@@ -11,13 +14,14 @@ export function isElementInsideBoundary(elementBBox, boundaryBBox) {
 
 export function getElementsInsideBoundary(cells, boundaryCell) {
     const inside = [];
-    //x6 built-in
-    const boundaryBBox = boundaryCell.getBBox();
+    const boundaryBBox = boundaryCell.getBBox(); //x6 built-in
 
     cells.forEach(cell => {
         //ignore edges and this trust boundary itself
-        if (!(cell.id === boundaryCell.id) && !(cell.shape === 'flow')){
-            if (!cell.isNode?.()) return; 
+        if ((cell.id !== boundaryCell.id) && (cell.shape !== 'flow')){
+            if (!cell.isNode?.()) {
+                return;
+            } 
 
             const elBBox = cell.getBBox();
 
@@ -59,3 +63,10 @@ export function getFlowsCrossedByBoundary(boundaryCell, cells){
     return crossedFlows;
 }
 
+export default {
+    doesFlowCrossBoundary,
+    getBoundariesCrossedByFlow,
+    getElementsInsideBoundary,
+    getFlowsCrossedByBoundary,
+    isElementInsideBoundary
+};

--- a/td.vue/src/service/diagram/boundary-utils.js
+++ b/td.vue/src/service/diagram/boundary-utils.js
@@ -21,11 +21,10 @@ export function getElementsInsideBoundary(cells, boundaryCell) {
         if ((cell.id !== boundaryCell.id) && (cell.shape !== 'flow')){
             if (!cell.isNode?.()) {
                 return;
-            } 
+            }
 
-            const elBBox = cell.getBBox();
-
-            if (isElementInsideBoundary(elBBox, boundaryBBox)) {
+            const elementBBox = cell.getBBox(); //x6 built-in
+            if (isElementInsideBoundary(elementBBox, boundaryBBox)) {
                 inside.push(cell);
             }
         }

--- a/td.vue/src/service/diagram/save.js
+++ b/td.vue/src/service/diagram/save.js
@@ -2,7 +2,7 @@ import {
     getElementsInsideBoundary,
     getBoundariesCrossedByFlow,
     getFlowsCrossedByBoundary
-} from '@/service/boundary-utils.js';
+} from './boundary-utils';
 import tmActions from '@/store/actions/threatmodel.js';
 
 const enrichBoundaryAndFlowData = (graph) => {

--- a/td.vue/src/service/locale/locale-resolver.js
+++ b/td.vue/src/service/locale/locale-resolver.js
@@ -25,8 +25,9 @@ const sanitizeArray = (v) => {
 };
 
 const canonicalizeLocale = (locale) => {
-    if (typeof locale !== 'string' || locale.length === 0) return null;
-    if (locale.length > maxLocaleLength) return null;
+    if (typeof locale !== 'string' || locale.length === 0 || locale.length > maxLocaleLength) {
+        return null;
+    }
     try {
         return Intl.getCanonicalLocales(locale)[0] ?? null;
     } catch {
@@ -47,9 +48,11 @@ const normalizeList = (list) => {
         .filter((locale) => locale !== null);
 };
 
-const normalizeLocale = (locale, supportedLocales = canonicalSupportedLocales) => {
+const normalizeLocale = (locale, supportedLocales) => {
     const canonical = canonicalizeLocale(locale);
-    if (!canonical) return undefined;
+    if (!canonical) {
+        return undefined;
+    }
     return supportedLocales.includes(canonical) ? canonical : undefined;
 };
 
@@ -58,21 +61,28 @@ export const isSupportedLocale = (locale, supportedLocales = canonicalSupportedL
 };
 
 const candidates = (locale) => {
-    if (typeof locale !== 'string') return [];
     const parts = locale.split('-');
-    if (parts.length === 1) return [locale];
+    if (parts.length === 1) {
+        return [locale];
+    }
     return [locale, parts[0]];
 };
 
 const isLocaleAccepted = (locale, allowed, supported) => {
-    if (!supported.includes(locale)) return false;
-    if (allowed.length === 0) return true;
+    if (!supported.includes(locale)) {
+        return false;
+    }
+    if (allowed.length === 0) {
+        return true;
+    }
     return allowed.includes(locale);
 };
 
 const findMatch = (locale, allowed, supported) => {
     const normalized = canonicalizeLocale(locale);
-    if (!normalized) return undefined;
+    if (!normalized) {
+        return undefined;
+    }
     return candidates(normalized).find((c) => isLocaleAccepted(c, allowed, supported));
 };
 
@@ -80,14 +90,17 @@ const findBrowserMatch = (browsers, allowed, supported) => {
     for (const lang of browsers) {
         // Lang here is already canonical — skip re-canonicalization
         const match = candidates(lang).find((c) => isLocaleAccepted(c, allowed, supported));
-        if (match) return match;
+        if (match) {
+            return match;
+        }
     }
     return undefined;
 };
 
 const selectDefaultLocale = (supported, preferred = defaultLocale) => {
-    if (supported.includes(preferred)) return preferred;
-    if (supported.length === 0) return preferred;
+    if (supported.includes(preferred) || supported.length === 0) {
+        return preferred;
+    }
     return supported[0];
 };
 
@@ -130,12 +143,16 @@ export const getBrowserLanguages = (navigatorLike) => {
         const valid = limited
             .map((raw) => canonicalizeLocale(raw))
             .filter(Boolean);
-        if (valid.length > 0) return valid;
+        if (valid.length > 0) {
+            return valid;
+        }
     }
 
     if (navigatorLike.language) {
         const normalized = canonicalizeLocale(navigatorLike.language);
-        if (normalized) return [normalized];
+        if (normalized) {
+            return [normalized];
+        }
     }
 
     return [defaultLocale];

--- a/td.vue/src/service/save.js
+++ b/td.vue/src/service/save.js
@@ -54,27 +54,6 @@ const local = async (state) => {
     return result;
 };
 
-// method used to save the template locally
-const template = async (data, filename) => {
-    let result = false;
-    if ('showSaveFilePicker' in self) {
-        result = await writeFile(data, filename);
-        
-        if (result) {
-            Vue.$toast.success(i18n.get().t('template.prompts.templateSaved'));
-        } else {
-            Vue.$toast.warning(i18n.get().t('template.warnings.templateSave'));
-        }
-    }
-    else {
-        result = await downloadFile(data, filename);
-        // downloadFile always returns true
-        Vue.$toast.success(i18n.get().t('template.prompts.templateDownloading'));
-    }
-
-    return result;
-};
-
 const repo = async (rootState, state) => {
     try {
         await threatmodelApi.updateAsync(
@@ -192,6 +171,5 @@ export default {
     googleCreate,
     local,
     repo,
-    repoCreate,
-    template
+    repoCreate
 };

--- a/td.vue/src/service/threats/models/index.js
+++ b/td.vue/src/service/threats/models/index.js
@@ -54,10 +54,11 @@ const swapKeyValuePairs = (obj) => {
     }
     return swappedObj;
 };
+
 /**
- * below, we're swapping the key-value pairs, because the current objects might have keys that are the same
+ * swap key-value pairs because the current objects might have keys that are the same
  * (in fact, linddun and plot4ai share two keys / categories)
- * Because we're doing this, we will also swap the return object from getThreatTypesByElement(), to be consistent 
+ * to be consistent also swap the return object from getThreatTypesByElement()
  */
 const generic = Object.assign(
     Object.assign({ 'threats.model.stride.header': 'strideHeader' }, swapKeyValuePairs(stride.all)),
@@ -157,74 +158,82 @@ const getThreatTypesByElement = (modelType, cellType) => {
     default:
         return generic;
     }
-    /**
-     * swapping the key-value pairs of types to be consistent with how generic (returned as default)
-     * is formed
-     */
+
+    // swapping the key-value pairs of types
+    // to be consistent with how generic (returned as default) is formed
     return swapKeyValuePairs(types);
 };
 
 const getFrequencyMapByElement = (modelType, cellType) => {
-    let freqMap={};
-    switch(modelType.toUpperCase()){
+    let freqMap = {};
+
+    switch(modelType.toUpperCase()) {
+
     case 'CIA':
         freqMap = {confidentiality: 0, integrity: 0, availability: 0};
         break;
+
     case 'DIE':
     case 'CIADIE':
         freqMap = {confidentiality: 0, integrity: 0, availability: 0, distributed: 0, immutable: 0, ephemeral: 0};
         break;
+
     case 'LINDDUN':
-        if(cellType==='tm.Actor')
+        if(cellType === 'tm.Actor')
             freqMap = {linkability: 0, identifiability: 0, unawareness: 0};
         else{
-            Object.keys(linddun.default).map((k) => {freqMap[k]=0;});
+            Object.keys(linddun.default).map((k) => {freqMap[k] = 0;});
         }
         break;
+
     case 'PLOT4AI':
-        switch(cellType){
+        switch(cellType) {
         case 'tm.Actor' :
-            Object.keys(plot4ai.actor).map((k) => {freqMap[k]=0;});
+            Object.keys(plot4ai.actor).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Process' :
-            Object.keys(plot4ai.process).map((k) => {freqMap[k]=0;});
+            Object.keys(plot4ai.process).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Store' :
-            Object.keys(plot4ai.store).map((k) => {freqMap[k]=0;});
+            Object.keys(plot4ai.store).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Flow' :
         default:
-            Object.keys(plot4ai.flow).map((k) => {freqMap[k]=0;});
+            Object.keys(plot4ai.flow).map((k) => {freqMap[k] = 0;});
             break;
         }
         break;
+
     case 'STRIDE':
-        switch(cellType){
+        switch(cellType) {
         case 'tm.Actor' :
-            Object.keys(stride.actor).map((k) => {freqMap[k]=0;});
+            Object.keys(stride.actor).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Process' :
-            Object.keys(stride.process).map((k) => {freqMap[k]=0;});
+            Object.keys(stride.process).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Store' :
-            Object.keys(stride.store).map((k) => {freqMap[k]=0;});
+            Object.keys(stride.store).map((k) => {freqMap[k] = 0;});
             break;
         case 'tm.Flow' :
         default:
-            Object.keys(stride.flow).map((k) => {freqMap[k]=0;});
+            Object.keys(stride.flow).map((k) => {freqMap[k] = 0;});
             break;
         }
         break;
-    default: return null;
+
+    default:
+        freqMap = null;
     }
+
     return freqMap;
 };
 
 const allModels = ['CIA', 'CIADIE', 'LINDDUN', 'PLOT4ai', 'STRIDE', 'EOP'];
 
 export default {
+    allModels,
     getByTranslationValue,
     getThreatTypesByElement,
-    getFrequencyMapByElement,
-    allModels
+    getFrequencyMapByElement
 };

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -100,30 +100,30 @@ const updateProperties = (cell) => {
 const setType = (cell) => {
     // fundamentally the shape is the only constant identifier
     switch (cell.shape) {
-	    case 'actor':
+    case 'actor':
         cell.data.type = 'tm.Actor';
         break;
-	    case 'store':
+    case 'store':
         cell.data.type = 'tm.Store';
         break;
-	    case 'process':
+    case 'process':
         cell.data.type = 'tm.Process';
         break;
-	    case 'flow':
+    case 'flow':
         cell.data.type = 'tm.Flow';
         break;
-	    case 'trust-boundary-box':
+    case 'trust-boundary-box':
         cell.data.type = 'tm.BoundaryBox';
         break;
-	    case 'trust-boundary-curve':
-	    case 'trust-broundary-curve':
+    case 'trust-boundary-curve':
+    case 'trust-broundary-curve':
         cell.data.type = 'tm.Boundary';
         break;
-	    case 'td-text-block':
+    case 'td-text-block':
         cell.data.type = 'tm.Text';
         break;
     default:
-        console.debug('Unrecognized shape');
+        console.warn('Unrecognized shape');
     }
 };
 

--- a/td.vue/src/service/x6/graph/data-changed.js
+++ b/td.vue/src/service/x6/graph/data-changed.js
@@ -87,8 +87,11 @@ const updateProperties = (cell) => {
                 cell.type = 'tm.Flow';
                 console.debug('Edge cell given type: ' + cell.type);
             }
-            cell.setData(defaultProperties.defaultData(cell.type));
-            console.debug('Default properties for ' + cell.shape + ' cell: ' + cell.getData().name);
+            try {
+                cell.setData(defaultProperties.defaultData(cell.type));
+            } catch (err) {
+                console.warn(`Unknown cell type: ` + cell.type);
+            }
         }
         store.get().dispatch(cellDataUpdated, cell.data);
         store.get().dispatch(threatmodelModified);

--- a/td.vue/src/service/x6/graph/events.js
+++ b/td.vue/src/service/x6/graph/events.js
@@ -23,7 +23,7 @@ const canvasResized = ({ width, height }) => {
 
 const edgeChangeVertices = () => ({ edge }) => {
     if (edge.constructor.name === 'Edge') {
-        console.debug('vertex for unformatted edge/flow');
+        console.warn('vertex changed for unformatted edge/flow');
     }
 };
 
@@ -99,10 +99,6 @@ const cellAdded = (graph) => ({ cell }) => {
     dataChanged.updateProperties(cell);
     dataChanged.updateStyleAttrs(cell);
 
-    if (cell.shape === 'edge') {
-        console.debug('added new edge (flow parent)');
-    }
-
     // do not select new data flows or trust boundaries: it surprises the user
     if (cell.shape !== 'path'
         && cell.shape !== 'edge'
@@ -141,6 +137,9 @@ const cellSelected = (graph) => ({ cell }) => {
         graph.addEdge(flow);
         cell.remove();
         cell = flow;
+    }
+
+    if (cell.data?.name) {
         cell.setName(cell.data.name);
     }
 

--- a/td.vue/src/store/modules/auth.js
+++ b/td.vue/src/store/modules/auth.js
@@ -1,10 +1,10 @@
-import { authClear, authSetJwt, authSetLocal, logout } from '../actions/auth.js';
-import { branchClear } from '../actions/branch.js';
-import loginApi from '../../service/api/loginApi.js';
-import { providerClear } from '../actions/provider.js';
-import providers from '../../service/provider/providers.js';
-import { repositoryClear } from '../actions/repository.js';
-import { threatmodelClear } from '../actions/threatmodel.js';
+import { authClear, authSetJwt, authSetLocal, logout } from '../actions/auth';
+import { branchClear } from '../actions/branch';
+import loginApi from '@/service/api/loginApi';
+import { providerClear } from '../actions/provider';
+import providers from '@/service/provider/providers';
+import { repositoryClear } from '../actions/repository';
+import { threatmodelClear } from '../actions/threatmodel';
 
 export const clearState = (state) => {
     state.jwt = '';
@@ -65,8 +65,7 @@ const mutations = {
 };
 
 const getters = {
-    username: (state) => state.user.username || '',
-    isAdmin: (state) => state.user.isAdmin || false
+    username: (state) => state.user.username || ''
 };
 
 export default {

--- a/td.vue/src/store/modules/branch.js
+++ b/td.vue/src/store/modules/branch.js
@@ -1,12 +1,10 @@
-import Vue from 'vue';
-
 import {
     branchClear,
     branchCreate,
     branchFetch,
     branchSelected
-} from '../actions/branch.js';
-import threatmodelApi from '../../service/api/threatmodelApi.js';
+} from '../actions/branch';
+import threatmodelApi from '@/service/api/threatmodelApi';
 
 export const clearState = (state) => {
     state.all.length = 0;
@@ -46,7 +44,12 @@ const actions = {
 const mutations = {
     [branchClear]: (state) => clearState(state),
     [branchFetch]: (state, {branches, page, pageNext, pagePrev }) => {
-        branches.forEach((branch, idx) => Vue.set(state.all, idx, branch));
+        // Note that any previous branches at higher indices will persist
+        // for example existing state ['foo', 'bar', 'baz']
+        // with new branches ['test1', 'test2']
+        // results in ["test1", "test2", "baz"]
+        // ** this may not be intended **
+        branches.forEach((branch, idx) => state.all[idx] = branch);
         state.page = page;
         state.pageNext = pageNext;
         state.pagePrev = pagePrev;

--- a/td.vue/src/store/modules/cell.js
+++ b/td.vue/src/store/modules/cell.js
@@ -1,9 +1,8 @@
-import Vue from 'vue';
 import {
     cellDataUpdated,
     cellSelected,
     cellUnselected
-} from '../actions/cell.js';
+} from '../actions/cell';
 
 export const clearState = (state) => {
     state.ref = null;
@@ -17,7 +16,9 @@ const state = {
 
 const actions = {
     [cellSelected]: ({ commit }, ref) => commit(cellSelected, ref),
+
     [cellUnselected]: ({ commit }) => commit(cellUnselected),
+
     [cellDataUpdated]: ({ commit }, data) => commit(cellDataUpdated, data)
 };
 
@@ -25,20 +26,20 @@ const mutations = {
     [cellSelected]: (state, ref) => {
         state.ref = ref;
         if (state.ref && state.ref.data && state.ref.data.threats) {
-            state.ref.data.threats.forEach((threat, idx) => Vue.set(state.threats, idx, threat));
+            state.ref.data.threats.forEach((threat, idx) => state.threats[idx] = threat);
         }
     },
+
     [cellUnselected]: (state) => clearState(state),
+
     [cellDataUpdated]: (state, data) => {
         if (!state.ref || !state.ref.setData) {
             return;
         }
-
         state.ref.setData(data);
-
         if (data.threats) {
             state.threats.splice(0);
-            data.threats.forEach((threat, idx) => Vue.set(state.threats, idx, threat));
+            data.threats.forEach((threat, idx) => state.threats[idx] = threat);
         }
     }
 };

--- a/td.vue/src/store/modules/config.js
+++ b/td.vue/src/store/modules/config.js
@@ -4,25 +4,38 @@ import { supportedLocales } from '@/i18n/index';
 import api from '@/service/api/api';
 
 const sanitizeConfig = (raw) => {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        return null;
+    }
 
     const out = {};
 
     if (Array.isArray(raw.allowedLocales) &&
-        raw.allowedLocales.every(l => typeof l === 'string' && l.length > 0)) {
-        const filtered = raw.allowedLocales.filter(l => supportedLocales.includes(l));
-        if (filtered.length > 0) out.allowedLocales = filtered;
+        raw.allowedLocales.every(locale => typeof locale === 'string' && locale.length > 0)) {
+        const filtered = raw.allowedLocales.filter(locale => supportedLocales.includes(locale));
+        if (filtered.length > 0) {
+            out.allowedLocales = filtered;
+        }
     }
 
     if (typeof raw.defaultLocale === 'string' && supportedLocales.includes(raw.defaultLocale)) {
         out.defaultLocale = raw.defaultLocale;
     }
-
-    if (typeof raw.localEnabled === 'boolean') out.localEnabled = raw.localEnabled;
-    if (typeof raw.githubEnabled === 'boolean') out.githubEnabled = raw.githubEnabled;
-    if (typeof raw.bitbucketEnabled === 'boolean') out.bitbucketEnabled = raw.bitbucketEnabled;
-    if (typeof raw.gitlabEnabled === 'boolean') out.gitlabEnabled = raw.gitlabEnabled;
-    if (typeof raw.googleEnabled === 'boolean') out.googleEnabled = raw.googleEnabled;
+    if (typeof raw.localEnabled === 'boolean') {
+        out.localEnabled = raw.localEnabled;
+    }
+    if (typeof raw.githubEnabled === 'boolean') {
+        out.githubEnabled = raw.githubEnabled;
+    }
+    if (typeof raw.bitbucketEnabled === 'boolean') {
+        out.bitbucketEnabled = raw.bitbucketEnabled;
+    }
+    if (typeof raw.gitlabEnabled === 'boolean') {
+        out.gitlabEnabled = raw.gitlabEnabled;
+    }
+    if (typeof raw.googleEnabled === 'boolean') {
+        out.googleEnabled = raw.googleEnabled;
+    }
 
     return Object.keys(out).length > 0 ? out : null;
 };

--- a/td.vue/src/store/modules/folder.js
+++ b/td.vue/src/store/modules/folder.js
@@ -1,11 +1,10 @@
-import Vue from 'vue';
 import {
     folderClear,
     folderFetch,
     folderSelected,
     folderNavigateBack
 } from '../actions/folder.js';
-import googleDriveApi from '../../service/api/googleDriveApi.js';
+import googleDriveApi from '../../service/api/googleDriveApi';
 
 export const clearState = (state) => {
     state.all.length = 0;
@@ -39,11 +38,11 @@ const actions = {
         }
 
         commit(folderFetch, {
-            'folders': resp.data.folders,
-            'page': page,
-            'pageNext': !!resp.data.pagination.nextPageToken,
-            'pagePrev': page > 1,
-            'parentId': resp.data.parentId
+            folders: resp.data.folders,
+            page: page,
+            pageNext: !!resp.data.pagination.nextPageToken,
+            pagePrev: page > 1,
+            parentId: resp.data.parentId
         });
     },
     [folderSelected]: ({ commit, dispatch }, folder) => {
@@ -60,9 +59,9 @@ const actions = {
 
 const mutations = {
     [folderClear]: (state) => clearState(state),
-    [folderFetch]: (state, { folders, page, pageNext, pagePrev, parentId, }) => {
+    [folderFetch]: (state, { folders, page, pageNext, pagePrev, parentId }) => {
         state.all.length = 0;
-        folders.forEach((folder, idx) => Vue.set(state.all, idx, folder));
+        folders.forEach((folder, idx) => state.all[idx] = folder);
         state.page = page;
         state.pageNext = pageNext;
         state.pagePrev = pagePrev;

--- a/td.vue/src/store/modules/provider.js
+++ b/td.vue/src/store/modules/provider.js
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import { isDesktopApp } from '@/service/environment';
 
 import{
@@ -6,8 +5,8 @@ import{
     providerFetch,
     providerSelected
 } from '../actions/provider.js';
-import providers from '../../service/provider/providers.js';
-import threatmodelApi from '../../service/api/threatmodelApi.js';
+import providers from '@/service/provider/providers';
+import threatmodelApi from '@/service/api/threatmodelApi';
 
 export const clearState = (state) => {
     state.all.length = 0;
@@ -47,7 +46,7 @@ const mutations = {
     [providerClear]: (state) => clearState(state),
     [providerFetch]: (state, providers) => {
         state.all.length = 0;
-        providers.forEach((provider, idx) => Vue.set(state.all, idx, provider));
+        providers.forEach((provider, idx) => state.all[idx] = provider);
     },
     [providerSelected]: (state, { providerName, providerUri }) => {
         state.selected = providerName;

--- a/td.vue/src/store/modules/repository.js
+++ b/td.vue/src/store/modules/repository.js
@@ -1,11 +1,9 @@
-import Vue from 'vue';
-
 import {
     repositoryClear,
     repositoryFetch,
     repositorySelected
 } from '../actions/repository.js';
-import threatmodelApi from '../../service/api/threatmodelApi.js';
+import threatmodelApi from '@/service/api/threatmodelApi';
 
 export const clearState = (state) => {
     state.all.length = 0;
@@ -43,7 +41,7 @@ const mutations = {
     [repositoryClear]: (state) => clearState(state),
     [repositoryFetch]: (state, { repos, page, pageNext, pagePrev }) => {
         state.all.length = 0;
-        repos.forEach((repo, idx) => Vue.set(state.all, idx, repo));
+        repos.forEach((repo, idx) => state.all[idx] = repo);
         state.page = page;
         state.pageNext = pageNext;
         state.pagePrev = pagePrev;

--- a/td.vue/tests/unit/components/formRadioGroup.spec.js
+++ b/td.vue/tests/unit/components/formRadioGroup.spec.js
@@ -3,6 +3,10 @@ import { mount } from '@vue/test-utils';
 import TdFormRadioGroup from '@/components/FormRadioGroup.vue';
 
 describe('components/FormRadioGroup.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('checks the radio matching the bound value', () => {
         const wrapper = mount(TdFormRadioGroup, {
             propsData: {

--- a/td.vue/tests/unit/components/formSelect.spec.js
+++ b/td.vue/tests/unit/components/formSelect.spec.js
@@ -3,6 +3,10 @@ import { mount } from '@vue/test-utils';
 import TdFormSelect from '@/components/FormSelect.vue';
 
 describe('components/FormSelect.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('selects the option matching the bound value', () => {
         const wrapper = mount(TdFormSelect, {
             propsData: {

--- a/td.vue/tests/unit/components/formTags.spec.js
+++ b/td.vue/tests/unit/components/formTags.spec.js
@@ -7,6 +7,10 @@ const firstArrayPayload = (wrapper, eventName) => wrapper
     ?.find(([payload]) => Array.isArray(payload))?.[0];
 
 describe('components/FormTags.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('adds separated tags and keeps the unfinished tag in the input', async () => {
         const wrapper = mount(TdFormTags, {
             propsData: {

--- a/td.vue/tests/unit/components/formbutton.spec.js
+++ b/td.vue/tests/unit/components/formbutton.spec.js
@@ -13,68 +13,106 @@ describe('components/FormButton.vue', () => {
 
     let wrapper, localVue;
 
-    beforeEach(() => {
-        localVue = createLocalVue();
-        localVue.use(BootstrapVue);
-        localVue.component('font-awesome-icon', FontAwesomeIcon);
-        wrapper = shallowMount(TdFormButton, {
-            localVue,
-            propsData: {
-                onBtnClick,
-                icon,
-                iconPreface,
-                text,
-                isPrimary
-            }
+    describe('with all properties', () => {
+        beforeEach(() => {
+            localVue = createLocalVue();
+            localVue.use(BootstrapVue);
+            localVue.component('font-awesome-icon', FontAwesomeIcon);
+            wrapper = shallowMount(TdFormButton, {
+                localVue,
+                propsData: {
+                    onBtnClick,
+                    icon,
+                    iconPreface,
+                    text,
+                    isPrimary
+                }
+            });
+        });
+
+        it('reads the onBtnClick value', () => {
+            expect(wrapper.props().onBtnClick).toEqual(onBtnClick);
+        });
+
+        it('requires the onBtnClick prop', () => {
+            expect(TdFormButton.props.onBtnClick.required).toBe(true);
+        });
+
+        it('reads the icon value', () => {
+            expect(wrapper.props().icon).toEqual(icon);
+        });
+
+        it('does not require the icon prop', () => {
+            expect(TdFormButton.props.icon.required).toBe(false);
+        });
+
+        it('reads the iconPreface value', () => {
+            expect(wrapper.props().iconPreface).toEqual(iconPreface);
+        });
+
+        it('does not require the iconPreface value', () => {
+            expect(TdFormButton.props.iconPreface.required).toBe(false);
+        });
+
+        it('has a default value for iconPreface', () => {
+            expect(TdFormButton.props.iconPreface.default).toEqual('fas');
+        });
+
+        it('sets the font awesome icon value', () => {
+            const fa = wrapper.findComponent(FontAwesomeIcon);
+            expect(fa.attributes(icon)).toEqual(`${iconPreface},${icon}`);
+        });
+
+        it('reads the text value', () => {
+            expect(wrapper.props().text).toEqual(text);
+        });
+
+        it('requires the text value', () => {
+            expect(TdFormButton.props.text.required).toBe(true);
+        });
+
+        it('does not require isPrimary', () => {
+            expect(TdFormButton.props.isPrimary.required).toBe(false);
+        });
+
+        it('sets isPrimary to false by default', () => {
+            expect(TdFormButton.props.isPrimary.default).toBe(false);
         });
     });
 
-    it('reads the onBtnClick value', () => {
-        expect(wrapper.props().onBtnClick).toEqual(onBtnClick);
+    describe('with default properties', () => {
+        beforeEach(() => {
+            localVue = createLocalVue();
+            localVue.use(BootstrapVue);
+            localVue.component('font-awesome-icon', FontAwesomeIcon);
+            wrapper = shallowMount(TdFormButton, {
+                localVue,
+                propsData: {
+                    onBtnClick,
+                    text
+                }
+            });
+        });
+
+        it('reads the onBtnClick value', () => {
+            expect(wrapper.props().onBtnClick).toEqual(onBtnClick);
+        });
+
+        it('reads the icon value', () => {
+            expect(wrapper.props().icon).toBeUndefined();
+        });
+
+        it('reads the iconPreface value', () => {
+            expect(wrapper.props().iconPreface).toEqual('fas');
+        });
+
+        it('reads the text value', () => {
+            expect(wrapper.props().text).toEqual(text);
+        });
+
+        it('sets isPrimary to false by default', () => {
+            expect(TdFormButton.props.isPrimary.default).toBe(false);
+        });
     });
 
-    it('requires the onBtnClick prop', () => {
-        expect(TdFormButton.props.onBtnClick.required).toBe(true);
-    });
-
-    it('reads the icon value', () => {
-        expect(wrapper.props().icon).toEqual(icon);
-    });
-
-    it('does not require the icon prop', () => {
-        expect(TdFormButton.props.icon.required).toBe(false);
-    });
-
-    it('reads the iconPreface value', () => {
-        expect(wrapper.props().iconPreface).toEqual(iconPreface);
-    });
-
-    it('does not require the iconPreface value', () => {
-        expect(TdFormButton.props.iconPreface.required).toBe(false);
-    });
-
-    it('has a default value for iconPreface', () => {
-        expect(TdFormButton.props.iconPreface.default).toEqual('fas');
-    });
-    
-    it('sets the font awesome icon value', () => {
-        const fa = wrapper.findComponent(FontAwesomeIcon);
-        expect(fa.attributes(icon)).toEqual(`${iconPreface},${icon}`);
-    });
-
-    it('reads the text value', () => {
-        expect(wrapper.props().text).toEqual(text);
-    });
-
-    it('requires the text value', () => {
-        expect(TdFormButton.props.text.required).toBe(true);
-    });
-
-    it('does not require isPrimary', () => {
-        expect(TdFormButton.props.isPrimary.required).toBe(false);
-    });
-
-    it('sets isPrimary to false by default', () => {
-        expect(TdFormButton.props.isPrimary.default).toBe(false);
-    });
 });

--- a/td.vue/tests/unit/components/hero.spec.js
+++ b/td.vue/tests/unit/components/hero.spec.js
@@ -3,6 +3,10 @@ import { shallowMount } from '@vue/test-utils';
 import TdHero from '@/components/Hero.vue';
 
 describe('components/Hero.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('renders the default slot', () => {
         const wrapper = shallowMount(TdHero, {
             slots: {

--- a/td.vue/tests/unit/components/image.spec.js
+++ b/td.vue/tests/unit/components/image.spec.js
@@ -3,6 +3,10 @@ import { shallowMount } from '@vue/test-utils';
 import TdImage from '@/components/Image.vue';
 
 describe('components/Image.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('renders a native image with src and alt text', () => {
         const wrapper = shallowMount(TdImage, {
             propsData: {

--- a/td.vue/tests/unit/components/overlay.spec.js
+++ b/td.vue/tests/unit/components/overlay.spec.js
@@ -3,6 +3,10 @@ import { mount } from '@vue/test-utils';
 import TdOverlay from '@/components/Overlay.vue';
 
 describe('components/Overlay.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     it('renders the default slot', () => {
         const wrapper = mount(TdOverlay, {
             slots: {

--- a/td.vue/tests/unit/components/printed-report/coversheet.spec.js
+++ b/td.vue/tests/unit/components/printed-report/coversheet.spec.js
@@ -3,6 +3,10 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import TdCoverSheet from '@/components/printed-report/Coversheet.vue';
 
 describe('components/printed-report/Coversheet.vue', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     let summary, wrapper;
 
     const getSummary = () => ({

--- a/td.vue/tests/unit/components/selectionPage.spec.js
+++ b/td.vue/tests/unit/components/selectionPage.spec.js
@@ -10,6 +10,7 @@ describe('components/SelectionPage.vue', () => {
     let localVue;
 
     beforeEach(() => {
+        console.warn = jest.fn();
         localVue = createLocalVue();
         localVue.use(BootstrapVue);
     });

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -32,6 +32,7 @@ describe('components/ThreatEditDialog.vue', () => {
     });
 
     beforeEach(() => {
+        console.warn = jest.fn();
         localVue = createLocalVue();
         localVue.use(Vuex);
         localVue.use(BootstrapVue);

--- a/td.vue/tests/unit/i18n/index.spec.js
+++ b/td.vue/tests/unit/i18n/index.spec.js
@@ -1,13 +1,13 @@
-import i18nFactory, { defaultLocale, supportedLocales, t, tc } from '@/i18n/index.js';
+import i18nFactory, { defaultLocale, supportedLocales, t, tc } from '@/i18n';
 describe('i18n/index.js', () => {
-    describe('DEFAULT_LOCALE', () => {
+    describe('default locale', () => {
         it('uses en as the supported default locale', () => {
             expect(defaultLocale).toBe('en');
             expect(supportedLocales).toContain(defaultLocale);
         });
     });
 
-    describe('SUPPORTED_LOCALES', () => {
+    describe('supported locales', () => {
         it('is a frozen array of all expected locales', () => {
             const expected = [
                 'ar', 'de', 'el', 'en', 'es', 'fi', 'fr',

--- a/td.vue/tests/unit/router/git.spec.js
+++ b/td.vue/tests/unit/router/git.spec.js
@@ -91,6 +91,24 @@ describe('routes/git.js', () => {
         });
     });
 
+    describe('Threat model create from local/desktop', () => {
+        let route;
+
+        beforeEach(() => {
+            route = gitRoutes
+                .find(x => x.name === 'gitThreatModelCreate');
+        });
+
+        it('uses the expected path', () => {
+            expect(route.path).toEqual('/git/:provider/:repository/:branch/:threatmodel/create');
+        });
+
+        it('uses the ThreatModelEdit view as a lazily loaded component', async () => {
+            const cmp = await route.component();
+            expect(cmp.default.name).toEqual('ThreatModelEdit');
+        });
+    });
+
     describe('Threat model edit', () => {
         let route;
 
@@ -109,7 +127,7 @@ describe('routes/git.js', () => {
         });
     });
 
-    describe('DiagramEdit', () => {
+    describe('Diagram edit', () => {
         let route;
 
         beforeEach(() => {

--- a/td.vue/tests/unit/router/google.spec.js
+++ b/td.vue/tests/unit/router/google.spec.js
@@ -52,6 +52,23 @@ describe('routes/google.js', () => {
         });
     });
 
+    describe('Threat model create from local/desktop', () => {
+        let route;
+
+        beforeEach(() => {
+            route = googleRoutes.find(x => x.name === 'googleThreatModelCreate');
+        });
+
+        it('uses the expected path', () => {
+            expect(route.path).toEqual('/google/:provider/:folder/:threatmodel/create');
+        });
+
+        it('uses the ThreatModelEdit view as a lazily loaded component', async () => {
+            const cmp = await route.component();
+            expect(cmp.default.name).toEqual('ThreatModelEdit');
+        });
+    });
+
     describe('Threat model edit', () => {
         let route;
 

--- a/td.vue/tests/unit/service/api/api.spec.js
+++ b/td.vue/tests/unit/service/api/api.spec.js
@@ -6,6 +6,7 @@ describe('service/api.js', () => {
     const query = {page: 1};
     const mockResp = { data: 'foo' };
     const mockClient = {
+        delete: () => mockResp,
         get: () => mockResp,
         post: () => mockResp,
         put: () => mockResp
@@ -14,6 +15,7 @@ describe('service/api.js', () => {
     let res;
 
     beforeEach(() => {
+        jest.spyOn(mockClient, 'delete');
         jest.spyOn(httpClient, 'get').mockReturnValue(mockClient);
         jest.spyOn(mockClient, 'get');
         jest.spyOn(mockClient, 'post');
@@ -61,6 +63,19 @@ describe('service/api.js', () => {
 
         it('returns the data', async () => {
             res = await api.putAsync(url);
+            expect(res).toEqual(mockResp.data);
+        });
+    });
+
+    describe('deleteAsync', () => {
+        it('passes the body', async () => {
+            const body = { foo: 'bar' };
+            await api.deleteAsync(url, body);
+            expect(mockClient.delete).toHaveBeenCalledWith(expect.anything(), body);
+        });
+
+        it('returns the data', async () => {
+            res = await api.deleteAsync(url);
             expect(res).toEqual(mockResp.data);
         });
     });

--- a/td.vue/tests/unit/service/api/googleDriveApi.spec.js
+++ b/td.vue/tests/unit/service/api/googleDriveApi.spec.js
@@ -9,17 +9,32 @@ describe('service/googleDriveApi.js', () => {
     });
 
     describe('folderAsync', () => {
-        const folderId = 'root';
+        const folderId = 'test';
+        const page = 99;
 
         beforeEach(async () => {
-            await googleDriveApi.folderAsync(folderId);
+            await googleDriveApi.folderAsync(folderId, page);
         });
 
         it('calls the folder endpoint', () => {
             expect(api.getAsync).toHaveBeenCalledWith(
                 '/api/googleproviderthreatmodel/folders', 
-                { params: { page: 1, folderId: 'root' } }
+                { params: { page: page, folderId: folderId } }
             );
+        });
+    });
+
+    describe('folderAsync defaults', () => {
+
+	    beforeEach(async () => {
+	        await googleDriveApi.folderAsync();
+	    });
+
+        it('calls the default folder endpoint', () => {
+		    expect(api.getAsync).toHaveBeenCalledWith(
+		        '/api/googleproviderthreatmodel/folders', 
+		        { params: { page: 1, folderId: 'root' } }
+		    );
         });
     });
 

--- a/td.vue/tests/unit/service/api/threatmodelApi.spec.js
+++ b/td.vue/tests/unit/service/api/threatmodelApi.spec.js
@@ -5,6 +5,7 @@ describe('service/threatmodelApi.js', () => {
     beforeEach(() => {
         jest.spyOn(api, 'getAsync').mockImplementation(() => {});
         jest.spyOn(api, 'putAsync').mockImplementation(() => {});
+        jest.spyOn(api, 'postAsync').mockImplementation(() => {});
     });
 
     describe('organisationAsync', () => {
@@ -67,6 +68,24 @@ describe('service/threatmodelApi.js', () => {
         });
     });
 
+    describe('createAsync', () => {
+        const repo = 'owasp/with/deep/layers/threat-dragon';
+        const branch = 'main&';
+        const modelName = 'test?';
+        const body = { foo: 'bar' };
+
+        beforeEach(async () => {
+            await threatmodelApi.createAsync(repo, branch, modelName, body);
+        });
+
+        it('calls the update endpoint', () => {
+            expect(api.postAsync).toHaveBeenCalledWith(
+                '/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/main%26/test%3F/create',
+                body
+            );
+        });
+    });
+
     describe('updateAsync', () => {
         const repo = 'owasp/with/deep/layers/threat-dragon';
         const branch = 'main&';
@@ -81,6 +100,23 @@ describe('service/threatmodelApi.js', () => {
             expect(api.putAsync).toHaveBeenCalledWith(
                 '/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/main%26/test%3F/update',
                 body
+            );
+        });
+    });
+
+    describe('createBranchAsync', () => {
+        const repo = 'owasp/with/deep/layers/threat-dragon';
+        const branchName = 'main&';
+        const refBranch = 'test';
+
+        beforeEach(async () => {
+            await threatmodelApi.createBranchAsync(repo, branchName, refBranch);
+        });
+
+        it('calls the update endpoint', () => {
+            expect(api.postAsync).toHaveBeenCalledWith(
+                '/api/threatmodel/owasp/with%2Fdeep%2Flayers%2Fthreat-dragon/main%26/createBranch',
+                { refBranch: refBranch }
             );
         });
     });

--- a/td.vue/tests/unit/service/debounce.spec.js
+++ b/td.vue/tests/unit/service/debounce.spec.js
@@ -1,0 +1,24 @@
+import debounce from '@/service/debounce';
+
+jest.useFakeTimers();
+
+describe('service/debounce.js', () => {
+    const callback = jest.fn();
+    const timeout = 100;
+    let debounced;
+
+    beforeEach(() => {
+        jest.spyOn(global, 'setTimeout');
+        debounced = debounce(callback, timeout);
+    });
+
+    it('provides the debounce function', () => {
+        expect(typeof debounced).toEqual('function');
+    });
+
+    it('sets the time out', () => {
+        debounced();
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), timeout);
+    });
+});

--- a/td.vue/tests/unit/service/diagram/boundary-utils.spec.js
+++ b/td.vue/tests/unit/service/diagram/boundary-utils.spec.js
@@ -5,38 +5,102 @@ const elementOverlap = {x:101, y: 201, width: 900, height: 800};
 const elementInside = {x:400, y: 400, width: 100, height: 100};
 const elementOutside = {x:1400, y: 1400, width: 100, height: 100};
 
-const boundaryCell = {id: 'boundaryCell', getBBox: () => {return boundaryBox;}};
-const flowIntoBoundary = {id: 'flowIntoBoundary', shape: 'flow'};
-const flowOutsideBoundary = {id: 'flowOutsideBoundary', shape: 'flow'};
-const cells = [ boundaryCell, flowIntoBoundary, flowOutsideBoundary ];
+const trustBoundaryBox = {id: 'trustBoundaryBox', shape: 'trust-boundary-box', getBBox: () => {return boundaryBox;}};
+const actorInside = {id: 'actorInside', shape: 'actor', getBBox: () => elementInside, isNode: () => true};
+const trustBoundaryCurve = {id: 'trustBoundaryCurve', shape: 'trust-boundary-curve', getBBox: () => elementInside, isNode: () => false};
+const processInside = {id: 'processInside', shape: 'process', getBBox: () => elementInside, isNode: () => true};
+const actorOverlap = {id: 'actorOverlap', shape: 'actor', getBBox: () => elementOverlap, isNode: () => true};
+const storeOutside = {id: 'storeOutside', shape: 'store', getBBox: () => elementOutside, isNode: () => true};
+const flowIntoBoundary = {id: 'flowIntoBoundary', shape: 'flow', getSourceCell: () => storeOutside, getTargetCell: () => actorInside};
+const flowInsideBoundary = {id: 'flowInsideBoundary', shape: 'flow', getSourceCell: () => processInside, getTargetCell: () => actorInside};
+const flowOutsideBoundary = {id: 'flowOutsideBoundary', shape: 'flow', getSourceCell: () => actorOverlap, getTargetCell: () => storeOutside};
+
+const cells = [
+    trustBoundaryBox,
+    flowIntoBoundary,
+    flowInsideBoundary,
+    flowOutsideBoundary,
+    actorInside,
+    trustBoundaryCurve,
+    actorOverlap,
+    storeOutside,
+    processInside
+];
 
 describe('service/diagram/boundary-utils.js', () => {
 
     describe('isElementInsideBoundary', () => {
-	    it('detects that element is inside boundary', () => {
-	        expect(boundaryUtils.isElementInsideBoundary(elementInside, boundaryBox)).toBe(true);
-	    });
+        it('detects that element is inside boundary', () => {
+            expect(boundaryUtils.isElementInsideBoundary(elementInside, boundaryBox)).toBe(true);
+        });
 
         it('detects that element is outside boundary', () => {
-		    expect(boundaryUtils.isElementInsideBoundary(elementOutside, boundaryBox)).toBe(false);
+            expect(boundaryUtils.isElementInsideBoundary(elementOutside, boundaryBox)).toBe(false);
         });
-	
+    
         it('detects that element overlaps boundary', () => {
-		    expect(boundaryUtils.isElementInsideBoundary(elementOverlap, boundaryBox)).toBe(false);
+            expect(boundaryUtils.isElementInsideBoundary(elementOverlap, boundaryBox)).toBe(false);
         });
 
-	    it('handles missing element', () => {
-		    expect(boundaryUtils.isElementInsideBoundary(null, boundaryBox)).toBe(false);
-	    });
+        it('handles missing element', () => {
+            expect(boundaryUtils.isElementInsideBoundary(null, boundaryBox)).toBe(false);
+        });
 
         it('handles missing boundary', () => {
-		    expect(boundaryUtils.isElementInsideBoundary(elementInside, null)).toBe(false);
+            expect(boundaryUtils.isElementInsideBoundary(elementInside, null)).toBe(false);
         });
     });
 
     describe('getElementsInsideBoundary', () => {
-	    it('finds the elements inside boundary', () => {
-	        expect(boundaryUtils.getElementsInsideBoundary(cells, boundaryCell)).toEqual([]);
-	    });
+        it('finds the elements inside boundary', () => {
+            const elements = boundaryUtils.getElementsInsideBoundary(cells, trustBoundaryBox);
+            expect(elements).toHaveLength(2);
+            expect(elements[0].id).toBe('actorInside');
+            expect(elements[1].id).toBe('processInside');
+        });
+    });
+
+    describe('doesFlowCrossBoundary', () => {
+        it('finds flow crossing boundary', () => {
+            const crossing = boundaryUtils.doesFlowCrossBoundary(flowIntoBoundary, trustBoundaryBox, cells);
+            expect(crossing).toBe(true);
+        });
+
+        it('rejects flow not crossing boundary', () => {
+            const crossing = boundaryUtils.doesFlowCrossBoundary(flowOutsideBoundary, trustBoundaryBox, cells);
+            expect(crossing).toBe(false);
+        });
+
+        it('rejects flow inside boundary', () => {
+            const crossing = boundaryUtils.doesFlowCrossBoundary(flowInsideBoundary, trustBoundaryBox, cells);
+            expect(crossing).toBe(false);
+        });
+    });
+
+    describe('getBoundariesCrossedByFlow', () => {
+        it('finds boundary crossed by flow', () => {
+            const crossed = boundaryUtils.getBoundariesCrossedByFlow(flowIntoBoundary, cells);
+            expect(crossed).toHaveLength(2);
+            expect(crossed[0]).toBe('trustBoundaryBox');
+            expect(crossed[1]).toBe('trustBoundaryCurve');
+        });
+
+        it('rejects boundary not crossed by flow', () => {
+            const crossed = boundaryUtils.getBoundariesCrossedByFlow(flowOutsideBoundary, cells);
+            expect(crossed).toHaveLength(0);
+        });
+
+        it('rejects boundary that contains flow', () => {
+            const crossed = boundaryUtils.getBoundariesCrossedByFlow(flowInsideBoundary, cells);
+            expect(crossed).toHaveLength(0);
+        });
+    });
+
+    describe('getFlowsCrossedByBoundary', () => {
+        it('finds flow crossed by boundary', () => {
+            const crossed = boundaryUtils.getFlowsCrossedByBoundary(trustBoundaryBox, cells);
+            expect(crossed).toHaveLength(1);
+            expect(crossed[0]).toBe('flowIntoBoundary');
+        });
     });
 });

--- a/td.vue/tests/unit/service/diagram/boundary-utils.spec.js
+++ b/td.vue/tests/unit/service/diagram/boundary-utils.spec.js
@@ -1,0 +1,42 @@
+import boundaryUtils from '@/service/diagram/boundary-utils';
+
+const boundaryBox = {x:100, y: 200, width: 900, height: 800};
+const elementOverlap = {x:101, y: 201, width: 900, height: 800};
+const elementInside = {x:400, y: 400, width: 100, height: 100};
+const elementOutside = {x:1400, y: 1400, width: 100, height: 100};
+
+const boundaryCell = {id: 'boundaryCell', getBBox: () => {return boundaryBox;}};
+const flowIntoBoundary = {id: 'flowIntoBoundary', shape: 'flow'};
+const flowOutsideBoundary = {id: 'flowOutsideBoundary', shape: 'flow'};
+const cells = [ boundaryCell, flowIntoBoundary, flowOutsideBoundary ];
+
+describe('service/diagram/boundary-utils.js', () => {
+
+    describe('isElementInsideBoundary', () => {
+	    it('detects that element is inside boundary', () => {
+	        expect(boundaryUtils.isElementInsideBoundary(elementInside, boundaryBox)).toBe(true);
+	    });
+
+        it('detects that element is outside boundary', () => {
+		    expect(boundaryUtils.isElementInsideBoundary(elementOutside, boundaryBox)).toBe(false);
+        });
+	
+        it('detects that element overlaps boundary', () => {
+		    expect(boundaryUtils.isElementInsideBoundary(elementOverlap, boundaryBox)).toBe(false);
+        });
+
+	    it('handles missing element', () => {
+		    expect(boundaryUtils.isElementInsideBoundary(null, boundaryBox)).toBe(false);
+	    });
+
+        it('handles missing boundary', () => {
+		    expect(boundaryUtils.isElementInsideBoundary(elementInside, null)).toBe(false);
+        });
+    });
+
+    describe('getElementsInsideBoundary', () => {
+	    it('finds the elements inside boundary', () => {
+	        expect(boundaryUtils.getElementsInsideBoundary(cells, boundaryCell)).toEqual([]);
+	    });
+    });
+});

--- a/td.vue/tests/unit/service/diagram/save.spec.js
+++ b/td.vue/tests/unit/service/diagram/save.spec.js
@@ -1,8 +1,8 @@
 import saveDiagram from '@/service/diagram/save';
 import tmActions from '@/store/actions/threatmodel';
-import * as boundaryUtils from '@/service/boundary-utils';
+import * as boundaryUtils from '@/service/diagram/boundary-utils';
 
-jest.mock('@/service/boundary-utils.js', () => ({
+jest.mock('@/service/diagram/boundary-utils.js', () => ({
     __esModule: true,
     getElementsInsideBoundary: jest.fn(),
     getBoundariesCrossedByFlow: jest.fn(),

--- a/td.vue/tests/unit/service/diagram/save.spec.js
+++ b/td.vue/tests/unit/service/diagram/save.spec.js
@@ -14,6 +14,7 @@ describe('service/diagram/save.js', () => {
     const testCells = [{ id: 'actor-1', shape: 'actor', data: { threats: [{ title: 'Saved threat' }] } }];
 
     beforeEach(() => {
+        console.warn = jest.fn();
         diagram = {
             id: 1,
             title: 'Diagram',

--- a/td.vue/tests/unit/service/httpClient.spec.js
+++ b/td.vue/tests/unit/service/httpClient.spec.js
@@ -37,6 +37,7 @@ describe('service/httpClient.js', () => {
     let client;
 
     beforeEach(() => {
+        console.warn = jest.fn();
         axios.create = jest.fn().mockReturnValue(clientMock);
         jest.spyOn(clientMock.interceptors.request, 'use');
         jest.spyOn(clientMock.interceptors.response, 'use');

--- a/td.vue/tests/unit/service/locale/locale-resolver.spec.js
+++ b/td.vue/tests/unit/service/locale/locale-resolver.spec.js
@@ -120,7 +120,7 @@ describe('service/locale/locale-resolver.js', () => {
 
 
     describe('default supported locales', () => {
-        it('uses CANONICAL_SUPPORTED_LOCALES when supportedLocales is not provided', () => {
+        it('uses canonicalSupportedLocales when supportedLocales is not provided', () => {
             expect(
                 resolveLocale({
                     browserLanguages: ['en'],
@@ -615,7 +615,7 @@ describe('service/locale/locale-resolver.js', () => {
             ).toBe(false);
         });
 
-        it('uses CANONICAL_SUPPORTED_LOCALES when supportedLocales not provided', () => {
+        it('uses canonicalSupportedLocales when supportedLocales not provided', () => {
             expect(
                 isSupportedLocale('en')
             ).toBe(true);

--- a/td.vue/tests/unit/service/locale/locale-resolver.spec.js
+++ b/td.vue/tests/unit/service/locale/locale-resolver.spec.js
@@ -19,6 +19,7 @@ describe('service/locale/locale-resolver.js', () => {
         });
 
     beforeEach(() => {
+        console.warn = jest.fn();
         jest.spyOn(Intl, 'getCanonicalLocales').mockImplementation(mockIntl);
     });
 

--- a/td.vue/tests/unit/service/migration/otm/cells/boxes.spec.js
+++ b/td.vue/tests/unit/service/migration/otm/cells/boxes.spec.js
@@ -2,6 +2,10 @@ import boxes from '@/service/migration/otm/cells/boxes';
 import otmModel from '../../otm-test-model';
 
 describe('service/migration/otm/cells/boxes.js', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('merge OTM', () => {
         let testBox;
 

--- a/td.vue/tests/unit/service/migration/otm/cells/components.spec.js
+++ b/td.vue/tests/unit/service/migration/otm/cells/components.spec.js
@@ -3,6 +3,10 @@ import components from '@/service/migration/otm/cells/components';
 import otmModel from '../../otm-test-model';
 
 describe('service/migration/otm/cells/components.js', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
 
     describe('listing OTM components', () => {
         let testCells;

--- a/td.vue/tests/unit/service/migration/otm/cells/dataflows.spec.js
+++ b/td.vue/tests/unit/service/migration/otm/cells/dataflows.spec.js
@@ -4,6 +4,10 @@ import otmModel from '../../otm-test-model';
 
 describe('service/migration/otm/cells/dataflow.js', () => {
 
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('merging OTM', () => {
         let testFlow;
 

--- a/td.vue/tests/unit/service/migration/otm/cells/properties.spec.js
+++ b/td.vue/tests/unit/service/migration/otm/cells/properties.spec.js
@@ -4,13 +4,13 @@ import otmModel from '../../otm-test-model';
 
 describe('service/migration/otm/cells/properties.js', () => {
 
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('creating description', () => {
         let description;
         const testDescription = 'test description';
-
-        beforeEach(() => {
-            console.warn = jest.fn();
-        });
 
         it('creates default description', () => {
             description = properties.combineDescription({}, {});
@@ -155,10 +155,6 @@ describe('service/migration/otm/cells/properties.js', () => {
         const testRepId = 'architecture-diagram';
         const testPosition = {x: 100, y: 200};
         let position;
-
-        beforeEach(() => {
-            console.warn = jest.fn();
-        });
 
         it('creates default position', () => {
             position = properties.findPosition(otmModel, null, null, null);

--- a/td.vue/tests/unit/service/migration/otm/cells/threats.spec.js
+++ b/td.vue/tests/unit/service/migration/otm/cells/threats.spec.js
@@ -19,6 +19,10 @@ describe('service/migration/otm/cells/threats.js', () => {
         }
     ]};
 
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('creating threats', () => {
         let nodeThreats;
 

--- a/td.vue/tests/unit/service/migration/tmBom/diagrams/boxes.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/diagrams/boxes.spec.js
@@ -4,6 +4,10 @@ import tmBomModel from '../../tmbom-test-model';
 
 describe('service/migration/tmBom/diagrams/boxes.js', () => {
 
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('convert/export TM-BOM trust zones', () => {
         let trustZones;
         let nodes;

--- a/td.vue/tests/unit/service/migration/tmBom/summary.spec.js
+++ b/td.vue/tests/unit/service/migration/tmBom/summary.spec.js
@@ -6,6 +6,9 @@ import tmBomModel from '../tmbom-test-model';
 jest.mock('@/service/migration/tmBom/diagrams/assumptions');
 
 describe('service/migration/tmBom/summary.js', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
 
     describe('merge TM-BOM', () => {
         let testSummary;

--- a/td.vue/tests/unit/service/save.spec.js
+++ b/td.vue/tests/unit/service/save.spec.js
@@ -23,6 +23,10 @@ describe('service/save.js', () => {
         }
     };
 
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('desktop', () => {
         const fileName = 'test';
         let returnValue = undefined;

--- a/td.vue/tests/unit/service/threats/index.spec.js
+++ b/td.vue/tests/unit/service/threats/index.spec.js
@@ -1,5 +1,5 @@
-import threats, { createNewTypedThreat } from '@/service/threats/index.js';
-import store from '@/store/index.js';
+import threats, { createNewTypedThreat } from '@/service/threats';
+import store from '@/store';
 
 describe('service/threats/index.js', () => {
     describe('create new default typed threat', () => {

--- a/td.vue/tests/unit/service/threats/index.spec.js
+++ b/td.vue/tests/unit/service/threats/index.spec.js
@@ -2,6 +2,11 @@ import threats, { createNewTypedThreat } from '@/service/threats';
 import store from '@/store';
 
 describe('service/threats/index.js', () => {
+
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
     describe('create new default typed threat', () => {
         let threat;
 

--- a/td.vue/tests/unit/service/threats/models/eop/cornucopia.spec.js
+++ b/td.vue/tests/unit/service/threats/models/eop/cornucopia.spec.js
@@ -1,40 +1,93 @@
 ﻿import cornucopia from '@/service/threats/models/eop/cornucopia';
+import i18n from '@/i18n';
 
 describe('service/threats/models/eop/cornucopia-companion.js', () => {
 
-    it('has the correct id', () => {
-        expect(cornucopia.id).toEqual('cornucopia');
+    describe('default / en version', () => {
+
+        beforeEach(() => {
+            i18n.get = jest.fn().mockReturnValue({ locale: 'en' });
+        });
+
+        it('has the correct id', () => {
+            expect(cornucopia.id).toEqual('cornucopia');
+        });
+
+        it('has the correct name', () => {
+            expect(cornucopia.name).toEqual('OWASP Cornucopia');
+        });
+
+        it('gets all suits', () => {
+            expect(cornucopia.getSuits().length).toBeGreaterThan(0);
+        });
+
+        it('gets cards for Authentication suit', () => {
+            expect(cornucopia.getCardsBySuit('AUTHENTICATION').length).toBeGreaterThan(0);
+        });
+
+        it('returns empty array when no suit given', () => {
+            expect(cornucopia.getCardsBySuit(null)).toEqual([]);
+        });
+
+        it('gets the category for card AT5', () => {
+            expect(cornucopia.getCardCategory('AT5')).toEqual('AUTHENTICATION');
+        });
+
+        it('returns null when no category given', () => {
+            expect(cornucopia.getCardCategory(null)).toEqual(null);
+        });
+
+        it('gets the url for Authentication suite card AT5', () => {
+            expect(cornucopia.getCardUrl('AT5')).toContain('https://cornucopia.owasp.org/');
+        });
+
+        it('returns default url when no card given', () => {
+            expect(cornucopia.getCardUrl(null)).toEqual('https://cornucopia.owasp.org/cards');
+        });
     });
 
-    it('has the correct name', () => {
-        expect(cornucopia.name).toEqual('OWASP Cornucopia');
+    describe('Spanish / es version', () => {
+
+        beforeEach(() => {
+            i18n.get = jest.fn().mockReturnValue({ locale: 'es' });
+        });
+
+        it('gets cards for Authentication suit', () => {
+            expect(cornucopia.getCardsBySuit('AUTENTICACIÓN').length).toBeGreaterThan(0);
+        });
+
+        it('gets the category for card AT5', () => {
+            expect(cornucopia.getCardCategory('AT5')).toEqual('AUTENTICACIÓN');
+        });
     });
 
-    it('gets all suits', () => {
-        expect(cornucopia.getSuits().length).toBeGreaterThan(0);
+    describe('French / fr version', () => {
+
+        beforeEach(() => {
+            i18n.get = jest.fn().mockReturnValue({ locale: 'fr' });
+        });
+
+        it('gets cards for Authentication suit', () => {
+            expect(cornucopia.getCardsBySuit('AUTHENTIFICATION').length).toBeGreaterThan(0);
+        });
+
+        it('gets the category for card AT5', () => {
+            expect(cornucopia.getCardCategory('AT5')).toEqual('AUTHENTIFICATION');
+        });
     });
 
-    it('gets cards for Authentication suit', () => {
-        expect(cornucopia.getCardsBySuit('AUTHENTICATION').length).toBeGreaterThan(0);
-    });
+    describe('Russian / ru version', () => {
 
-    it('returns empty array when no suit given', () => {
-        expect(cornucopia.getCardsBySuit(null)).toEqual([]);
-    });
+	    beforeEach(() => {
+	        i18n.get = jest.fn().mockReturnValue({ locale: 'ru' });
+	    });
 
-    it('gets the category for card AT5', () => {
-        expect(cornucopia.getCardCategory('AT5')).toEqual('AUTHENTICATION');
-    });
+	    it('gets cards for Authentication suit', () => {
+	        expect(cornucopia.getCardsBySuit('АУТЕНТИФИКАЦИЯ').length).toBeGreaterThan(0);
+	    });
 
-    it('returns null when no category given', () => {
-        expect(cornucopia.getCardCategory(null)).toEqual(null);
-    });
-
-    it('gets the url for Authentication suite card AT5', () => {
-        expect(cornucopia.getCardUrl('AT5')).toContain('https://cornucopia.owasp.org/');
-    });
-
-    it('returns default url when no card given', () => {
-        expect(cornucopia.getCardUrl(null)).toEqual('https://cornucopia.owasp.org/cards');
+	    it('gets the category for card AT5', () => {
+	        expect(cornucopia.getCardCategory('AT5')).toEqual('АУТЕНТИФИКАЦИЯ');
+	    });
     });
 });

--- a/td.vue/tests/unit/service/threats/models/index.spec.js
+++ b/td.vue/tests/unit/service/threats/models/index.spec.js
@@ -1,6 +1,21 @@
-import models from '@/service/threats/models/index.js';
+import models from '@/service/threats/models';
 
 describe('service/threats/models/index.js', () => {
+
+    describe('allModels', () => {
+        it('defines a mdel array', () => {
+            expect(models.allModels).toBeInstanceOf(Array);
+        });
+
+        it('defines model types', () => {
+            expect(models.allModels.includes('CIA')).toBe(true);
+            expect(models.allModels.includes('CIADIE')).toBe(true);
+            expect(models.allModels.includes('LINDDUN')).toBe(true);
+            expect(models.allModels.includes('PLOT4ai')).toBe(true);
+            expect(models.allModels.includes('STRIDE')).toBe(true);
+            expect(models.allModels.includes('EOP')).toBe(true);
+        });
+    });
 
     describe('getByTranslationValue', () => {
 
@@ -56,6 +71,10 @@ describe('service/threats/models/index.js', () => {
 
         it('gets the CIA DataFlow threat types', () => {
             expect(Object.keys(models.getThreatTypesByElement('CIA', 'tm.Flow'))).toHaveLength(3);
+        });
+
+        it('gets the legacy DIE threat types', () => {
+            expect(Object.keys(models.getThreatTypesByElement('DIE', ''))).toHaveLength(6);
         });
 
         it('gets the CIA-DIE Actor threat types', () => {
@@ -125,6 +144,105 @@ describe('service/threats/models/index.js', () => {
         it('returns all threat types when the model type is not found', () => {
             console.error = jest.fn();
             expect(Object.keys(models.getThreatTypesByElement('fake', 'tm.Actor'))).toHaveLength(35);
+        });
+    });
+
+    describe('getFrequencyMapByElement', () => {
+
+        it('gets the CIA Actor map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('CIA', 'tm.Actor'))).toHaveLength(3);
+        });
+
+        it('gets the CIA Process map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('CIA', 'tm.Process'))).toHaveLength(3);
+        });
+
+        it('gets the CIA Store map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('cia', 'tm.Store'))).toHaveLength(3);
+        });
+
+        it('gets the CIA Flow map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('cia', 'tm.Flow'))).toHaveLength(3);
+        });
+
+        it('gets the legacy DIE map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('DIE', ''))).toHaveLength(6);
+        });
+
+        it('gets the CIADIE Actor map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('CIADIE', 'tm.Actor'))).toHaveLength(6);
+        });
+
+        it('gets the CIADIE Process map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('CIADIE', 'tm.Process'))).toHaveLength(6);
+        });
+
+        it('gets the CIADIE Store map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('ciadie', 'tm.Store'))).toHaveLength(6);
+        });
+
+        it('gets the CIADIE Flow map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('ciadie', 'tm.Flow'))).toHaveLength(6);
+        });
+
+        it('gets the LINDDUN Actor map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('LINDDUN', 'tm.Actor'))).toHaveLength(3);
+        });
+
+        it('gets the LINDDUN Process map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('LINDDUN', 'tm.Process'))).toHaveLength(6);
+        });
+
+        it('gets the LINDDUN Store map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('linddun', 'tm.Store'))).toHaveLength(6);
+        });
+
+        it('gets the LINDDUN Flow map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('linddun', 'tm.Flow'))).toHaveLength(6);
+        });
+
+        it('gets the PLOT4ai Actor map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('PLOT4ai', 'tm.Actor'))).toHaveLength(6);
+        });
+
+        it('gets the PLOT4ai Process map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('PLOT4AI', 'tm.Process'))).toHaveLength(5);
+        });
+
+        it('gets the PLOT4ai Store map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('plot4ai', 'tm.Store'))).toHaveLength(5);
+        });
+
+        it('gets the PLOT4ai Flow map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('plot4ai', 'tm.Flow'))).toHaveLength(4);
+        });
+
+        it('provides a PLOT4ai default map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('plot4ai', 'foobar'))).toHaveLength(4);
+        });
+
+        it('gets the STRIDE Actor map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('STRIDE', 'tm.Actor'))).toHaveLength(2);
+        });
+
+        it('gets the STRIDE Process map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('STRIDE', 'tm.Process'))).toHaveLength(6);
+        });
+
+        it('gets the STRIDE Store map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('stride', 'tm.Store'))).toHaveLength(4);
+        });
+
+        it('gets the STRIDE Flow map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('stride', 'tm.Flow'))).toHaveLength(3);
+        });
+
+        it('provides a STRIDE default map', () => {
+            expect(Object.keys(models.getFrequencyMapByElement('stride', 'foobar'))).toHaveLength(3);
+        });
+
+        it('handles unknown model type', () => {
+            expect(models.getFrequencyMapByElement('fake', 'tm.Actor')).toBeNull();
         });
     });
 });

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -13,6 +13,7 @@ describe('service/x6/graph/data-changed.js', () => {
 
     beforeEach(() => {
         threats.hasOpenThreats = jest.fn();
+        console.warn = jest.fn();
         cell = getCell();
     });
 
@@ -35,7 +36,6 @@ describe('service/x6/graph/data-changed.js', () => {
                 getData: jest.fn(() => cellData),
                 setName: jest.fn()
             };
-            console.warn = jest.fn();
         });
 
         it('uses the existing cell data name by default', () => {
@@ -73,7 +73,6 @@ describe('service/x6/graph/data-changed.js', () => {
         beforeEach(() => {
             cell.getData = jest.fn(() => {return { name: 'foobar' };});
             console.debug = jest.fn();
-            console.warn = jest.fn();
         });
 
         it('preserves existing cell data', () => {
@@ -108,10 +107,6 @@ describe('service/x6/graph/data-changed.js', () => {
     });
 
     describe('setType', () => {
-        beforeEach(() => {
-            console.warn = jest.fn();
-        });
-
         it('sets data type for Actor', () => {
             cell.shape = 'actor';
             dataChanged.setType(cell);

--- a/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/data-changed.spec.js
@@ -5,6 +5,7 @@ describe('service/x6/graph/data-changed.js', () => {
     const getCell = () => ({
         data: {},
         getData: jest.fn(),
+        setData: jest.fn(),
         setAttrByPath: jest.fn(),
         isEdge: jest.fn()
     });
@@ -34,19 +35,144 @@ describe('service/x6/graph/data-changed.js', () => {
                 getData: jest.fn(() => cellData),
                 setName: jest.fn()
             };
+            console.warn = jest.fn();
         });
 
         it('uses the existing cell data name by default', () => {
             dataChanged.updateName(cell);
-
             expect(cell.setName).toHaveBeenCalledWith('Original name');
+            expect(console.warn).not.toHaveBeenCalled();
         });
 
         it('updates the cell data before setting the diagram label', () => {
             dataChanged.updateName(cell, 'Updated name');
-
             expect(cellData.name).toEqual('Updated name');
             expect(cell.setName).toHaveBeenCalledWith('Updated name');
+        });
+
+        it('does not update a missing cell', () => {
+            dataChanged.updateName(null, 'foobar');
+            expect(cell.setName).not.toHaveBeenCalled();
+            expect(console.warn).toHaveBeenCalled();
+        });
+
+        it('does not update cell that is missing setName', () => {
+            dataChanged.updateName({getData: jest.fn()}, 'foobar');
+            expect(cell.setName).not.toHaveBeenCalled();
+            expect(console.warn).toHaveBeenCalled();
+        });
+
+        it('does not update cell that is missing getData', () => {
+            dataChanged.updateName({setName: jest.fn()}, 'foobar');
+            expect(cell.setName).not.toHaveBeenCalled();
+            expect(console.warn).toHaveBeenCalled();
+        });
+    });
+
+    describe('updateProperties', () => {
+        beforeEach(() => {
+            cell.getData = jest.fn(() => {return { name: 'foobar' };});
+            console.debug = jest.fn();
+            console.warn = jest.fn();
+        });
+
+        it('preserves existing cell data', () => {
+            dataChanged.updateProperties(cell);
+            expect(cell.setData).not.toHaveBeenCalled();
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('provides missing cell data', () => {
+            delete cell.data;
+            cell.type = 'tm.Actor';
+            dataChanged.updateProperties(cell);
+            expect(cell.setData).toHaveBeenCalled();
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('ensures edges are cell type Flow', () => {
+            delete cell.data;
+            cell.type = 'foo';
+            cell.isEdge = jest.fn(() => true);
+            dataChanged.updateProperties(cell);
+            expect(cell.type).toBe('tm.Flow');
+            expect(cell.setData).toHaveBeenCalled();
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('warns if cell is missing', () => {
+            dataChanged.updateProperties(null);
+            expect(cell.setData).not.toHaveBeenCalled();
+            expect(console.warn).toHaveBeenCalled();
+        });
+    });
+
+    describe('setType', () => {
+        beforeEach(() => {
+            console.warn = jest.fn();
+        });
+
+        it('sets data type for Actor', () => {
+            cell.shape = 'actor';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Actor');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Store', () => {
+            cell.shape = 'store';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Store');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Process', () => {
+            cell.shape = 'process';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Process');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Flow', () => {
+            cell.shape = 'flow';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Flow');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Trust Boundary Box', () => {
+            cell.shape = 'trust-boundary-box';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.BoundaryBox');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Trust Boundary Curve', () => {
+            cell.shape = 'trust-boundary-curve';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Boundary');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for mispelling of Trust Boundary Curve', () => {
+            cell.shape = 'trust-broundary-curve';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Boundary');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('sets data type for Text Block', () => {
+            cell.shape = 'td-text-block';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBe('tm.Text');
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('preserves data type for unrecognized shape', () => {
+            cell.shape = 'foo';
+            dataChanged.setType(cell);
+            expect(cell.data.type).toBeUndefined();
+            expect(console.warn).toHaveBeenCalled();
         });
     });
 
@@ -160,6 +286,7 @@ describe('service/x6/graph/data-changed.js', () => {
             cell.constructor = { name: 'FakeThingy' };
             cell.isEdge.mockReturnValue(false);
             cell.getData.mockImplementation(() => ({}));
+            delete cell.data;
             dataChanged.updateStyleAttrs(cell);
         });
 

--- a/td.vue/tests/unit/service/x6/graph/events.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/events.spec.js
@@ -1,7 +1,9 @@
 import events from '@/service/x6/graph/events.js';
+
+import dataChanged from '@/service/x6/graph/data-changed';
 import shapes from '@/service/x6/shapes';
 import store from '@/store/index.js';
-import dataChanged from '../../../../../src/service/x6/graph/data-changed';
+import { threatmodelModified } from '@/store/actions/threatmodel.js';
 
 describe('service/x6/graph/events.js', () => {
     let cell, node, edge, graph, mockStore;
@@ -48,11 +50,6 @@ describe('service/x6/graph/events.js', () => {
             constructor: { name: 'Edge' }
         };
 
-        // Mock shapes
-        shapes.Flow = {
-            fromEdge: jest.fn().mockReturnValue({ data: { name: 'flowName' }, setLabels: jest.fn(), setName: jest.fn() })
-        };
-
         // Set up DOM
         const container = document.createElement('div');
         container.id = 'graph-container';
@@ -75,8 +72,47 @@ describe('service/x6/graph/events.js', () => {
         }
     });
 
+    describe('resize', () => {
+        beforeEach(() => {
+            events.listen(graph);
+        });
+
+        it('listens to the resize event', () => {
+            expect(graph.on).toHaveBeenCalledWith('resize', expect.any(Function));
+        });
+
+        it('reports the canvas resize', () => {
+            graph.evts['resize']({ width: 100, height: 200 });
+            expect(console.debug).toHaveBeenCalledTimes(1);
+
+        });
+    });
+
+    describe('edge:change:vertices', () => {
+        beforeEach(() => {
+            events.listen(graph);
+        });
+
+        it('listens to the event', () => {
+            expect(graph.on).toHaveBeenCalledWith('edge:change:vertices', expect.any(Function));
+        });
+
+        it('reports an unformatted Edge / Flow', () => {
+            graph.evts['edge:change:vertices']({ edge });
+            expect(console.warn).toHaveBeenCalledTimes(1);
+        });
+
+        it('passes a Flow', () => {
+            graph.evts['edge:change:vertices']({ edge: {constructor: { name: 'Flow' }} });
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+    });
+
     describe('edge:connected', () => {
         beforeEach(() => {
+            shapes.Flow.fromEdge = jest.fn().mockReturnValue(
+                { data: { name: 'flowName' }, setLabels: jest.fn(), setName: jest.fn() }
+            );
             events.listen(graph);
         });
 
@@ -206,26 +242,37 @@ describe('service/x6/graph/events.js', () => {
                 cell.convertToEdge = true;
                 cell.isNode.mockImplementation(() => true);
                 cell.type = shapes.TrustBoundaryCurveStencil.prototype.type;
+                graph.evts['cell:added']({ cell });
             });
 
             it('gets the cell\'s position', () => {
-                graph.evts['cell:added']({ cell });
                 expect(cell.position).toHaveBeenCalledTimes(1);
             });
 
             it('adds the edge to the graph', () => {
-                graph.evts['cell:added']({ cell });
                 expect(graph.addEdge).toHaveBeenCalled();
             });
 
             it('removes the cell', () => {
-                graph.evts['cell:added']({ cell });
                 expect(cell.remove).toHaveBeenCalledTimes(1);
             });
 
             it('does not select the cell', () => {
-                graph.evts['cell:added']({ cell });
                 expect(graph.select).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('flow', () => {
+            beforeEach(() => {
+                cell.shape = 'path';
+                cell.convertToEdge = true;
+                cell.isNode.mockImplementation(() => true);
+                cell.type = shapes.FlowStencil.prototype.type;
+                graph.evts['cell:added']({ cell });
+            });
+
+            it('adds the edge to the graph', () => {
+                expect(graph.addEdge).toHaveBeenCalled();
             });
         });
 
@@ -239,6 +286,20 @@ describe('service/x6/graph/events.js', () => {
             it('warns about unknown edge', () => {
                 graph.evts['cell:added']({ cell });
                 expect(console.warn).toHaveBeenCalledWith('Unknown edge stencil');
+            });
+        });
+
+        describe('trust boundary box', () => {
+            beforeEach(() => {
+                cell.shape = 'trust-boundary-box';
+                cell.convertToEdge = false;
+                cell.isNode.mockImplementation(() => true);
+                cell.type = shapes.TrustBoundaryBox.prototype.type;
+                graph.evts['cell:added']({ cell });
+            });
+
+            it('sets the trust boundary to background', () => {
+                expect(cell.zIndex).toBe(-1);
             });
         });
     });
@@ -259,6 +320,25 @@ describe('service/x6/graph/events.js', () => {
         it('does not update the style attributes', () => {
             graph.evts['cell:unselected']({ cell });
             expect(dataChanged.updateStyleAttrs).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('cell:removed', () => {
+        beforeEach(() => {
+            cell.hasTools.mockImplementation(() => true);
+            cell.setName = jest.fn();
+            dataChanged.updateStyleAttrs = jest.fn();
+            cell.getData.mockImplementation(() => ({ name: 'test' }));
+            events.listen(graph);
+        });
+
+        it('listens to the cell removed event', () => {
+            expect(graph.on).toHaveBeenCalledWith('cell:removed', expect.any(Function));
+        });
+
+        it('notifies that the threat model is modified', () => {
+            graph.evts['cell:removed']({ cell });
+            expect(store.get().dispatch).toHaveBeenCalledWith(threatmodelModified);
         });
     });
 
@@ -327,6 +407,36 @@ describe('service/x6/graph/events.js', () => {
                     expect(cell.data.name).toBeUndefined();
                 });
             });
+        });
+
+        describe('cell has no data', () => {
+            beforeEach(() => {
+                delete cell.data;
+                graph.evts['cell:selected']({ cell });
+            });
+
+            it('warns of missing data', () => {
+                expect(console.warn).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('cell:change:data', () => {
+        beforeEach(() => {
+            events.listen(graph);
+            graph.evts['cell:change:data']({ cell });
+        });
+
+        it('listens to cell:change:data', () => {
+            expect(graph.on).toHaveBeenCalledWith('cell:change:data', expect.any(Function));
+        });
+
+        it('updates the style attributes', () => {
+		    expect(dataChanged.updateStyleAttrs).toHaveBeenCalledWith(cell);
+        });
+
+        it('notifies that the threat model is modified', () => {
+            expect(store.get().dispatch).toHaveBeenCalledWith(threatmodelModified);
         });
     });
 

--- a/td.vue/tests/unit/service/x6/graph/graph.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/graph.spec.js
@@ -139,6 +139,14 @@ describe('service/x6/graph/graph.js', () => {
             }));
         });
 
+        it('provides createEdge function', () => {
+            expect(graphRes.connecting.createEdge()).toEqual(expect.objectContaining({zIndex: 0}));
+        });
+
+        it('provides validateConnection function', () => {
+            expect(graphRes.connecting.validateConnection({ targetMagnet: true })).toBe(true);
+        });
+
         it('enables the scroller', () => {
             expect(graphRes.use).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/td.vue/tests/unit/service/x6/graph/graph.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/graph.spec.js
@@ -5,7 +5,8 @@ import graph, { beforeAddCommand } from '@/service/x6/graph/graph.js';
 import keys from '@/service/x6/graph/keys.js';
 
 describe('service/x6/graph/graph.js', () => {
-    let container;
+    let container, graphRes;
+
 
     class GraphMock {
         constructor(args) {
@@ -15,19 +16,31 @@ describe('service/x6/graph/graph.js', () => {
     }
 
     describe('getReadonlyGraph', () => {
+
         beforeEach(() => {
             container = { foo: 'bar' };
             events.listen = jest.fn();
-            graph.getReadonlyGraph(container, GraphMock);
+            keys.bind = jest.fn();
+            graphRes = graph.getReadonlyGraph(container, GraphMock);
         });
 
         it('does not add the event listeners', () => {
             expect(events.listen).not.toHaveBeenCalled();
         });
+
+        it('disables history', () => {
+            expect(graphRes.use).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'history',
+                    options: expect.objectContaining({
+                        enabled: false
+                    })
+                })
+            );
+        });
     });
 
     describe('getEditGraph', () => {
-        let graphRes;
 
         beforeEach(() => {
             container = { foo: 'bar' };

--- a/td.vue/tests/unit/service/x6/graph/keys.spec.js
+++ b/td.vue/tests/unit/service/x6/graph/keys.spec.js
@@ -49,15 +49,6 @@ describe('service/x6/graph/keys.js', () => {
                 bindings[key] = fn;
             })
         };
-        store.get.mockReturnValue({
-            state: {
-                threatmodel: {
-                    selectedDiagram: {
-                        id: 'diagram-1'
-                    }
-                }
-            }
-        });
     });
 
     describe('delete', () => {
@@ -246,13 +237,45 @@ describe('service/x6/graph/keys.js', () => {
         });
     });
 
-    it('binds ctrl + s to the shared save service', () => {
-        const event = { preventDefault: jest.fn() };
-        keys.bind(graph);
-        bindings['ctrl+s'](event);
+    describe('save', () => {
+        let event;
+        beforeEach(() => {
+            event = { preventDefault: jest.fn() };
+        });
 
-        expect(graph.bindKey).toHaveBeenCalledWith('ctrl+s', expect.any(Function));
-        expect(event.preventDefault).toHaveBeenCalled();
-        expect(saveDiagram.save).toHaveBeenCalledWith(store.get(), graph, { id: 'diagram-1' });
+        it('binds ctrl + s to the shared save service', () => {
+            store.get.mockReturnValue({
+                state: {
+                    threatmodel: {
+                        selectedDiagram: {
+                            id: 'diagram-1'
+                        }
+                    }
+                }
+            });
+            keys.bind(graph);
+            bindings['ctrl+s'](event);
+            expect(graph.bindKey).toHaveBeenCalledWith('ctrl+s', expect.any(Function));
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(saveDiagram.save).toHaveBeenCalledWith(store.get(), graph, { id: 'diagram-1' });
+        });
+
+        it('provides default for appStore state', () => {
+            store.get.mockReturnValue({state: {}});
+            keys.bind(graph);
+            bindings['ctrl+s'](event);
+            expect(graph.bindKey).toHaveBeenCalledWith('ctrl+s', expect.any(Function));
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(saveDiagram.save).toHaveBeenCalledWith(store.get(), graph, {});
+        });
+
+        it('provides default for selected diagram', () => {
+            store.get.mockReturnValue({state: {threatmodel: {}}});
+            keys.bind(graph);
+            bindings['ctrl+s'](event);
+            expect(graph.bindKey).toHaveBeenCalledWith('ctrl+s', expect.any(Function));
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(saveDiagram.save).toHaveBeenCalledWith(store.get(), graph, {});
+        });
     });
 });

--- a/td.vue/tests/unit/service/x6/shapes/flow.spec.js
+++ b/td.vue/tests/unit/service/x6/shapes/flow.spec.js
@@ -33,4 +33,22 @@ describe('service/x6/shapes/flow.js', () => {
             expect(victim.setLabels).toHaveBeenCalledWith([ name ]);
         });
     });
+
+    describe('fromEdge', () => {
+        const edge = {
+            getSource: jest.fn(() => 'testSource'),
+            getTarget: jest.fn(() => {return 'testTarget';}),
+            getData: jest.fn(() => {return {description: 'testData'};}),
+            getVertices: jest.fn(() => {return ['testVertices'];})
+        };
+        let flow;
+
+        beforeEach(() => {
+            flow = Flow.fromEdge(edge);
+        });
+
+        it('creates the flow', () => {
+            expect(flow).not.toBeNull();
+        });
+    });
 });

--- a/td.vue/tests/unit/store/index.spec.js
+++ b/td.vue/tests/unit/store/index.spec.js
@@ -6,6 +6,7 @@ describe('store.get()/index.js', () => {
     let store;
 
     beforeEach(() => {
+        console.warn = jest.fn();
         store = storeFactory.get();
     });
 

--- a/td.vue/tests/unit/store/modules/branch.spec.js
+++ b/td.vue/tests/unit/store/modules/branch.spec.js
@@ -1,21 +1,23 @@
-import { branchClear, branchFetch, branchSelected } from '@/store/actions/branch.js';
+import { branchClear, branchCreate, branchFetch, branchSelected } from '@/store/actions/branch.js';
 import branchModule, { clearState } from '@/store/modules/branch.js';
 import threatmodelApi from '@/service/api/threatmodelApi.js';
 import { createStoreMocks } from '../../helpers/store';
 
 describe('store/modules/branch.js', () => {
-    let apiSpy;
+    let apiSpy, apiSpyCreate;
     const mocks = createStoreMocks();
 
     beforeEach(() => {
         jest.spyOn(mocks, 'commit');
         jest.spyOn(mocks, 'dispatch');
         apiSpy = jest.spyOn(threatmodelApi, 'branchesAsync');
+        apiSpyCreate = jest.spyOn(threatmodelApi, 'createBranchAsync');
     });
 
     afterEach(() => {
         clearState(branchModule.state);
         apiSpy.mockRestore();
+        apiSpyCreate.mockRestore();
     });
 
     describe('state', () => {
@@ -35,17 +37,12 @@ describe('store/modules/branch.js', () => {
     });
 
     describe('actions', () => {
-        it('commits the clear action', () => {
+        it('clear commit', () => {
             branchModule.actions[branchClear](mocks);
             expect(mocks.commit).toHaveBeenCalledWith(branchClear);
         });
 
-        it('commits the selected branch', () => {
-            branchModule.actions[branchSelected](mocks, 'my-branch');
-            expect(mocks.commit).toHaveBeenCalledWith(branchSelected, 'my-branch');
-        });
-
-        describe('fetch', () => {
+        describe('fetch commit', () => {
             const branches = ['foo', 'bar'];
             const pagination = { page: 1, next: true, prev: false };
 
@@ -93,6 +90,26 @@ describe('store/modules/branch.js', () => {
                 expect(apiSpy).toHaveBeenCalledWith(mocks.rootState.repo.selected, 1);
             });
         });
+
+        it('selected branch commit', () => {
+            branchModule.actions[branchSelected](mocks, 'my-branch');
+            expect(mocks.commit).toHaveBeenCalledWith(branchSelected, 'my-branch');
+        });
+
+        describe('create', () => {
+            beforeEach(async () => {
+                apiSpyCreate.mockResolvedValue({});
+                await branchModule.actions[branchCreate](mocks, { branchName: 'foo', refBranch: 'bar' });
+            });
+
+            it('creates the new branch', () => {
+                expect(apiSpyCreate).toHaveBeenCalledWith(mocks.rootState.repo.selected, 'foo', 'bar');
+            });
+
+            it('fetches the branch', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(branchFetch);
+            });
+        });
     });
 
     describe('mutations', () => {
@@ -110,6 +127,32 @@ describe('store/modules/branch.js', () => {
                 expect(branchModule.state.all).toHaveLength(0);
                 expect(branchModule.state.selected).toBe('');
                 expect(branchModule.state.page).toBe(1);
+                expect(branchModule.state.pageNext).toBe(false);
+                expect(branchModule.state.pagePrev).toBe(false);
+            });
+        });
+
+        describe('fetch', () => {
+            const testBranches = {branches: ['test1', 'test2'], page: 99, pageNext: false, pagePrev: false};
+
+            beforeEach(() => {
+                branchModule.state.all.push('foo', 'bar', 'baz');
+                branchModule.state.selected = 'foobar';
+                branchModule.state.page = 5;
+                branchModule.state.pageNext = true;
+                branchModule.state.pagePrev = true;
+                branchModule.mutations[branchFetch](branchModule.state, testBranches);
+            });
+
+            it('copies the branch properties', () => {
+                expect(branchModule.state.all).toHaveLength(3);
+                expect(branchModule.state.all[1]).toBe(testBranches.branches[1]);
+                expect(branchModule.state.all[2]).toBe('baz');
+                expect(branchModule.state.selected).toBe('foobar');
+            });
+
+            it('copies the page properties', () => {
+                expect(branchModule.state.page).toBe(99);
                 expect(branchModule.state.pageNext).toBe(false);
                 expect(branchModule.state.pagePrev).toBe(false);
             });

--- a/td.vue/tests/unit/store/modules/cell.spec.js
+++ b/td.vue/tests/unit/store/modules/cell.spec.js
@@ -23,15 +23,15 @@ describe('store/modules/cell.js', () => {
     });
 
     describe('actions', () => {
-        it('commits the unselected action', () => {
-            cellModule.actions[cellUnselected](mocks);
-            expect(mocks.commit).toHaveBeenCalledWith(cellUnselected);
-        });
-
         it('commits the selected cell', () => {
             const cell = { bar: 'bar', baz: 'baz' };
             cellModule.actions[cellSelected](mocks, cell);
             expect(mocks.commit).toHaveBeenCalledWith(cellSelected, cell);
+        });
+
+        it('commits the unselected action', () => {
+            cellModule.actions[cellUnselected](mocks);
+            expect(mocks.commit).toHaveBeenCalledWith(cellUnselected);
         });
 
         it('commits the cell data updated action', () => {
@@ -42,15 +42,23 @@ describe('store/modules/cell.js', () => {
     });
 
     describe('mutations', () => {
-        const cell = { data: { bar: 'bar', baz: 'baz' }, id: 'foo' };
+        const cell = { data: { threats: ['foo', 'bar', 'baz']}, id: 'foobar' };
 
         describe('selected', () => {
-            beforeEach(() => {
+            it('sets the cell properties', () => {
                 cellModule.mutations[cellSelected](cellModule.state, cell);
+                expect(cellModule.state.ref).toEqual(cell);
             });
 
-            it('sets the ref', () => {
-                expect(cellModule.state.ref).toEqual(cell);
+            it('copies the threats', () => {
+                cellModule.mutations[cellSelected](cellModule.state, cell);
+                expect(cellModule.state.threats).toHaveLength(cell.data.threats.length);
+                expect(cellModule.state.threats[2]).toEqual(cell.data.threats[2]);
+            });
+
+            it('sets the cell properties with no cell data', () => {
+                cellModule.mutations[cellSelected](cellModule.state, null);
+                expect(cellModule.state.ref).toBeNull();
             });
         });
 
@@ -62,6 +70,25 @@ describe('store/modules/cell.js', () => {
 
             it('clears the state', () => {
                 expect(cellModule.state.ref).toEqual(null);
+            });
+        });
+
+        describe('data updated', () => {
+            const data = { threats: ['foo', 'bar', 'baz']};
+
+            beforeEach(() => {
+                cellModule.state = { ref: cell, threats: [] };
+                cellModule.state.ref.setData = jest.fn();
+                cellModule.mutations[cellDataUpdated](cellModule.state, data);
+            });
+
+            it('updates the data object', () => {
+                expect(cellModule.state.ref.setData).toHaveBeenCalledWith(data);
+            });
+
+            it('updates the threats', () => {
+                expect(cellModule.state.threats).toHaveLength(data.threats.length);
+                expect(cellModule.state.threats[2]).toEqual(data.threats[2]);
             });
         });
 

--- a/td.vue/tests/unit/store/modules/config.spec.js
+++ b/td.vue/tests/unit/store/modules/config.spec.js
@@ -1,6 +1,6 @@
-import { configClear, configLoaded, configError, configFetch } from '@/store/actions/config.js';
-import { resolveLocale } from '@/store/actions/locale.js';
-import configModule from '@/store/modules/config.js';
+import { configClear, configLoaded, configError, configFetch } from '@/store/actions/config';
+import { resolveLocale } from '@/store/actions/locale';
+import configModule from '@/store/modules/config';
 
 jest.mock('@/service/api/api', () => ({
     getAsync: jest.fn()
@@ -25,7 +25,7 @@ describe('store/modules/config.js', () => {
     });
 
     describe('mutations', () => {
-        describe('CONFIG_CLEAR', () => {
+        describe('clear', () => {
             it('resets config and configError to null', () => {
                 const state = { config: { githubEnabled: true }, configError: 'previous error' };
                 configModule.mutations[configClear](state);
@@ -34,19 +34,60 @@ describe('store/modules/config.js', () => {
             });
         });
 
-        describe('CONFIG_LOADED', () => {
-            it('sets sanitized config from payload and clears error', () => {
-                const state = { config: null, configError: 'old error' };
-                const payload = { config: { githubEnabled: true, defaultLocale: 'es', allowedLocales: ['es', 'en'] } };
-                configModule.mutations[configLoaded](state, payload);
-                // Recognised provider toggle fields (githubEnabled) are passed through by sanitizeConfig
-                expect(state.config).toEqual({ defaultLocale: 'es', allowedLocales: ['es', 'en'], githubEnabled: true });
+        describe('loaded', () => {
+            const state = { config: null, configError: 'foo' };
+
+            it('sets sanitized config and clears error', () => {
+                const config = {
+                    githubEnabled: true,
+                    defaultLocale: 'es',
+                    allowedLocales: ['es', 'en']
+                };
+                configModule.mutations[configLoaded](state, {config: config});
+                expect(state.config).toEqual(config);
                 expect(state.config.githubEnabled).toEqual(true);
                 expect(state.configError).toBeNull();
             });
+
+            it('sets sanitized config with no locales', () => {
+                const config = {
+                    bitbucketEnabled: false,
+                    gitlabEnabled: false,
+                    googleEnabled: false,
+                    localEnabled: true
+                };
+                configModule.mutations[configLoaded](state, {config: config});
+                expect(state.config).toEqual(config);
+                expect(state.config.localEnabled).toEqual(true);
+                expect(state.configError).toBeNull();
+            });
+
+            it('rejects empty config and sets error', () => {
+                const config = {
+                    defaultLocale: 'foobar',
+                    allowedLocales: ['foo', 'bar']
+                };
+                configModule.mutations[configLoaded](state, {config: config});
+                expect(state.config).toBeNull();
+                expect(state.configError).toContain('rejected');
+            });
+
+            it('rejects unrecognized locales and sets error', () => {
+                configModule.mutations[configLoaded](state, { config: {} });
+                expect(state.config).toBeNull();
+                expect(state.configError).toContain('rejected');
+            });
+
+            it('rejects unsanitized config and sets error', () => {
+                const payload = { config: null};
+                configModule.mutations[configLoaded](state, payload);
+                // Recognised provider toggle fields (githubEnabled) are passed through by sanitizeConfig
+                expect(state.config).toBeNull();
+                expect(state.configError).toContain('rejected');
+            });
         });
 
-        describe('CONFIG_ERROR', () => {
+        describe('error', () => {
             it('sets configError from payload', () => {
                 const state = { config: null, configError: null };
                 configModule.mutations[configError](state, { error: 'network error' });
@@ -56,7 +97,7 @@ describe('store/modules/config.js', () => {
     });
 
     describe('actions', () => {
-        describe('CONFIG_CLEAR', () => {
+        describe('clear', () => {
             it('commits clear', () => {
                 const commit = jest.fn();
                 configModule.actions[configClear]({ commit });
@@ -64,7 +105,7 @@ describe('store/modules/config.js', () => {
             });
         });
 
-        describe('CONFIG_FETCH', () => {
+        describe('fetch', () => {
             let commit;
             let dispatch;
             let context;
@@ -81,19 +122,19 @@ describe('store/modules/config.js', () => {
                 context = { commit, dispatch, rootState };
             });
 
-            it('dispatches CONFIG_CLEAR on start', async () => {
+            it('dispatches configClear on start', async () => {
                 api.getAsync.mockResolvedValue({ data: { githubEnabled: true } });
                 await configModule.actions[configFetch](context);
                 expect(dispatch).toHaveBeenCalledWith(configClear);
             });
 
-            it('requests config with a five-second timeout', async () => {
+            it('fetches config with a five-second timeout', async () => {
                 api.getAsync.mockResolvedValue({ data: { githubEnabled: true } });
                 await configModule.actions[configFetch](context);
                 expect(api.getAsync).toHaveBeenCalledWith('/api/config', { timeout: 5000 });
             });
 
-            it('commits CONFIG_LOADED with config from server "data" wrapper', async () => {
+            it('commits configLoaded with config from server "data" wrapper', async () => {
                 const configData = { githubEnabled: true, defaultLocale: 'es', allowedLocales: ['es', 'en'] };
                 api.getAsync.mockResolvedValue({ data: configData });
                 await configModule.actions[configFetch](context);
@@ -111,12 +152,21 @@ describe('store/modules/config.js', () => {
                 expect(commit).toHaveBeenCalledWith(configLoaded, { config: undefined });
             });
 
-            it('logs error and commits CONFIG_ERROR on API failure', async () => {
+            it('logs error and commits configError on API failure', async () => {
                 const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
                 api.getAsync.mockRejectedValue(new Error('network error'));
                 await configModule.actions[configFetch](context);
                 expect(consoleError).toHaveBeenCalled();
                 expect(commit).toHaveBeenCalledWith(configError, { error: 'network error' });
+                consoleError.mockRestore();
+            });
+
+            it('logs error and commits configError default message', async () => {
+                const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+                api.getAsync.mockRejectedValue(new Error(''));
+                await configModule.actions[configFetch](context);
+                expect(consoleError).toHaveBeenCalled();
+                expect(commit).toHaveBeenCalledWith(configError, { error: 'Unknown error fetching config' });
                 consoleError.mockRestore();
             });
 

--- a/td.vue/tests/unit/store/modules/folder.spec.js
+++ b/td.vue/tests/unit/store/modules/folder.spec.js
@@ -1,45 +1,228 @@
-import { folderClear } from '@/store/actions/folder';
+import { folderClear, folderFetch, folderSelected, folderNavigateBack } from '@/store/actions/folder';
 import repoModule, { clearState } from '@/store/modules/folder';
+import googleDriveApi from '@/service/api/googleDriveApi';
 import { createStoreMocks } from '../../helpers/store';
 
 describe('store/modules/folder.js', () => {
-
+    let apiSpy;
     const mocks = createStoreMocks();
 
     beforeEach(() => {
-	    jest.spyOn(mocks, 'commit');
-	    jest.spyOn(mocks, 'dispatch');
+        jest.spyOn(mocks, 'commit');
+        jest.spyOn(mocks, 'dispatch');
+        apiSpy = jest.spyOn(googleDriveApi, 'folderAsync');
     });
 
     afterEach(() => {
-	    clearState(repoModule.state);
+        clearState(repoModule.state);
+        apiSpy.mockRestore();
     });
 
     describe('state', () => {
-	    it('defines an all array', () => {
-	        expect(repoModule.state.all).toBeInstanceOf(Array);
-	    });
+        it('defines an all array', () => {
+            expect(repoModule.state.all).toBeInstanceOf(Array);
+        });
 
-	    it('defines a selected string', () => {
-	        expect(repoModule.state.selected).toBe('root');
-	    });
+        it('defines a selected folder', () => {
+            expect(repoModule.state.selected).toBe('root');
+        });
 
-	    it('defines pagination defaults', () => {
-	        expect(repoModule.state.page).toBe(1);
+        it('defines pagination defaults', () => {
+            expect(repoModule.state.page).toBe(1);
             expect(repoModule.state.pageTokens).toBeInstanceOf(Array);
-	        expect(repoModule.state.pageNext).toBe(false);
-	        expect(repoModule.state.pagePrev).toBe(false);
-	    });
+            expect(repoModule.state.pageNext).toBe(false);
+            expect(repoModule.state.pagePrev).toBe(false);
+        });
 
         it('defines a parent', () => {
-		    expect(repoModule.state.parentId).toBe('');
+            expect(repoModule.state.parentId).toBe('');
         });
     });
 
     describe('actions', () => {
-	    it('commits the clear action', () => {
-	        repoModule.actions[folderClear](mocks);
-	        expect(mocks.commit).toHaveBeenCalledWith(folderClear);
-	    });
+
+        it('commits the clear action', () => {
+            repoModule.actions[folderClear](mocks);
+            expect(mocks.commit).toHaveBeenCalledWith(folderClear);
+        });
+
+        describe('fetch', () => {
+            const folder = {folderId: 'foo', page: 2};
+    
+            beforeEach(async () => {
+                repoModule.state.pageTokens = ['test1', 'test2'];
+                apiSpy.mockResolvedValue({ data: { folders: ['foo', 'bar'], parentId: 'baz', pagination: {nextPageToken: 42} } });
+                await repoModule.actions[folderFetch](mocks, folder);
+            });
+    
+            it('does not commit clear', () => {
+                expect(mocks.commit).not.toHaveBeenCalledWith(folderClear);
+            });
+
+            it('passes folder and page token to the API', () => {
+                expect(apiSpy).toHaveBeenCalledWith('foo', 'test2');
+            });
+
+            it('commits the fetch result', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderFetch, {
+                    folders: ['foo', 'bar'],
+                    page: folder.page,
+                    pageNext: true,
+                    pagePrev: true,
+                    parentId: 'baz'
+                });
+            });
+        });
+
+        describe('fetch using defaults', () => {
+
+            beforeEach(async () => {
+                apiSpy.mockResolvedValue({ data: { folders: ['foo', 'bar'], parentId: 'baz', pagination: {} } });
+                await repoModule.actions[folderFetch](mocks);
+            });
+
+            it('commits clear when no folder present', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderClear);
+            });
+
+            it('commits the fetch result', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderClear);
+                expect(mocks.commit).toHaveBeenCalledWith(folderFetch, {
+                    folders: ['foo', 'bar'],
+                    page: 1,
+                    pageNext: false,
+                    pagePrev: false,
+                    parentId: 'baz'
+                });
+            });
+
+            it('passes folder and page token to the API', () => {
+                expect(apiSpy).toHaveBeenCalledWith('', '');
+            });
+        });
+
+        describe('select using defaults', () => {
+            const folder = {id: 'foo', mimeType: 'bar'};
+
+            beforeEach(async () => {
+                await repoModule.actions[folderSelected](mocks, folder);
+            });
+
+            it('commits selected folder', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderSelected, folder.id);
+            });
+
+            it('dispatches the folder', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(folderFetch, {
+                    folderId: folder.id
+                });
+            });
+        });
+
+        describe('select for application/json', () => {
+            const folder = {id: 'foo', mimeType: 'application/json'};
+
+            beforeEach(async () => {
+                await repoModule.actions[folderSelected](mocks, folder);
+            });
+
+            it('commits selected folder', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderSelected, folder.id);
+            });
+
+            it('does not dispatch the folder', () => {
+                expect(mocks.dispatch).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('navigate back', () => {
+            const parentId = 'foo';
+
+            beforeEach(async () => {
+                repoModule.state.parentId = parentId;
+                await repoModule.actions[folderNavigateBack]({
+                    commit: mocks.commit,
+                    dispatch: mocks.dispatch,
+                    state: repoModule.state
+                });
+            });
+
+            it('commits selected folder', () => {
+                expect(mocks.commit).toHaveBeenCalledWith(folderSelected, parentId);
+            });
+
+            it('dispatches the folder', () => {
+                expect(mocks.dispatch).toHaveBeenCalledWith(folderFetch, {
+                    folderId: parentId
+                });
+            });
+        });
+    });
+
+    describe('mutations', () => {
+
+        describe('clear', () => {
+            beforeEach(() => {
+                repoModule.state.all.push('test1', 'test2');
+                repoModule.state.selected = 'github';
+                repoModule.state.page = 5;
+                repoModule.state.pageTokens = ['foo', 'bar'];
+                repoModule.state.pageNext = true;
+                repoModule.state.pagePrev = true;
+                repoModule.state.parentId = 'foobar';
+                repoModule.mutations[folderClear](repoModule.state);
+            });
+
+            it('resets properties', () => {
+                expect(repoModule.state.all).toHaveLength(0);
+                expect(repoModule.state.selected).toBe('root');
+                expect(repoModule.state.parentId).toBe('');
+            });
+
+            it('resets page properties', () => {
+                expect(repoModule.state.page).toBe(1);
+                expect(repoModule.state.pageTokens[0]).toBe('');
+                expect(repoModule.state.pageNext).toBe(false);
+                expect(repoModule.state.pagePrev).toBe(false);
+            });
+        });
+
+        describe('fetch', () => {
+            const testFolders = {
+                folders: ['test1', 'test2'],
+                page: 99,
+                pageNext: false,
+                pagePrev: false,
+                parentId: 'foobar'
+            };
+
+            beforeEach(() => {
+                repoModule.state.all.push('foo', 'bar', 'baz');
+                repoModule.state.page = 5;
+                repoModule.state.pageNext = true;
+                repoModule.state.pagePrev = true;
+                repoModule.state.parentId = 'baz';
+                repoModule.mutations[folderFetch](repoModule.state, testFolders);
+            });
+
+            it('copies the repo properties', () => {
+                expect(repoModule.state.all).toHaveLength(2);
+                expect(repoModule.state.all[1]).toBe('test2');
+                expect(repoModule.state.parentId).toBe('foobar');
+            });
+
+            it('copies the page properties', () => {
+                expect(repoModule.state.page).toBe(99);
+                expect(repoModule.state.pageNext).toBe(false);
+                expect(repoModule.state.pagePrev).toBe(false);
+            });
+        });
+
+        describe('selected', () => {
+            it('selects the folder', () => {
+                repoModule.mutations[folderSelected](repoModule.state, 'foo');
+                expect(repoModule.state.selected).toBe('foo');
+            });
+        });
     });
 });

--- a/td.vue/tests/unit/store/modules/provider.spec.js
+++ b/td.vue/tests/unit/store/modules/provider.spec.js
@@ -86,6 +86,15 @@ describe('store/modules/provider.js', () => {
                         'providerUri': 'https://github.com' 
                     });
             });
+
+            it('commits the local provider', async () => {
+                await providerModule.actions[providerSelected](mocks, providerService.providerNames.local);
+                expect(mocks.commit).toHaveBeenCalledWith(providerSelected,
+                    { 
+                        'providerName': providerService.providerNames.local, 
+                        'providerUri': 'threat-dragon-local' 
+                    });
+            });
         });
 
         describe('selected — desktop', () => {
@@ -118,8 +127,7 @@ describe('store/modules/provider.js', () => {
     describe('mutations', () => {
         describe('clear', () => {
             beforeEach(() => {
-                providerModule.state.all.push('test1');
-                providerModule.state.all.push('test2');
+                providerModule.state.all.push('test1', 'test2');
                 providerModule.state.selected = 'github';
                 providerModule.state.providerUri = 'https://github.com';
                 providerModule.mutations[providerClear](providerModule.state);
@@ -138,6 +146,19 @@ describe('store/modules/provider.js', () => {
             });
         });
 
+        describe('fetch', () => {
+            const providers = ['foo', 'bar'];
+
+            beforeEach(() => {
+                providerModule.mutations[providerFetch](providerModule.state, providers);
+            });
+
+            it('sets the providers property', () => {
+                expect(providerModule.state.all).toHaveLength(2);
+                expect(providerModule.state.all[1]).toBe('bar');
+            });
+        });
+
         describe('selected', () => {
             const provider = 'test';
             const providerUri = 'https://github.com';
@@ -146,11 +167,11 @@ describe('store/modules/provider.js', () => {
                 providerModule.mutations[providerSelected](providerModule.state, {'providerName': provider, 'providerUri': providerUri});
             });
 
-            it('sets the provider prop', () => {
+            it('selects the provider', () => {
                 expect(providerModule.state.selected).toEqual(provider);
             });
 
-            it('sets the providerUri prop', () => {
+            it('sets the providerUri property', () => {
                 expect(providerModule.state.providerUri).toEqual(providerUri);
             });
         });

--- a/td.vue/tests/unit/store/modules/repository.spec.js
+++ b/td.vue/tests/unit/store/modules/repository.spec.js
@@ -1,6 +1,6 @@
-import { repositoryClear, repositoryFetch, repositorySelected } from '@/store/actions/repository.js';
-import repoModule, { clearState } from '@/store/modules/repository.js';
-import threatmodelApi from '@/service/api/threatmodelApi.js';
+import { repositoryClear, repositoryFetch, repositorySelected } from '@/store/actions/repository';
+import repoModule, { clearState } from '@/store/modules/repository';
+import threatmodelApi from '@/service/api/threatmodelApi';
 import { createStoreMocks } from '../../helpers/store';
 
 describe('store/modules/repository.js', () => {
@@ -90,6 +90,7 @@ describe('store/modules/repository.js', () => {
     });
 
     describe('mutations', () => {
+
         describe('clear', () => {
             beforeEach(() => {
                 repoModule.state.all.push('test1', 'test2');
@@ -109,8 +110,31 @@ describe('store/modules/repository.js', () => {
             });
         });
 
+        describe('fetch', () => {
+            const testRepos = {repos: ['test1', 'test2'], page: 99, pageNext: false, pagePrev: false};
+
+            beforeEach(() => {
+                repoModule.state.all.push('foo', 'bar', 'baz');
+                repoModule.state.page = 5;
+                repoModule.state.pageNext = true;
+                repoModule.state.pagePrev = true;
+                repoModule.mutations[repositoryFetch](repoModule.state, testRepos);
+            });
+
+            it('copies the repo properties', () => {
+                expect(repoModule.state.all).toHaveLength(2);
+                expect(repoModule.state.all[1]).toBe('test2');
+            });
+
+            it('copies the page properties', () => {
+			    expect(repoModule.state.page).toBe(99);
+			    expect(repoModule.state.pageNext).toBe(false);
+			    expect(repoModule.state.pagePrev).toBe(false);
+            });
+        });
+
         describe('selected', () => {
-            it('sets the repo prop', () => {
+            it('sets the repo properties', () => {
                 repoModule.mutations[repositorySelected](repoModule.state, 'my-repo');
                 expect(repoModule.state.selected).toBe('my-repo');
             });

--- a/td.vue/tests/unit/views/importModel.spec.js
+++ b/td.vue/tests/unit/views/importModel.spec.js
@@ -19,7 +19,9 @@ jest.mock('@/service/migration/tmBom/tmBom');
 
 describe('views/ImportModel.vue', () => {
     let wrapper, localVue, mockRouter, mockStore, toast;
+
     beforeEach(() => {
+        console.warn = jest.fn();
         toast = { error: jest.fn(), warning: jest.fn() };
         localVue = createLocalVue();
         mockStore = createStore({

--- a/td.vue/tests/unit/views/threatmodelSelect.spec.js
+++ b/td.vue/tests/unit/views/threatmodelSelect.spec.js
@@ -15,6 +15,7 @@ describe('views/ThreatModelSelect.vue', () => {
     let wrapper, localVue, mockStore, mockRouter;
 
     beforeEach(() => {
+        console.warn = jest.fn();
         localVue = createLocalVue();
         localVue.use(Vuex);
         mockStore = getMockStore();

--- a/td.vue/vue.config.js
+++ b/td.vue/vue.config.js
@@ -152,6 +152,7 @@ module.exports = {
                 options.img = 'src';
                 options.image = 'xlink:href';
                 options.compilerOptions = {
+                    sourceMap: true,
                     ...options.compilerOptions,
                     // Sets the compatability mode to 2, meaning "vue 2"
                     // TODO: Once TODOs and additional warnings are sorted, we should


### PR DESCRIPTION
**Summary**:  

Increases front-end unit test coverage to over 90% for statements and lines:

```
File                                          | % Stmts | % Branch | % Funcs | % Lines                                
All files                                     |   91.38 |    86.98 |   87.93 |   91.26 |  
```

Closes #1555 

**Description for the changelog**:  

increase coverage of statements and lines to over 90%

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Previous test coverage:

```
File                                          | % Stmts | % Branch | % Funcs | % Lines |
All files                                     |   88.15 |    82.41 |    85.3 |   88.34 | 
```
