### PR TITLE
Codeowners cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,14 @@
 # default reviewers for pull requests
 *	@jgadsden @lreading
 
+# dependency maintenance
+/.github/dependabot.yaml	@lreading
+/Dockerfile	@lreading
+/package.json	@lreading
+/package-lock.json	@lreading
+/td.server/package.json	@lreading
+/td.server/package-lock.json	@lreading
+/td.vue/package.json	@lreading
+/td.vue/package-lock.json	@lreading
+/docs/Gemfile	@lreading
+/docs/Gemfile.lock	@lreading

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: ".github/workflows"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10
@@ -28,6 +30,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10
@@ -52,6 +56,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10
@@ -76,6 +82,8 @@ updates:
     directory: "/td.server"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10
@@ -100,6 +108,8 @@ updates:
     directory: "/td.vue"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10
@@ -124,6 +134,8 @@ updates:
     directory: "/docs"
     schedule:
       interval: "weekly"
+    assignees:
+      - "lreading"
     open-pull-requests-limit: 1
     cooldown:
       default-days: 10


### PR DESCRIPTION
**Summary**:  

I've taken ownership of dependency updates. 
Because our CODEOWNERS lists Jon and I both as codeowners for everything, he is always added as a reviewer to the dependabot PRs as well. 
Usually he's quicker than I am! :laughing: Jon's been removing himself as a reviewer and assigning me manually every time there's a new dependabot PR. This PR automates that - mostly.

The one exception is for GH actions updates. If I listed only myself as a codeowner for GH Actions, Jon wouldn't be asked for reviews on any updates to GH Actions. 

**Description for the changelog**:  

chore: codeowners cleanup

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
