### PR TITLE
Add contributors access policy

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -32,6 +32,14 @@ Github issues are used to coordinate contributions and keep track of progress to
 * provide your contributed content as a [pull request][request]
 * you **must** be assigned the issue before submitting a pull request
 
+### Contributor Access
+
+Regular contributors may be granted "Write" or "Maintain" access to this repository.
+These roles grant elevated permissions, including the ability to push code.
+
+Elevated access may be removed after 12 months of inactivity to reduce the risk of
+account takeover. Access can be restored if a contributor becomes active again.
+
 ## Got a Question or Problem?
 
 If you have a question or problem relating to using Threat Dragon then the first thing to do is to check the


### PR DESCRIPTION
**Summary**:  

We have a good number of contributors with write or maintain roles.
The number of members with elevated access has organically grown over time.
This PR establishes a policy to remove elevated access after 12 months of inactivity.

The risk I'm trying to solve is more around account takeover. Standing access should be avoided if it's no longer needed. 

**Description for the changelog**:  

chore: add contributor access policy

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

Open for discussion! I hope that this is not taken as a slight towards the people who have contributed. 
This is a relatively common pattern - kubernetes and nodejs both have similar policies.

If aligned/merged, I'll create a pinned issue and do a UAR to remove anyone with greater than read permissions if they have not contributed in the past 12 months. Names will not be shared, just an explanation of what we're doing and why. :) 