### PR TITLE
Allow cypress env for smokes in browserstack

### DIFF
--- a/td.vue/e2e.nightly.config.js
+++ b/td.vue/e2e.nightly.config.js
@@ -8,7 +8,8 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-    allowCypressEnv: false,
+    // BrowserStack's injected runner currently uses Cypress.env().
+    allowCypressEnv: true,
     retries: {
         runMode: 2,
         openMode: 0,

--- a/td.vue/e2e.smokes.config.js
+++ b/td.vue/e2e.smokes.config.js
@@ -6,7 +6,8 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-    allowCypressEnv: false,
+    // BrowserStack's injected runner currently uses Cypress.env().
+    allowCypressEnv: true,
     retries: {
         runMode: 2,
         openMode: 0,


### PR DESCRIPTION
**Summary**:  

Browserstack's internals are using `Cypress.Env()`.
This is causing a failure on main's actions smoke tests.
Browserstack supports specific versions of Cypress, and I couldn't find a documented path to a version without Browserstack using the dangerous call. 

**Description for the changelog**:  

chore: fix deploy smoke tests

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

No AI generated content - but I used ChatGPT to help me research the Browserstack support.
