### PR TITLE
Repo access review scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,5 +16,7 @@ Dependencies:
 | ------ | ------- |
 | [`td-build-desktop-linux-appimage.sh`](./td-build-desktop-linux-appimage.sh) | Build Linux AppImage (amd64) |
 | [`td-pr-check.sh`](./td-pr-check.sh) | Run local checks that emulate the PR workflow |
+| [`td-repo-access-review.sh`](./td-repo-access-review.sh) | Create an editable review of collaborators with elevated repository access |
+| [`td-repo-access-demote.sh`](./td-repo-access-demote.sh) | Change selected reviewed collaborators to Read access |
 | [`td-trivy-check.sh`](./td-trivy-check.sh) | Run local Trivy scan (requires docker) |
 | [`td-update-node-version.sh`](./td-update-node-version.sh) | Update digest-pinned Docker Node images and GitHub Actions |

--- a/scripts/td-repo-access-demote.sh
+++ b/scripts/td-repo-access-demote.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+script_name="td-repo-access-demote.sh"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repository="OWASP/threat-dragon"
+input_file=".repo-access-review.yaml"
+dry_run="false"
+
+# shellcheck source=scripts/td-repo-root.sh
+. "$script_dir/td-repo-root.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/td-repo-access-demote.sh [options]
+
+Change selected OWASP/threat-dragon collaborators to Read using the editable
+YAML review created by td-repo-access-review.sh. Set demote_to_read to false,
+or remove an entry, to retain access. The script verifies the current role
+before each change and does not add users who no longer have repository access.
+
+The authenticated GitHub CLI account must have permission to manage repository
+collaborators.
+
+Options:
+  --input PATH       Read the review from PATH. Defaults to
+                     .repo-access-review.yaml.
+  --dry-run          Print the changes that would be made without changing
+                     GitHub state.
+  -h, --help         Show this help.
+EOF
+}
+
+die() {
+    echo "$script_name: $*" >&2
+    exit 2
+}
+
+need_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+valid_login() {
+    echo "$1" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9-]{0,38}$'
+}
+
+selected_users() {
+    awk '
+        /^[[:space:]]*-[[:space:]]+login:[[:space:]]*/ {
+            if (login != "") {
+                print login "\t" demote
+            }
+            login = $0
+            sub(/^[[:space:]]*-[[:space:]]+login:[[:space:]]*/, "", login)
+            sub(/^"/, "", login)
+            sub(/"$/, "", login)
+            demote = "true"
+            next
+        }
+        /^[[:space:]]+demote_to_read:[[:space:]]*/ {
+            demote = $0
+            sub(/^[[:space:]]+demote_to_read:[[:space:]]*/, "", demote)
+            next
+        }
+        END {
+            if (login != "") {
+                print login "\t" demote
+            }
+        }
+    ' "$input_file"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --input)
+            shift
+            [ "$#" -gt 0 ] || die "--input requires a path"
+            input_file="$1"
+            ;;
+        --dry-run)
+            dry_run="true"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+    shift
+done
+
+need_command gh
+td_require_repo_root "$script_name"
+[ -f "$input_file" ] || die "review file not found: $input_file"
+
+review_repository="$(awk '/^repository:[[:space:]]*/ { sub(/^repository:[[:space:]]*/, ""); print; exit }' "$input_file")"
+[ "$review_repository" = "$repository" ] \
+    || die "review file must identify repository $repository"
+
+users="$(selected_users)" || die "unable to read review file: $input_file"
+[ -n "$users" ] || {
+    echo "No users selected for demotion."
+    exit 0
+}
+
+while IFS="$(printf '\t')" read -r login demote; do
+    valid_login "$login" || die "invalid GitHub login in review file: $login"
+    case "$demote" in
+        true) ;;
+        false)
+            echo "Skipped $login (demote_to_read is false)"
+            continue
+            ;;
+        *) die "demote_to_read for $login must be true or false" ;;
+    esac
+
+    current_permission="$(gh api "repos/$repository/collaborators/$login/permission" --jq '.role_name')" \
+        || die "unable to get current permission for $login"
+
+    if [ "$current_permission" = "read" ]; then
+        echo "Skipped $login (already Read)"
+        continue
+    fi
+
+    case "$current_permission" in
+        triage|write|maintain|admin) ;;
+        *) die "unexpected current permission for $login: $current_permission" ;;
+    esac
+
+    if [ "$dry_run" = "true" ]; then
+        echo "Would change $login from $current_permission to Read"
+        continue
+    fi
+
+    gh api --method PUT "repos/$repository/collaborators/$login" -f permission=read >/dev/null \
+        || die "unable to change $login from $current_permission to Read"
+    echo "Changed $login from $current_permission to Read"
+done <<EOF
+$users
+EOF

--- a/scripts/td-repo-access-review.sh
+++ b/scripts/td-repo-access-review.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+script_name="td-repo-access-review.sh"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repository="OWASP/threat-dragon"
+output_file=".repo-access-review.yaml"
+
+# shellcheck source=scripts/td-repo-root.sh
+. "$script_dir/td-repo-root.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/td-repo-access-review.sh [options]
+
+Create an editable YAML review of every OWASP/threat-dragon collaborator whose
+effective repository role is greater than Read. The output includes the latest
+GitHub-attributed authored commit in this repository only; it does not inspect
+global GitHub activity. The output file is gitignored.
+
+The authenticated GitHub CLI account must be permitted to view repository
+collaborators (GitHub generally requires Push access or higher).
+
+Options:
+  --output PATH      Write the review to PATH. Defaults to
+                     .repo-access-review.yaml.
+  -h, --help         Show this help.
+EOF
+}
+
+die() {
+    echo "$script_name: $*" >&2
+    exit 2
+}
+
+need_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+last_commit() {
+    login="$1"
+
+    gh api "repos/$repository/commits?author=$login&per_page=1" \
+        --jq 'if length == 0 then empty else .[0] | [.sha, .commit.author.date, .html_url] | @tsv end'
+}
+
+write_user() {
+    login="$1"
+    permission="$2"
+    commit="$(last_commit "$login")" || die "unable to find the last commit for $login"
+
+    printf '  - login: "%s"\n' "$login"
+    printf '    current_permission: "%s"\n' "$permission"
+    if [ -n "$commit" ]; then
+        IFS="$(printf '\t')" read -r commit_sha commit_date commit_url <<EOF
+$commit
+EOF
+        printf '    last_contribution:\n'
+        printf '      commit: "%s"\n' "$commit_sha"
+        printf '      date: "%s"\n' "$commit_date"
+        printf '      url: "%s"\n' "$commit_url"
+    else
+        printf '    last_contribution: null\n'
+    fi
+    printf '    demote_to_read: true\n'
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --output)
+            shift
+            [ "$#" -gt 0 ] || die "--output requires a path"
+            output_file="$1"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+    shift
+done
+
+need_command gh
+td_require_repo_root "$script_name"
+
+case "$output_file" in
+    /*) ;;
+    *) output_file="$(pwd)/$output_file" ;;
+esac
+
+output_dir="$(dirname "$output_file")"
+[ -d "$output_dir" ] || die "output directory does not exist: $output_dir"
+tmp_file="${output_file}.tmp.$$"
+trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
+
+collaborators="$(
+    gh api --paginate "repos/$repository/collaborators?affiliation=all&per_page=100" \
+        --jq '.[] | select(.role_name == "triage" or .role_name == "write" or .role_name == "maintain" or .role_name == "admin") | [.login, .role_name] | @tsv'
+)" || die "unable to list repository collaborators"
+
+{
+    printf '# Review the entries below before applying changes.\n'
+    printf '# Set demote_to_read to false, or remove an entry, to retain access.\n'
+    printf '# last_contribution is the latest GitHub-attributed authored commit in this repository.\n'
+    printf 'repository: %s\n' "$repository"
+    printf 'generated_at: "%s"\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'users:\n'
+
+    if [ -n "$collaborators" ]; then
+        while IFS="$(printf '\t')" read -r login permission; do
+            write_user "$login" "$permission"
+        done <<EOF
+$collaborators
+EOF
+    else
+        printf '  []\n'
+    fi
+} > "$tmp_file" || die "unable to write review output"
+
+mv "$tmp_file" "$output_file" || die "unable to save review output"
+trap - EXIT HUP INT TERM
+
+echo "Wrote repository access review to $output_file"

--- a/scripts/td-repo-access-review.sh
+++ b/scripts/td-repo-access-review.sh
@@ -15,7 +15,9 @@ Usage: scripts/td-repo-access-review.sh [options]
 Create an editable YAML review of every OWASP/threat-dragon collaborator whose
 effective repository role is greater than Read. The output includes the latest
 GitHub-attributed authored commit in this repository only; it does not inspect
-global GitHub activity. The output file is gitignored.
+global GitHub activity. A collaborator is selected for demotion only when they
+have no attributed commit in the year before the review runs. The output file is
+gitignored.
 
 The authenticated GitHub CLI account must be permitted to view repository
 collaborators (GitHub generally requires Push access or higher).
@@ -43,9 +45,18 @@ last_commit() {
         --jq 'if length == 0 then empty else .[0] | [.sha, .commit.author.date, .html_url] | @tsv end'
 }
 
+one_year_ago() {
+    if date -u -d '1 year ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null; then
+        return
+    fi
+
+    date -u -v-1y +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+}
+
 write_user() {
     login="$1"
     permission="$2"
+    inactivity_cutoff="$3"
     commit="$(last_commit "$login")" || die "unable to find the last commit for $login"
 
     printf '  - login: "%s"\n' "$login"
@@ -61,7 +72,12 @@ EOF
     else
         printf '    last_contribution: null\n'
     fi
-    printf '    demote_to_read: true\n'
+
+    if [ -z "$commit" ] || [[ "$commit_date" < "$inactivity_cutoff" ]]; then
+        printf '    demote_to_read: true\n'
+    else
+        printf '    demote_to_read: false\n'
+    fi
 }
 
 while [ "$#" -gt 0 ]; do
@@ -94,6 +110,10 @@ output_dir="$(dirname "$output_file")"
 [ -d "$output_dir" ] || die "output directory does not exist: $output_dir"
 tmp_file="${output_file}.tmp.$$"
 trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    || die "unable to determine the review time"
+inactivity_cutoff="$(one_year_ago)" \
+    || die "unable to calculate the one-year inactivity cutoff"
 
 collaborators="$(
     gh api --paginate "repos/$repository/collaborators?affiliation=all&per_page=100" \
@@ -102,15 +122,17 @@ collaborators="$(
 
 {
     printf '# Review the entries below before applying changes.\n'
+    printf '# demote_to_read is true only when no attributed commit was made in the preceding year.\n'
     printf '# Set demote_to_read to false, or remove an entry, to retain access.\n'
     printf '# last_contribution is the latest GitHub-attributed authored commit in this repository.\n'
     printf 'repository: %s\n' "$repository"
-    printf 'generated_at: "%s"\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'generated_at: "%s"\n' "$generated_at"
+    printf 'inactivity_cutoff: "%s"\n' "$inactivity_cutoff"
     printf 'users:\n'
 
     if [ -n "$collaborators" ]; then
         while IFS="$(printf '\t')" read -r login permission; do
-            write_user "$login" "$permission"
+            write_user "$login" "$permission" "$inactivity_cutoff"
         done <<EOF
 $collaborators
 EOF


### PR DESCRIPTION
**Summary**:  

Closes #1841 

Add scripts to perform a user access review, both using the GitHub CLI.
`td-repo-access-review.sh` identifies all users with more access than "read", determines their latest commit, and writes the results to `.repo-access-review.yaml`. 
I chose commit as the proxy for the latest contribution. Not because other types of contributions aren't valuable - it's because you do not need elevated access to participate in pull requests, issues, discussions, etc. 
The YAML includes a property `demote_to_read` that is set by the script based on the latest commit.  If there are users that you feel should retain elevated permissions despite not having a recent commit, you can delete the entire user object or set `demote_to_read: false`.

`td-repo-access-demote.sh` does the actual demotion based on the contents `.repo-access-review.yaml`. There's a `--dry-run` flag for safety.

**Description for the changelog**:  

chore: repository user access review automation

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `gpt-5.6-terra`
  - Prompts: `Create 2 scripts for a github repo UAR: 1 to identify all users with higher than "read" access along with their last commit date. The second script needs to change the access based on the output of the previous.`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
