### PR TITLE
Remove b-badge component

### DIFF
--- a/td.vue/src/components/Badge.vue
+++ b/td.vue/src/components/Badge.vue
@@ -1,0 +1,27 @@
+<template>
+    <span class="td-badge">
+        <slot></slot>
+    </span>
+</template>
+
+<style scoped>
+.td-badge {
+    display: inline-block;
+    padding: 0.25em 0.4em;
+    color: #ffffff;
+    font-size: 75%;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    vertical-align: baseline;
+    white-space: nowrap;
+    background-color: #aea79f;
+    border-radius: 0.25rem;
+}
+</style>
+
+<script>
+export default {
+    name: 'TdBadge'
+};
+</script>

--- a/td.vue/src/components/GraphThreats.vue
+++ b/td.vue/src/components/GraphThreats.vue
@@ -89,9 +89,9 @@
             </b-col>
 
             <b-col align-h="end">
-                <b-badge v-if="modelTypeResolved">
+                <td-badge v-if="modelTypeResolved">
                     {{ modelTypeResolved === 'EOP' ? 'EoP' : modelTypeResolved }}
-                </b-badge>
+                </td-badge>
             </b-col>
         </b-row>
     </b-card-text>
@@ -138,11 +138,15 @@
 </style>
 
 <script>
+import TdBadge from '@/components/Badge.vue';
 import { getGame } from '../service/threats/models/eop';
 import { isResolved } from '@/service/threats/status.js';
 
 export default {
     name: 'TdGraphThreats',
+    components: {
+        TdBadge
+    },
 
     props: {
         threat: {

--- a/td.vue/tests/unit/components/badge.spec.js
+++ b/td.vue/tests/unit/components/badge.spec.js
@@ -1,0 +1,34 @@
+import { shallowMount } from '@vue/test-utils';
+
+import TdBadge from '@/components/Badge.vue';
+
+describe('components/Badge.vue', () => {
+    it('renders its content in a native span', () => {
+        const wrapper = shallowMount(TdBadge, {
+            slots: {
+                default: 'CIA'
+            }
+        });
+
+        expect(wrapper.element.tagName).toBe('SPAN');
+        expect(wrapper.text()).toBe('CIA');
+    });
+
+    it('uses the Threat Dragon badge style', () => {
+        const wrapper = shallowMount(TdBadge);
+
+        expect(wrapper.classes()).toContain('td-badge');
+    });
+
+    it('passes attributes through to the native span', () => {
+        const wrapper = shallowMount(TdBadge, {
+            attrs: {
+                id: 'model-type',
+                class: 'model-type-badge'
+            }
+        });
+
+        expect(wrapper.attributes('id')).toBe('model-type');
+        expect(wrapper.classes()).toContain('model-type-badge');
+    });
+});

--- a/td.vue/tests/unit/components/graphThreats.spec.js
+++ b/td.vue/tests/unit/components/graphThreats.spec.js
@@ -3,6 +3,7 @@ import { shallowMount } from '@vue/test-utils';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { createLocalVue, mountOptions } from '../helpers/vueTestUtils';
+import TdBadge from '@/components/Badge.vue';
 import TdGraphThreats from '@/components/GraphThreats.vue';
 
 describe('components/GraphThreats.vue', () => {
@@ -165,7 +166,7 @@ describe('components/GraphThreats.vue', () => {
         });
 
         it('displays the model type', () => {
-            expect(wrapper.find('.threat-card').text()).toContain('CIA');
+            expect(wrapper.findComponent(TdBadge).text()).toBe('CIA');
         });
     });
 


### PR DESCRIPTION
**Summary**:  

Relates to #1080 

Replaces Bootstrap's `b-badge` component with a custom component

**Description for the changelog**:  

chore: remove bootstrap b-badge


**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `gpt-5.6-terra`
  - Prompts: `Replace all b-badge instances with a custom component`

**Other info**:  

This was only on the threat cards. The original one was using black font on a gray background. It was kind of hard to read due to the low contrast. I opted to make the font white instead.

Original:
<img width="401" height="284" alt="image" src="https://github.com/user-attachments/assets/7233b7d8-fa6a-47ae-987b-743d7958354b" />


New:
<img width="414" height="281" alt="image" src="https://github.com/user-attachments/assets/c2f4b9a6-3ae2-484e-b556-a305fd753eee" />
