### PR TITLE
replace b-spinner with custom component

### DIFF
--- a/td.vue/src/components/Spinner.vue
+++ b/td.vue/src/components/Spinner.vue
@@ -1,0 +1,57 @@
+<template>
+    <div class="td-spinner" role="status" :aria-label="label">
+        <span class="td-spinner-dots" aria-hidden="true">
+            <span class="td-spinner-dot"></span>
+            <span class="td-spinner-dot"></span>
+            <span class="td-spinner-dot"></span>
+        </span>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.td-spinner-dots {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.75rem;
+}
+
+.td-spinner-dot {
+    animation: td-spinner-pulse 1.2s ease-in-out infinite;
+    background-color: $orange;
+    border-radius: 50%;
+    height: 1.25rem;
+    width: 1.25rem;
+}
+
+.td-spinner-dot:nth-child(2) {
+    animation-delay: 0.15s;
+}
+
+.td-spinner-dot:nth-child(3) {
+    animation-delay: 0.3s;
+}
+
+@keyframes td-spinner-pulse {
+    0%, 60%, 100% {
+        opacity: 0.35;
+        transform: translateY(0);
+    }
+
+    30% {
+        opacity: 1;
+        transform: translateY(-0.75rem);
+    }
+}
+</style>
+
+<script>
+export default {
+    name: 'TdSpinner',
+    props: {
+        label: {
+            type: String,
+            default: 'Loading'
+        }
+    }
+};
+</script>

--- a/td.vue/src/views/HomePage.vue
+++ b/td.vue/src/views/HomePage.vue
@@ -16,11 +16,9 @@
                     />
                 </b-col>
                 <b-col md="8">
-                    <b-row v-if="!ready">
-                        <b-col class="text-center" style="margin-top: 10rem;">
-                            <b-spinner variant="primary" label="Loading" style="width: 7em; height: 7em; border-width: 1em;"></b-spinner>
-                        </b-col>
-                    </b-row>
+                    <div v-if="!ready" class="td-home-loading">
+                        <td-spinner />
+                    </div>
                     <template v-if="ready">
                         <b-row>
                             <p class="td-description mt-5">
@@ -60,6 +58,14 @@
     margin-right: 20px;
     margin-left: 20px;
 }
+
+.td-home-loading {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-height: 20rem;
+}
+
 </style>
 
 <script>
@@ -69,6 +75,7 @@ import threatDragonLogo from '@/assets/threatdragon_logo_image.svg';
 import TdHero from '@/components/Hero.vue';
 import TdImage from '@/components/Image.vue';
 import TdProviderLoginButton from '@/components/ProviderLoginButton.vue';
+import TdSpinner from '@/components/Spinner.vue';
 import configActions from '@/store/actions/config.js';
 import { resolveLocale } from '@/store/actions/locale';
 import { mapState } from 'vuex';
@@ -116,5 +123,6 @@ export default {
         TdHero,
         TdImage,
         TdProviderLoginButton,
+        TdSpinner,
     },};
 </script>

--- a/td.vue/tests/e2e/specs/home.cy.js
+++ b/td.vue/tests/e2e/specs/home.cy.js
@@ -34,7 +34,7 @@ const loadWithConfig = (overrides = {}, alias = 'getConfig') => {
 
     cy.visit('/');
     cy.wait(`@${alias}`);
-    cy.get('.spinner-border', { timeout: 10000 }).should('not.exist');
+    cy.get('.td-spinner', { timeout: 10000 }).should('not.exist');
 };
 
 const verifyProviderButtons = (expected) => {
@@ -185,7 +185,7 @@ describe('home', () => {
             cy.visit('/');
             cy.wait('@getConfigFail');
 
-            cy.get('.spinner-border').should('not.exist');
+            cy.get('.td-spinner').should('not.exist');
             verifyProviderButtons(['local-login-btn']);
         });
 
@@ -198,13 +198,13 @@ describe('home', () => {
             cy.visit('/');
             cy.wait('@getConfig');
 
-            cy.get('.spinner-border').should('not.exist');
+            cy.get('.td-spinner').should('not.exist');
             verifyProviderButtons(['local-login-btn']);
         });
     });
 
     describe('loading state', () => {
-        it('shows spinner while loading config', () => {
+        it('shows the loading indicator while loading config', () => {
             cy.intercept('GET', '/api/config', (req) => {
                 req.on('response', (res) => {
                     res.setDelay(500);
@@ -213,18 +213,18 @@ describe('home', () => {
             }).as('slowConfig');
 
             cy.visit('/');
-            cy.get('.spinner-border').should('be.visible');
+            cy.get('.td-spinner').should('be.visible');
 
             cy.wait('@slowConfig');
-            cy.get('.spinner-border').should('not.exist');
+            cy.get('.td-spinner').should('not.exist');
         });
 
-        it('spinner disappears after success', () => {
+        it('hides the loading indicator after success', () => {
             cy.launchThreatDragon();
-            cy.get('.spinner-border').should('not.exist');
+            cy.get('.td-spinner').should('not.exist');
         });
 
-        it('spinner disappears after error', () => {
+        it('hides the loading indicator after error', () => {
             cy.intercept('GET', '/api/config', {
                 statusCode: 500,
                 body: { status: 500, error: 'Server error' }
@@ -233,7 +233,7 @@ describe('home', () => {
             cy.visit('/');
             cy.wait('@failConfig');
 
-            cy.get('.spinner-border').should('not.exist');
+            cy.get('.td-spinner').should('not.exist');
         });
     });
 

--- a/td.vue/tests/e2e/specs/locale-section.cy.js
+++ b/td.vue/tests/e2e/specs/locale-section.cy.js
@@ -26,7 +26,7 @@ const loadWithConfig = (overrides = {}, alias = 'getConfig') => {
 
     cy.visit('/');
     cy.wait(`@${alias}`);
-    cy.get('.spinner-border').should('not.exist');
+    cy.get('.td-spinner').should('not.exist');
     cy.get('#local-login-btn').should('be.visible');
 };
 

--- a/td.vue/tests/e2e/support/commands/startup.js
+++ b/td.vue/tests/e2e/support/commands/startup.js
@@ -4,6 +4,6 @@ Cypress.Commands.add('launchThreatDragon', () => {
         onBeforeLoad: (win) => win.sessionStorage.clear()
     });
     cy.wait('@getConfig');
-    cy.get('.spinner-border').should('not.exist');
+    cy.get('.td-spinner').should('not.exist');
     cy.get('#local-login-btn').should('be.visible');
 });

--- a/td.vue/tests/unit/components/spinner.spec.js
+++ b/td.vue/tests/unit/components/spinner.spec.js
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+
+import TdSpinner from '@/components/Spinner.vue';
+
+describe('components/Spinner.vue', () => {
+    it('identifies itself as a status indicator', () => {
+        const wrapper = mount(TdSpinner);
+
+        expect(wrapper.attributes('role')).toBe('status');
+    });
+
+    it('uses the default loading label', () => {
+        const wrapper = mount(TdSpinner);
+
+        expect(wrapper.attributes('aria-label')).toBe('Loading');
+    });
+
+    it('accepts a custom loading label', () => {
+        const wrapper = mount(TdSpinner, {
+            propsData: {
+                label: 'Saving'
+            }
+        });
+
+        expect(wrapper.attributes('aria-label')).toBe('Saving');
+    });
+
+    it('renders three animated dots', () => {
+        const wrapper = mount(TdSpinner);
+
+        expect(wrapper.findAll('.td-spinner-dot')).toHaveLength(3);
+    });
+});

--- a/td.vue/tests/unit/views/homePage.spec.js
+++ b/td.vue/tests/unit/views/homePage.spec.js
@@ -12,6 +12,7 @@ import HomePage, { resolveProviders } from '@/views/HomePage.vue';
 import TdHero from '@/components/Hero.vue';
 import TdImage from '@/components/Image.vue';
 import TdProviderLoginButton from '@/components/ProviderLoginButton.vue';
+import TdSpinner from '@/components/Spinner.vue';
 
 jest.mock('@/assets/threatdragon_logo_image.svg', () => 'threatdragon_logo_image.svg');
 jest.mock('@/service/environment', () => ({
@@ -42,7 +43,6 @@ const createControlledMount = (store, mocks = {}) => {
         localVue,
         store,
         stubs: {
-            'b-spinner': true,
             'b-container': true
         },
         mocks: {
@@ -166,23 +166,23 @@ describe('HomePage.vue', () => {
     });
 
     describe('loading state', () => {
-        it('shows spinner and hides content before mount resolves', () => {
+        it('shows the loading indicator and hides content before mount resolves', () => {
             const store = createStore({ githubEnabled: true });
             const { wrapper: w } = createControlledMount(store);
 
             expect(w.vm.ready).toBe(false);
-            expect(w.find('b-spinner-stub').exists()).toBe(true);
+            expect(w.findComponent(TdSpinner).exists()).toBe(true);
             expect(w.find('.td-description').exists()).toBe(false);
         });
 
-        it('shows content and hides spinner after mount resolves', async () => {
+        it('shows content and hides the loading indicator after mount resolves', async () => {
             const store = createStore({ githubEnabled: true });
             const { wrapper: w, resolve } = createControlledMount(store);
 
             await finishMount(w, resolve);
 
             expect(w.vm.ready).toBe(true);
-            expect(w.find('b-spinner-stub').exists()).toBe(false);
+            expect(w.findComponent(TdSpinner).exists()).toBe(false);
             expect(w.find('.td-description').exists()).toBe(true);
         });
     });
@@ -192,11 +192,11 @@ describe('HomePage.vue', () => {
             isDesktopApp.mockReturnValue(true);
         });
 
-        it('starts ready with no spinner', () => {
+        it('starts ready with no loading indicator', () => {
             const store = createStore({ githubEnabled: true });
             const { wrapper: w } = createControlledMount(store);
             expect(w.vm.ready).toBe(true);
-            expect(w.find('b-spinner-stub').exists()).toBe(false);
+            expect(w.findComponent(TdSpinner).exists()).toBe(false);
             expect(w.find('.td-description').exists()).toBe(true);
         });
 


### PR DESCRIPTION
**Summary**:  

Relates to #1080 
Replaces `b-spinner` with a custom component.
Because the spinner is not included in visual regressions, I took some liberties and made a 3-dot jumping style spinner that felt a bit more modern.

**Description for the changelog**:  

chore: replace bootstrap b-spinner

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `gpt-5.6-terra`
  - Prompts: `Replace all instances of b-spinner with a self-contained component that does not rely on bootstrap`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
