### PR TITLE
Analytics cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ regardless of whether the contributor is carbon-based, silicon-based, or legally
 - Breaking changes requiring a Threat Dragon major version bump are prohibited.
 - Comments should explain non-obvious constraints or decisions only. Avoid comments that restate the code.
 - Treat auth, tokens, repository access, file access, and generated artifacts as security-sensitive surfaces.
+- Analytics must never be tracked in the desktop or standalone front-end: they are opt-in only via
+  server configuration and preserve privacy. The server must explicitly allow-list events.
 - Pull requests must be tightly scoped and easily reviewed by maintainers. Humans will be reviewing all changes
   - PRs with > 20 files are not sustainable.
   - Break it down into smaller practical PRs, OR

--- a/docs/configure/analytics.md
+++ b/docs/configure/analytics.md
@@ -63,7 +63,7 @@ _Threat Dragon uses an allow-list for property values to help protect privacy._
 2. Select **Custom Properties**.
 3. Select **Add property**.
 4. Enter one property name from the table below.
-5. Save the property and repeat for all seven names.
+5. Save the property and repeat for all names.
 
 | Property | Threat Dragon's Allowed Values |
 | --- | --- |
@@ -71,9 +71,10 @@ _Threat Dragon uses an allow-list for property values to help protect privacy._
 | `source` | `github`, `gitlab`, `bitbucket`, `google`, `import`, `demo`, `type`, `context` |
 | `language` | `ar`, `de`, `el`, `en`, `es`, `fi`, `fr`, `hi`, `id`, `ja`, `ms`, `pt`, `pt-BR`, `zh` |
 | `duration_bucket` | `LESS_THAN_5_MINUTES`, `FIVE_TO_FIFTEEN_MINUTES`, `FIFTEEN_TO_THIRTY_MINUTES`, `THIRTY_TO_SIXTY_MINUTES`, `SIXTY_PLUS_MINUTES` |
+| `editor` | `diagram`, `threat_model` |
 | `methodology` | `CIA`, `CIADIE`, `LINDDUN`, `PLOT4AI`, `STRIDE`, `EOP`, `GENERIC` |
 | `status` | `NotApplicable`, `Open`, `Mitigated`, `Accepted`, `Transferred`, `Avoided`, `Eliminated` |
-| `format` | `PNG`, `SVG` |
+| `format` | `PNG`, `SVG`, `TM_BOM`, `PRINT` |
 
 #### Segments (optional)
 

--- a/td.server/src/constants/analyticsEvents.js
+++ b/td.server/src/constants/analyticsEvents.js
@@ -41,7 +41,8 @@ export const analyticsEventProperties = Object.freeze({
     [analyticsEvents.PROVIDER_SELECTED]: Object.freeze({ provider: providerValues }),
     [analyticsEvents.PROVIDER_AUTHENTICATION_SUCCEEDED]: Object.freeze({ provider: remoteProviderValues }),
     [analyticsEvents.THREAT_MODEL_OPENED]: Object.freeze({
-        source: Object.freeze([...remoteProviderValues, 'import', 'demo'])
+        source: Object.freeze([...remoteProviderValues, 'import', 'demo']),
+        provider: providerValues
     }),
     [analyticsEvents.THREAT_MODEL_CREATED]: Object.freeze({ provider: providerValues }),
     [analyticsEvents.THREAT_MODEL_SAVED]: Object.freeze({ provider: providerValues }),
@@ -55,12 +56,25 @@ export const analyticsEventProperties = Object.freeze({
             'FIFTEEN_TO_THIRTY_MINUTES',
             'THIRTY_TO_SIXTY_MINUTES',
             'SIXTY_PLUS_MINUTES'
-        ])
+        ]),
+        editor: Object.freeze(['diagram', 'threat_model'])
+    }),
+    [analyticsEvents.DIAGRAM_CREATED]: Object.freeze({
+        methodology: Object.freeze(['CIA', 'CIADIE', 'LINDDUN', 'PLOT4AI', 'STRIDE', 'EOP', 'GENERIC'])
     }),
     [analyticsEvents.DIAGRAM_METHODOLOGY_USED]: Object.freeze({
         methodology: Object.freeze(['CIA', 'CIADIE', 'LINDDUN', 'PLOT4AI', 'STRIDE', 'EOP', 'GENERIC'])
     }),
     [analyticsEvents.THREAT_STATUS_UPDATED]: Object.freeze({
+        status: Object.freeze(['NotApplicable', 'Open', 'Mitigated', 'Accepted', 'Transferred', 'Avoided', 'Eliminated'])
+    }),
+    [analyticsEvents.THREAT_CREATED_MANUALLY]: Object.freeze({
+        status: Object.freeze(['NotApplicable', 'Open', 'Mitigated', 'Accepted', 'Transferred', 'Avoided', 'Eliminated'])
+    }),
+    [analyticsEvents.THREAT_UPDATED]: Object.freeze({
+        status: Object.freeze(['NotApplicable', 'Open', 'Mitigated', 'Accepted', 'Transferred', 'Avoided', 'Eliminated'])
+    }),
+    [analyticsEvents.THREAT_DELETED]: Object.freeze({
         status: Object.freeze(['NotApplicable', 'Open', 'Mitigated', 'Accepted', 'Transferred', 'Avoided', 'Eliminated'])
     }),
     [analyticsEvents.THREAT_SUGGESTIONS_REQUESTED]: Object.freeze({
@@ -69,7 +83,9 @@ export const analyticsEventProperties = Object.freeze({
     [analyticsEvents.THREAT_SUGGESTION_APPLIED]: Object.freeze({
         source: Object.freeze(['type', 'context'])
     }),
-    [analyticsEvents.DIAGRAM_EXPORTED]: Object.freeze({ format: Object.freeze(['PNG', 'SVG']) })
+    [analyticsEvents.DIAGRAM_EXPORTED]: Object.freeze({ format: Object.freeze(['PNG', 'SVG']) }),
+    [analyticsEvents.THREAT_MODEL_TMBOM_EXPORTED]: Object.freeze({ format: Object.freeze(['TM_BOM']) }),
+    [analyticsEvents.THREAT_MODEL_REPORT_PRINT_REQUESTED]: Object.freeze({ format: Object.freeze(['PRINT']) })
 });
 
 export const pageViewPaths = Object.freeze({

--- a/td.server/src/helpers/plausible.helper.js
+++ b/td.server/src/helpers/plausible.helper.js
@@ -6,16 +6,33 @@ import {
 
 export const isAnalyticsEvent = (event) => analyticsEventNames.includes(event);
 
-export const hasValidProperties = (event, props) => {
-    const allowedProperties = analyticsEventProperties[event];
-    if (!allowedProperties) {return props === undefined;}
-    if (!props || typeof props !== 'object' || Array.isArray(props)) {return false;}
-
+const hasExpectedPropertyNames = (allowedProperties, props) => {
     const propertyNames = Object.keys(props);
     const allowedPropertyNames = Object.keys(allowedProperties);
-    if (propertyNames.length !== 1 || propertyNames[0] !== allowedPropertyNames[0]) {return false;}
 
-    return allowedProperties[propertyNames[0]].includes(props[propertyNames[0]]);
+    const hasNoUnexpectedProperties = propertyNames.
+        every((propertyName) => allowedPropertyNames.includes(propertyName));
+    const hasNoMissingProperties = allowedPropertyNames.
+        every((propertyName) => propertyNames.includes(propertyName));
+
+    return hasNoUnexpectedProperties && hasNoMissingProperties;
+};
+
+export const hasValidProperties = (event, props) => {
+    const allowedProperties = analyticsEventProperties[event];
+    if (!allowedProperties) {
+        return props === undefined;
+    }
+    if (!props || typeof props !== 'object' || Array.isArray(props)) {
+        return false;
+    }
+
+    if (!hasExpectedPropertyNames(allowedProperties, props)) {
+        return false;
+    }
+
+    return Object.keys(allowedProperties).
+        every((propertyName) => allowedProperties[propertyName].includes(props[propertyName]));
 };
 
 export const createPlausiblePayload = (config, event, props) => {

--- a/td.server/test/controllers/analyticscontroller.spec.js
+++ b/td.server/test/controllers/analyticscontroller.spec.js
@@ -67,7 +67,7 @@ describe('controllers/analyticscontroller.js', () => {
         const request = getMockRequest();
         request.ip = '192.0.2.1';
         request.get.withArgs('user-agent').returns('test-agent');
-        request.body = { event: analyticsEvents.DIAGRAM_CREATED };
+        request.body = { event: analyticsEvents.DIAGRAM_CREATED, props: { methodology: 'STRIDE' } };
         const response = getMockResponse();
         await controller.track(request, response);
         expect(sendEventDep).to.have.been.calledWith(
@@ -83,7 +83,7 @@ describe('controllers/analyticscontroller.js', () => {
             sendEventDep: sinon.stub().resolves()
         });
         const request = getMockRequest();
-        request.body = { event: analyticsEvents.DIAGRAM_CREATED };
+        request.body = { event: analyticsEvents.DIAGRAM_CREATED, props: { methodology: 'STRIDE' } };
         const response = getMockResponse();
         await controller.track(request, response);
         expect(response.status).to.have.been.calledWith(204);
@@ -97,7 +97,7 @@ describe('controllers/analyticscontroller.js', () => {
             loggerDep
         });
         const request = getMockRequest();
-        request.body = { event: analyticsEvents.DIAGRAM_CREATED };
+        request.body = { event: analyticsEvents.DIAGRAM_CREATED, props: { methodology: 'STRIDE' } };
         const response = getMockResponse();
         await controller.track(request, response);
         expect(loggerDep.warn).to.have.been.calledWith('Plausible event forwarding failed.');

--- a/td.server/test/helpers/plausible.helper.spec.js
+++ b/td.server/test/helpers/plausible.helper.spec.js
@@ -23,11 +23,11 @@ describe('helpers/plausible.helper.js', () => {
     });
 
     it('allows no properties for an event without properties', () => {
-        expect(hasValidProperties(analyticsEvents.DIAGRAM_CREATED)).to.equal(true);
+        expect(hasValidProperties(analyticsEvents.PAGE_VIEW_HOME)).to.equal(true);
     });
 
     it('rejects properties for an event without properties', () => {
-        expect(hasValidProperties(analyticsEvents.DIAGRAM_CREATED, { title: 'model name' })).to.equal(false);
+        expect(hasValidProperties(analyticsEvents.PAGE_VIEW_HOME, { title: 'model name' })).to.equal(false);
     });
 
     it('requires properties for an event with a property', () => {
@@ -62,19 +62,42 @@ describe('helpers/plausible.helper.js', () => {
     });
 
     it('rejects local as a model-open source', () => {
-        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_OPENED, { source: 'local' })).to.equal(false);
+        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_OPENED, {
+            source: 'local',
+            provider: 'local'
+        })).to.equal(false);
+    });
+
+    it('allows a local provider when a model is imported', () => {
+        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_OPENED, {
+            source: 'import',
+            provider: 'local'
+        })).to.equal(true);
+    });
+
+    it('requires a storage provider for a model-open event', () => {
+        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_OPENED, { source: 'import' })).to.equal(false);
+    });
+
+    it('rejects a report format that the browser cannot identify', () => {
+        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_REPORT_PRINT_REQUESTED, { format: 'PDF' })).to.equal(false);
     });
 
     it('allows the fixed property value for an event', () => {
         expect(hasValidProperties(analyticsEvents.PROVIDER_SELECTED, { provider: 'local' })).to.equal(true);
     });
 
+    it('requires both properties for an editing session', () => {
+        expect(hasValidProperties(analyticsEvents.THREAT_MODEL_EDIT_SESSION_ENDED, {
+            duration_bucket: 'LESS_THAN_5_MINUTES'
+        })).to.equal(false);
+    });
+
     Object.entries(analyticsEventProperties).forEach(([event, allowedProperties]) => {
-        const [propertyName] = Object.keys(allowedProperties);
         it(`allows the declared property for ${event}`, () => {
-            expect(hasValidProperties(event, {
-                [propertyName]: allowedProperties[propertyName][0]
-            })).to.equal(true);
+            const props = Object.fromEntries(Object.entries(allowedProperties)
+                .map(([propertyName, values]) => [propertyName, values[0]]));
+            expect(hasValidProperties(event, props)).to.equal(true);
         });
     });
 
@@ -94,12 +117,12 @@ describe('helpers/plausible.helper.js', () => {
         expect(createPlausiblePayload(
             config,
             analyticsEvents.THREAT_MODEL_EDIT_SESSION_ENDED,
-            { duration_bucket: 'SIXTY_PLUS_MINUTES' }
+            { duration_bucket: 'SIXTY_PLUS_MINUTES', editor: 'diagram' }
         )).to.deep.equal({
             domain: 'threatdragon.test',
             name: analyticsEvents.THREAT_MODEL_EDIT_SESSION_ENDED,
             url: 'https://threatdragon.test/analytics',
-            props: { duration_bucket: 'SIXTY_PLUS_MINUTES' }
+            props: { duration_bucket: 'SIXTY_PLUS_MINUTES', editor: 'diagram' }
         });
     });
 });

--- a/td.vue/src/components/Graph.vue
+++ b/td.vue/src/components/Graph.vue
@@ -56,17 +56,7 @@ import diagramService from '@/service/diagram/diagram.js';
 import saveDiagram from '@/service/diagram/save.js';
 import stencil from '@/service/x6/stencil.js';
 import tmActions from '@/store/actions/threatmodel.js';
-import analytics from '@/service/analytics.js';
-
-const methodologies = Object.freeze({
-    CIA: 'CIA',
-    DIE: 'CIADIE',
-    CIADIE: 'CIADIE',
-    LINDDUN: 'LINDDUN',
-    PLOT4ai: 'PLOT4AI',
-    STRIDE: 'STRIDE',
-    EOP: 'EOP'
-});
+import analytics, { methodologyForDiagramType } from '@/service/analytics.js';
 
 export default {
     name: 'TdGraph',
@@ -89,9 +79,9 @@ export default {
     },
     async mounted() {
         this.init();
-        analytics.startEditing();
+        analytics.startEditing('diagram');
         analytics.track('DIAGRAM_METHODOLOGY_USED', {
-            methodology: methodologies[this.diagram.diagramType] || 'GENERIC'
+            methodology: methodologyForDiagramType(this.diagram.diagramType)
         });
         if (this.providerType === providerTypes.desktop) {
             this.desktopSaveRequestHandler = () => this.handleDesktopSaveRequest();

--- a/td.vue/src/components/GraphMeta.vue
+++ b/td.vue/src/components/GraphMeta.vue
@@ -173,7 +173,7 @@ export default {
             this.$store.dispatch(cellDataUpdated, this.cellRef.data);
             dataChanged.updateStyleAttrs(this.cellRef);
             this.threatSelected(threat.id, 'new');
-            analytics.track('THREAT_CREATED_MANUALLY');
+            analytics.track('THREAT_CREATED_MANUALLY', { status: threat.status });
         },
         AddThreatByType(){
             this.$emit('threatSuggest', 'type');

--- a/td.vue/src/components/ThreatEditDialog.vue
+++ b/td.vue/src/components/ThreatEditDialog.vue
@@ -471,7 +471,7 @@ export default {
                 this.$store.dispatch(tmActions.modified);
                 dataChanged.updateStyleAttrs(this.cellRef);
                 if (!this.newThreat) {
-                    analytics.track('THREAT_UPDATED');
+                    analytics.track('THREAT_UPDATED', { status: this.threat.status });
                     if (previousStatus !== this.threat.status) {
                         analytics.track('THREAT_STATUS_UPDATED', { status: this.threat.status });
                     }
@@ -500,7 +500,7 @@ export default {
             this.$store.dispatch(cellDataUpdated, this.cellRef.data);
             this.$store.dispatch(tmActions.modified);
             dataChanged.updateStyleAttrs(this.cellRef);
-            if (threatExists) analytics.track('THREAT_DELETED');
+            if (threatExists) analytics.track('THREAT_DELETED', { status: this.threat.status });
         },
         hideModal() {
             this.$refs.editModal.hide();

--- a/td.vue/src/service/analytics.js
+++ b/td.vue/src/service/analytics.js
@@ -1,6 +1,20 @@
 import api from '@/service/api/api.js';
+import { isDesktopApp } from '@/service/environment.js';
 
 const analyticsPath = '/api/analytics';
+const editorTypes = new Set(['diagram', 'threat_model']);
+const methodologies = Object.freeze({
+    CIA: 'CIA',
+    DIE: 'CIADIE',
+    CIADIE: 'CIADIE',
+    LINDDUN: 'LINDDUN',
+    PLOT4ai: 'PLOT4AI',
+    STRIDE: 'STRIDE',
+    EOP: 'EOP'
+});
+
+const methodologyForDiagramType = (diagramType) => methodologies[diagramType] || 'GENERIC';
+
 const durationBucket = (durationMs) => {
     if (durationMs < 5 * 60 * 1000) return 'LESS_THAN_5_MINUTES';
     if (durationMs < 15 * 60 * 1000) return 'FIVE_TO_FIFTEEN_MINUTES';
@@ -20,16 +34,16 @@ const hasSafeDashboardUrl = (value) => {
 
 let enabled = false;
 let eventNames = new Set();
-let editStartedAt = null;
+let editSession = null;
 
 const disable = () => {
     enabled = false;
     eventNames = new Set();
-    editStartedAt = null;
+    editSession = null;
 };
 
 const configure = (config) => {
-    if (!config?.enabled || !hasSafeDashboardUrl(config.dashboardUrl) || !Array.isArray(config.eventNames)) {
+    if (isDesktopApp() || !config?.enabled || !hasSafeDashboardUrl(config.dashboardUrl) || !Array.isArray(config.eventNames)) {
         disable();
         return false;
     }
@@ -58,26 +72,37 @@ const track = async (event, props) => {
     }
 };
 
-const startEditing = (now = Date.now()) => {
-    if (!enabled || editStartedAt !== null) return false;
-    editStartedAt = now;
+const startEditing = (editor, now = Date.now()) => {
+    if (!enabled || editSession !== null || !editorTypes.has(editor)) return false;
+    editSession = { editor, startedAt: now };
     return true;
 };
 
-const finishEditing = (now = Date.now()) => {
-    if (editStartedAt === null) return false;
+const sendWithBeacon = (event, props) => {
+    if (!enabled || !eventNames.has(event) || typeof navigator.sendBeacon !== 'function') return false;
 
-    const startedAt = editStartedAt;
-    editStartedAt = null;
-    track('THREAT_MODEL_EDIT_SESSION_ENDED', {
-        duration_bucket: durationBucket(Math.max(0, now - startedAt))
-    });
+    const body = JSON.stringify({ event, props });
+    return navigator.sendBeacon(analyticsPath, new Blob([body], { type: 'application/json' }));
+};
+
+const finishEditing = (now = Date.now(), useBeacon = false) => {
+    if (editSession === null) return false;
+
+    const { editor, startedAt } = editSession;
+    editSession = null;
+    const props = {
+        duration_bucket: durationBucket(Math.max(0, now - startedAt)),
+        editor
+    };
+    if (!useBeacon || !sendWithBeacon('THREAT_MODEL_EDIT_SESSION_ENDED', props)) {
+        track('THREAT_MODEL_EDIT_SESSION_ENDED', props);
+    }
     return true;
 };
 
-window.addEventListener('pagehide', () => finishEditing());
+window.addEventListener('pagehide', () => finishEditing(Date.now(), true));
 
-export { durationBucket };
+export { durationBucket, methodologyForDiagramType };
 
 export default {
     configure,

--- a/td.vue/src/store/analytics.js
+++ b/td.vue/src/store/analytics.js
@@ -20,7 +20,10 @@ const analyticsPlugin = (store) => {
                 break;
             case threatmodelFetch:
                 if (remoteProviders.includes(state.provider.selected)) {
-                    analytics.track('THREAT_MODEL_OPENED', { source: state.provider.selected });
+                    analytics.track('THREAT_MODEL_OPENED', {
+                        source: state.provider.selected,
+                        provider: state.provider.selected
+                    });
                 }
                 break;
             default:

--- a/td.vue/src/views/ImportModel.vue
+++ b/td.vue/src/views/ImportModel.vue
@@ -88,7 +88,8 @@ export default {
     },
     computed: {
         ...mapState({
-            providerType: (state) => getProviderType(state.provider.selected)
+            providerType: (state) => getProviderType(state.provider.selected),
+            selectedProvider: (state) => state.provider.selected
         }),
         prompt() { return '{ ' + this.$t('threatmodel.dragAndDrop') + this.$t('threatmodel.jsonPaste') + ' ... }'; }
     },
@@ -202,7 +203,10 @@ export default {
                 return;
             }
 
-            analytics.track('THREAT_MODEL_OPENED', { source: 'import' });
+            analytics.track('THREAT_MODEL_OPENED', {
+                source: 'import',
+                provider: this.selectedProvider
+            });
             this.$router.push({ name: `${this.providerType}ThreatModel`, params });
         }
     }

--- a/td.vue/src/views/ReportModel.vue
+++ b/td.vue/src/views/ReportModel.vue
@@ -296,7 +296,7 @@ export default {
         },
         print() {
             console.debug('Print the report window');
-            analytics.track('THREAT_MODEL_REPORT_PRINT_REQUESTED');
+            analytics.track('THREAT_MODEL_REPORT_PRINT_REQUESTED', { format: 'PRINT' });
             window.print();
         },
         printPdf() {

--- a/td.vue/src/views/ThreatModel.vue
+++ b/td.vue/src/views/ThreatModel.vue
@@ -144,7 +144,7 @@ export default {
             const tmBom = this.$store.getters.tmBomExport;
             console.debug('Export to TM-BOM ' + JSON.stringify(tmBom, null, 2));
             await writeFile(tmBom, '');
-            analytics.track('THREAT_MODEL_TMBOM_EXPORTED');
+            analytics.track('THREAT_MODEL_TMBOM_EXPORTED', { format: 'TM_BOM' });
         },
         getThumbnailUrl(diagram) {
             if (!diagram || !diagram.diagramType) {

--- a/td.vue/src/views/ThreatModelEdit.vue
+++ b/td.vue/src/views/ThreatModelEdit.vue
@@ -235,7 +235,7 @@ import TdFormButton from '@/components/FormButton.vue';
 import TdFormTags from '@/components/FormTags.vue';
 import TdInputGroup from '@/components/InputGroup.vue';
 import tmActions from '@/store/actions/threatmodel.js';
-import analytics from '@/service/analytics.js';
+import analytics, { methodologyForDiagramType } from '@/service/analytics.js';
 
 export default {
     name: 'ThreatModelEdit',
@@ -244,6 +244,11 @@ export default {
         TdFormButton,
         TdFormTags,
         TdInputGroup
+    },
+    data() {
+        return {
+            createdDiagramIds: []
+        };
     },
     computed: {
         ...mapState({
@@ -265,7 +270,7 @@ export default {
     },
     async mounted() {
         this.init();
-        analytics.startEditing();
+        analytics.startEditing('threat_model');
     },
     methods: {
         init() {
@@ -289,6 +294,7 @@ export default {
                 const result = await this.$store.dispatch(tmActions.create);
                 // Only navigate to edit route if create was successful
                 if (result) {
+                    this.trackCreatedDiagrams();
                     const params = Object.assign({}, this.$route.params, {
                         threatmodel: this.model.summary.title
                     });
@@ -296,6 +302,7 @@ export default {
                 }
             } else {
                 await this.$store.dispatch(tmActions.saveModel);
+                if (!this.$store.getters.modelChanged) this.trackCreatedDiagrams();
             }
         },
         async onReloadClick(evt) {
@@ -320,8 +327,19 @@ export default {
             };
             this.$store.dispatch(tmActions.update, { diagramTop: this.diagramTop + 1 });
             this.model.detail.diagrams.push(newDiagram);
+            this.createdDiagramIds.push(newDiagram.id);
             this.$store.dispatch(tmActions.modified);
-            analytics.track('DIAGRAM_CREATED');
+        },
+        trackCreatedDiagrams() {
+            this.createdDiagramIds.forEach((diagramId) => {
+                const diagram = this.model.detail.diagrams.find((item) => item.id === diagramId);
+                if (diagram) {
+                    analytics.track('DIAGRAM_CREATED', {
+                        methodology: methodologyForDiagramType(diagram.diagramType)
+                    });
+                }
+            });
+            this.createdDiagramIds = [];
         },
         onDiagramTypeClick(idx, type) {
             let defaultTitle;

--- a/td.vue/src/views/demo/SelectDemoModel.vue
+++ b/td.vue/src/views/demo/SelectDemoModel.vue
@@ -57,7 +57,10 @@ export default {
     },
     methods: {
         onModelClick(model) {
-            analytics.track('THREAT_MODEL_OPENED', { source: 'demo' });
+            analytics.track('THREAT_MODEL_OPENED', {
+                source: 'demo',
+                provider: this.selectedProvider
+            });
             if (schema.isTmBom(model.model)) {
                 this.$store.dispatch(tmActions.selected, importTmbom(model.model));
             } else if (schema.isOtm(model.model)) {

--- a/td.vue/tests/unit/components/graph.spec.js
+++ b/td.vue/tests/unit/components/graph.spec.js
@@ -12,7 +12,7 @@ import diagramService from '@/service/diagram/diagram.js';
 import stencilService from '@/service/x6/stencil.js';
 import saveDiagram from '@/service/diagram/save.js';
 import tmActions from '@/store/actions/threatmodel.js';
-import analytics from '@/service/analytics.js';
+import analytics, { methodologyForDiagramType } from '@/service/analytics.js';
 
 jest.mock('@/service/diagram/save.js', () => ({
     __esModule: true,
@@ -23,7 +23,8 @@ jest.mock('@/service/diagram/save.js', () => ({
 jest.mock('@/service/analytics.js', () => ({
     startEditing: jest.fn(),
     finishEditing: jest.fn(),
-    track: jest.fn()
+    track: jest.fn(),
+    methodologyForDiagramType: jest.fn()
 }));
 
 describe('components/GraphButtons.vue', () => {
@@ -73,6 +74,7 @@ describe('components/GraphButtons.vue', () => {
         analytics.startEditing.mockClear();
         analytics.finishEditing.mockClear();
         analytics.track.mockClear();
+        methodologyForDiagramType.mockReturnValue('STRIDE');
         localVue = createLocalVue();
         localVue.use(BootstrapVue);
         localVue.use(Vuex);
@@ -141,24 +143,24 @@ describe('components/GraphButtons.vue', () => {
     });
 
     it('starts an editing session', () => {
-        expect(analytics.startEditing).toHaveBeenCalledTimes(1);
+        expect(analytics.startEditing).toHaveBeenCalledWith('diagram');
     });
 
-    it.each([
-        ['CIA', 'CIA'],
-        ['DIE', 'CIADIE'],
-        ['CIADIE', 'CIADIE'],
-        ['LINDDUN', 'LINDDUN'],
-        ['PLOT4ai', 'PLOT4AI'],
-        ['STRIDE', 'STRIDE'],
-        ['EOP', 'EOP'],
-        ['Generic', 'GENERIC']
-    ])('tracks %s when its diagram editor opens', (diagramType, methodology) => {
+    it('uses the analytics methodology mapping when its diagram editor opens', () => {
+        wrapper.destroy();
+        methodologyForDiagramType.mockClear();
+        wrapper = mountComponent('github', 'CIA');
+
+        expect(methodologyForDiagramType).toHaveBeenCalledWith('CIA');
+    });
+
+    it('tracks the mapped methodology when its diagram editor opens', () => {
         wrapper.destroy();
         analytics.track.mockClear();
-        wrapper = mountComponent('github', diagramType);
+        methodologyForDiagramType.mockReturnValue('CIA');
+        wrapper = mountComponent('github', 'CIA');
 
-        expect(analytics.track).toHaveBeenCalledWith('DIAGRAM_METHODOLOGY_USED', { methodology });
+        expect(analytics.track).toHaveBeenCalledWith('DIAGRAM_METHODOLOGY_USED', { methodology: 'CIA' });
     });
 
     it('shows the threat edit modal dialog', () => {

--- a/td.vue/tests/unit/components/graphMeta.spec.js
+++ b/td.vue/tests/unit/components/graphMeta.spec.js
@@ -220,7 +220,7 @@ describe('components/GraphMeta.vue', () => {
         });
 
         it('tracks manual threat creation', () => {
-            expect(analytics.track).toHaveBeenCalledWith('THREAT_CREATED_MANUALLY');
+            expect(analytics.track).toHaveBeenCalledWith('THREAT_CREATED_MANUALLY', { status: 'Open' });
         });
     });
 

--- a/td.vue/tests/unit/components/threatEditDialog.spec.js
+++ b/td.vue/tests/unit/components/threatEditDialog.spec.js
@@ -182,7 +182,7 @@ describe('components/ThreatEditDialog.vue', () => {
             });
 
             it('tracks a deleted threat without its contents', () => {
-                expect(analytics.track).toHaveBeenCalledWith('THREAT_DELETED');
+                expect(analytics.track).toHaveBeenCalledWith('THREAT_DELETED', { status: 'Open' });
             });
         });
     });
@@ -208,7 +208,7 @@ describe('components/ThreatEditDialog.vue', () => {
         });
 
         it('tracks an existing threat update without its contents', () => {
-            expect(analytics.track).toHaveBeenCalledWith('THREAT_UPDATED');
+            expect(analytics.track).toHaveBeenCalledWith('THREAT_UPDATED', { status: 'Open' });
         });
 
         it('tracks an allowlisted status when the status changes', () => {

--- a/td.vue/tests/unit/service/analytics.spec.js
+++ b/td.vue/tests/unit/service/analytics.spec.js
@@ -2,10 +2,16 @@ jest.mock('@/service/api/api.js', () => ({
     postAsync: jest.fn()
 }));
 
+jest.mock('@/service/environment.js', () => ({
+    isDesktopApp: jest.fn(() => false)
+}));
+
 import api from '@/service/api/api.js';
-import analytics, { durationBucket } from '@/service/analytics.js';
+import { isDesktopApp } from '@/service/environment.js';
+import analytics, { durationBucket, methodologyForDiagramType } from '@/service/analytics.js';
 
 describe('service/analytics.js', () => {
+    const sendBeaconDescriptor = Object.getOwnPropertyDescriptor(navigator, 'sendBeacon');
     const config = {
         enabled: true,
         dashboardUrl: 'https://plausible.test/share/threatdragon',
@@ -18,6 +24,15 @@ describe('service/analytics.js', () => {
         api.postAsync.mockResolvedValue({});
     });
 
+    afterEach(() => {
+        isDesktopApp.mockReturnValue(false);
+        if (sendBeaconDescriptor) {
+            Object.defineProperty(navigator, 'sendBeacon', sendBeaconDescriptor);
+        } else {
+            delete navigator.sendBeacon;
+        }
+    });
+
     it('does not send while disabled', async () => {
         await analytics.track('PAGE_VIEW_HOME');
         expect(api.postAsync).not.toHaveBeenCalled();
@@ -25,6 +40,13 @@ describe('service/analytics.js', () => {
 
     it('rejects incomplete configuration', () => {
         expect(analytics.configure({ enabled: true, eventNames: [] })).toBe(false);
+    });
+
+    it('does not configure analytics in the desktop app', async () => {
+        isDesktopApp.mockReturnValue(true);
+        expect(analytics.configure(config)).toBe(false);
+        await analytics.track('PAGE_VIEW_HOME');
+        expect(api.postAsync).not.toHaveBeenCalled();
     });
 
     it('rejects a malformed dashboard URL', () => {
@@ -74,11 +96,12 @@ describe('service/analytics.js', () => {
     it('sends fixed event properties to the same-origin endpoint', async () => {
         analytics.configure(config);
         await analytics.track('THREAT_MODEL_EDIT_SESSION_ENDED', {
-            duration_bucket: 'LESS_THAN_5_MINUTES'
+            duration_bucket: 'LESS_THAN_5_MINUTES',
+            editor: 'diagram'
         });
         expect(api.postAsync).toHaveBeenCalledWith('/api/analytics', {
             event: 'THREAT_MODEL_EDIT_SESSION_ENDED',
-            props: { duration_bucket: 'LESS_THAN_5_MINUTES' }
+            props: { duration_bucket: 'LESS_THAN_5_MINUTES', editor: 'diagram' }
         });
     });
 
@@ -109,24 +132,42 @@ describe('service/analytics.js', () => {
         expect(durationBucket(duration)).toBe(expected);
     });
 
+    it.each([
+        ['CIA', 'CIA'],
+        ['DIE', 'CIADIE'],
+        ['CIADIE', 'CIADIE'],
+        ['LINDDUN', 'LINDDUN'],
+        ['PLOT4ai', 'PLOT4AI'],
+        ['STRIDE', 'STRIDE'],
+        ['EOP', 'EOP'],
+        ['unknown', 'GENERIC']
+    ])('uses the fixed methodology value for %s', (diagramType, expected) => {
+        expect(methodologyForDiagramType(diagramType)).toBe(expected);
+    });
+
     it('does not start an edit session while disabled', () => {
-        expect(analytics.startEditing(1000)).toBe(false);
+        expect(analytics.startEditing('diagram', 1000)).toBe(false);
     });
 
     it('starts one edit session', () => {
         analytics.configure(config);
-        expect(analytics.startEditing(1000)).toBe(true);
+        expect(analytics.startEditing('diagram', 1000)).toBe(true);
     });
 
     it('does not start a second editing session', () => {
         analytics.configure(config);
-        analytics.startEditing(1000);
-        expect(analytics.startEditing(2000)).toBe(false);
+        analytics.startEditing('diagram', 1000);
+        expect(analytics.startEditing('threat_model', 2000)).toBe(false);
     });
 
     it('uses the current time when starting an edit session', () => {
         analytics.configure(config);
-        expect(analytics.startEditing()).toBe(true);
+        expect(analytics.startEditing('diagram')).toBe(true);
+    });
+
+    it('does not start an edit session for an unknown editor', () => {
+        analytics.configure(config);
+        expect(analytics.startEditing('other', 1000)).toBe(false);
     });
 
     it('does not finish a session that was not started', () => {
@@ -136,38 +177,54 @@ describe('service/analytics.js', () => {
 
     it('tracks a completed edit session once', () => {
         analytics.configure(config);
-        analytics.startEditing(1000);
+        analytics.startEditing('diagram', 1000);
         expect(analytics.finishEditing(2000)).toBe(true);
     });
 
     it('clamps a negative edit duration to the first bucket', async () => {
         analytics.configure(config);
-        analytics.startEditing(2000);
+        analytics.startEditing('diagram', 2000);
         analytics.finishEditing(1000);
         await Promise.resolve();
         expect(api.postAsync).toHaveBeenCalledWith('/api/analytics', {
             event: 'THREAT_MODEL_EDIT_SESSION_ENDED',
-            props: { duration_bucket: 'LESS_THAN_5_MINUTES' }
+            props: { duration_bucket: 'LESS_THAN_5_MINUTES', editor: 'diagram' }
         });
     });
 
     it('uses the current time when finishing an edit session', () => {
         analytics.configure(config);
-        analytics.startEditing(1000);
+        analytics.startEditing('diagram', 1000);
         expect(analytics.finishEditing()).toBe(true);
     });
 
     it('clears an edit session after it finishes', () => {
         analytics.configure(config);
-        analytics.startEditing(1000);
+        analytics.startEditing('diagram', 1000);
         analytics.finishEditing(2000);
         expect(analytics.finishEditing(3000)).toBe(false);
     });
 
-    it('ends editing when the page is hidden', () => {
+    it('uses a beacon to end editing when the page is hidden', () => {
+        Object.defineProperty(navigator, 'sendBeacon', {
+            configurable: true,
+            value: jest.fn().mockReturnValue(true)
+        });
         analytics.configure(config);
-        analytics.startEditing(1000);
+        analytics.startEditing('threat_model', 1000);
         window.dispatchEvent(new Event('pagehide'));
+        expect(navigator.sendBeacon).toHaveBeenCalledWith('/api/analytics', expect.any(Blob));
         expect(analytics.finishEditing(2000)).toBe(false);
+    });
+
+    it('does not bypass the server event allow-list when the page is hidden', () => {
+        Object.defineProperty(navigator, 'sendBeacon', {
+            configurable: true,
+            value: jest.fn().mockReturnValue(true)
+        });
+        analytics.configure({ ...config, eventNames: ['PAGE_VIEW_HOME'] });
+        analytics.startEditing('diagram', 1000);
+        window.dispatchEvent(new Event('pagehide'));
+        expect(navigator.sendBeacon).not.toHaveBeenCalled();
     });
 });

--- a/td.vue/tests/unit/store/analyticsPlugin.spec.js
+++ b/td.vue/tests/unit/store/analyticsPlugin.spec.js
@@ -20,7 +20,7 @@ describe('store/analytics.js', () => {
     });
 
     it('ignores a provider selection outside the allow-list', () => {
-        after({ type: 'PROVIDER_SELECTED', payload: 'desktop' }, {});
+        after({ type: 'PROVIDER_SELECTED', payload: 'private' }, {});
         expect(analytics.track).not.toHaveBeenCalled();
     });
 
@@ -31,7 +31,10 @@ describe('store/analytics.js', () => {
 
     it('tracks a model opened from the selected provider', () => {
         after({ type: 'THREATMODEL_FETCH' }, { provider: { selected: 'google' } });
-        expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', { source: 'google' });
+        expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', {
+            source: 'google',
+            provider: 'google'
+        });
     });
 
     it('does not report local imports as provider fetches', () => {

--- a/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
+++ b/td.vue/tests/unit/views/demo/selectDemoModel.spec.js
@@ -30,6 +30,11 @@ describe('views/demo/SelectDemoModel.vue', () => {
         localVue.use(Vuex);
 
         mockStore = new Vuex.Store({
+            state: {
+                provider: {
+                    selected: 'local'
+                }
+            },
             actions: {
                 threatmodelClear: () => {},
                 threatmodelLoadDemos: () => {},
@@ -271,7 +276,10 @@ describe('views/demo/SelectDemoModel.vue', () => {
             });
 
             it('tracks demo usage without the model name', () => {
-                expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', { source: 'demo' });
+                expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', {
+                    source: 'demo',
+                    provider: 'local'
+                });
             });
         });
 

--- a/td.vue/tests/unit/views/importModel.spec.js
+++ b/td.vue/tests/unit/views/importModel.spec.js
@@ -87,7 +87,10 @@ describe('views/ImportModel.vue', () => {
         });
 
         it('tracks an imported model without its name or contents', () => {
-            expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', { source: 'import' });
+            expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_OPENED', {
+                source: 'import',
+                provider: 'local'
+            });
         });
     });
 

--- a/td.vue/tests/unit/views/reportModel.spec.js
+++ b/td.vue/tests/unit/views/reportModel.spec.js
@@ -132,7 +132,7 @@ describe('views/ReportModel.vue', () => {
 
     it('tracks a print request without report contents', () => {
         wrapper.vm.print();
-        expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_REPORT_PRINT_REQUESTED');
+        expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_REPORT_PRINT_REQUESTED', { format: 'PRINT' });
     });
 });
 
@@ -186,5 +186,10 @@ describe('ReportModel.vue — desktop app', () => {
     it('calls electronAPI.modelPrint on printPdf', () => {
         wrapper.vm.printPdf();
         expect(window.electronAPI.modelPrint).toHaveBeenCalledWith('PDF');
+    });
+
+    it('does not track a PDF report export in the desktop app', () => {
+        wrapper.vm.printPdf();
+        expect(analytics.track).not.toHaveBeenCalled();
     });
 });

--- a/td.vue/tests/unit/views/threatmodel.spec.js
+++ b/td.vue/tests/unit/views/threatmodel.spec.js
@@ -145,7 +145,7 @@ describe('views/Threatmodel.vue', () => {
             });
 
             it('tracks the export without model contents', () => {
-                expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_TMBOM_EXPORTED');
+                expect(analytics.track).toHaveBeenCalledWith('THREAT_MODEL_TMBOM_EXPORTED', { format: 'TM_BOM' });
             });
         });
 

--- a/td.vue/tests/unit/views/threatmodelEdit.spec.js
+++ b/td.vue/tests/unit/views/threatmodelEdit.spec.js
@@ -3,6 +3,7 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import ThreatModelEdit from '@/views/ThreatModelEdit.vue';
+import TdDropdown from '@/components/Dropdown.vue';
 import TdFormTags from '@/components/FormTags.vue';
 import TdInputGroup from '@/components/InputGroup.vue';
 import { threatmodelContributorsUpdated, threatmodelRestore, threatmodelNotModified, } from '@/store/actions/threatmodel.js';
@@ -11,7 +12,8 @@ import analytics from '@/service/analytics.js';
 jest.mock('@/service/analytics.js', () => ({
     startEditing: jest.fn(),
     finishEditing: jest.fn(),
-    track: jest.fn()
+    track: jest.fn(),
+    methodologyForDiagramType: jest.fn((diagramType) => diagramType)
 }));
 
 describe('views/ThreatmodelEdit.vue', () => {
@@ -30,6 +32,7 @@ describe('views/ThreatmodelEdit.vue', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        analytics.methodologyForDiagramType.mockImplementation((diagramType) => diagramType);
         console.log = jest.fn();
         modelChanged = false;
         localVue = createLocalVue();
@@ -48,6 +51,7 @@ describe('views/ThreatmodelEdit.vue', () => {
                         detail: {
                             contributors: contributors.map(x => ({ name: x })),
                             diagrams,
+                            diagramTop: 2,
                             reviewer
                         }
                     }
@@ -64,6 +68,7 @@ describe('views/ThreatmodelEdit.vue', () => {
 
         mockRouter = {
             push: jest.fn(),
+            replace: jest.fn(),
             path
         };
 
@@ -77,13 +82,13 @@ describe('views/ThreatmodelEdit.vue', () => {
                 $t: key => key,
                 $route: mockRouter,
                 $router: mockRouter,
-                $toast: { info: jest.fn() }
+                $toast: { error: jest.fn(), info: jest.fn() }
             }
         });
     });
 
     it('starts an editing session', () => {
-        expect(analytics.startEditing).toHaveBeenCalledTimes(1);
+        expect(analytics.startEditing).toHaveBeenCalledWith('threat_model');
     });
 
     describe('layout', () => {
@@ -127,6 +132,40 @@ describe('views/ThreatmodelEdit.vue', () => {
         it('has a release date input', () => {
             expect(wrapper.find('#released-at').exists()).toEqual(true);
         });
+
+        it('selects each diagram type from the dropdown', async () => {
+            const dropdown = wrapper.findComponent(TdDropdown);
+            const types = ['CIA', 'CIADIE', 'LINDDUN', 'PLOT4ai', 'STRIDE', 'EOP', 'Generic'];
+
+            for (const index of types.keys()) {
+                await dropdown.find('.td-dropdown-toggle').trigger('click');
+                await dropdown.findAll('.td-dropdown-item').at(index).trigger('click');
+            }
+
+            expect(wrapper.vm.model.detail.diagrams[0].diagramType).toEqual('threatmodel.diagram.generic.select');
+        });
+
+        it('marks the model modified when form fields change', async () => {
+            mockStore.dispatch = jest.fn();
+            const inputs = [
+                wrapper.find('#title'),
+                wrapper.find('#owner'),
+                wrapper.find('#reviewer'),
+                wrapper.find('#release-version'),
+                wrapper.find('#released-at'),
+                wrapper.find('#description'),
+                wrapper.find('.td-diagram'),
+                wrapper.find('.td-diagram-description')
+            ];
+
+            for (const input of inputs) {
+                await input.setValue('changed');
+            }
+            await wrapper.findComponent(TdFormTags).vm.$emit('input', ['changed']);
+
+            expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_MODIFIED');
+        });
+
     });
 
     describe('form actions', () => {
@@ -262,9 +301,68 @@ describe('views/ThreatmodelEdit.vue', () => {
                 expect(mockStore.state.threatmodel.data.detail.diagrams).toHaveLength(diagramCount + 1);
             });
 
-            it('tracks diagram creation', () => {
-                expect(analytics.track).toHaveBeenCalledWith('DIAGRAM_CREATED');
+            it('does not track diagram creation before the model is saved', () => {
+                expect(analytics.track).not.toHaveBeenCalled();
             });
+        });
+
+        it('tracks a created diagram with its selected methodology after a successful save', async () => {
+            mockStore.state.threatmodel.data.detail.diagramTop = 3;
+            const diagramIndex = wrapper.vm.model.detail.diagrams.length;
+            wrapper.vm.onAddDiagramClick();
+            wrapper.vm.onDiagramTypeClick(diagramIndex, 'CIA');
+            const dispatch = mockStore.dispatch;
+            mockStore.dispatch = jest.fn().mockResolvedValue(true);
+            analytics.track.mockClear();
+
+            await wrapper.vm.onSaveClick({ preventDefault: jest.fn() });
+
+            expect(analytics.track).toHaveBeenCalledWith('DIAGRAM_CREATED', { methodology: 'CIA' });
+            mockStore.dispatch = dispatch;
+        });
+
+        it('does not track a created diagram when saving fails', async () => {
+            wrapper.vm.onAddDiagramClick();
+            const dispatch = mockStore.dispatch;
+            mockStore.dispatch = jest.fn();
+            modelChanged = true;
+            analytics.track.mockClear();
+
+            await wrapper.vm.onSaveClick({ preventDefault: jest.fn() });
+
+            expect(analytics.track).not.toHaveBeenCalled();
+            mockStore.dispatch = dispatch;
+        });
+
+        it('does not save a model without a title', async () => {
+            wrapper.vm.model.summary.title = ' ';
+            mockStore.dispatch = jest.fn();
+
+            await wrapper.vm.onSaveClick({ preventDefault: jest.fn() });
+
+            expect(wrapper.vm.$toast.error).toHaveBeenCalledWith('Threat model must have a title');
+        });
+
+        it('tracks created diagrams after creating a model', async () => {
+            mockRouter.name = 'gitThreatModelCreate';
+            wrapper.vm.onAddDiagramClick();
+            mockStore.dispatch = jest.fn().mockResolvedValue(true);
+            analytics.track.mockClear();
+
+            await wrapper.vm.onSaveClick({ preventDefault: jest.fn() });
+
+            expect(analytics.track).toHaveBeenCalledWith('DIAGRAM_CREATED', { methodology: 'STRIDE' });
+        });
+
+        it('does not track created diagrams when model creation fails', async () => {
+            mockRouter.name = 'gitThreatModelCreate';
+            wrapper.vm.onAddDiagramClick();
+            mockStore.dispatch = jest.fn().mockResolvedValue(false);
+            analytics.track.mockClear();
+
+            await wrapper.vm.onSaveClick({ preventDefault: jest.fn() });
+
+            expect(analytics.track).not.toHaveBeenCalled();
         });
 
         describe('duplicate diagram', () => {
@@ -333,9 +431,10 @@ describe('views/ThreatmodelEdit.vue', () => {
 
         describe('contributors setter', () => {
             const newContribs = [ '1a', '2b', '3c' ];
-            beforeEach(() => {
+            beforeEach(async () => {
                 mockStore.dispatch = jest.fn();
-                wrapper.setData({ contributors: newContribs });
+                wrapper.vm.contributors = newContribs;
+                await wrapper.vm.$nextTick();
             });
 
             it('dispatches the contributors updated event', () => {
@@ -344,6 +443,49 @@ describe('views/ThreatmodelEdit.vue', () => {
                     newContribs
                 );
             });
+        });
+
+        it('does not track a diagram that was removed before saving', () => {
+            wrapper.vm.createdDiagramIds = [999];
+
+            wrapper.vm.trackCreatedDiagrams();
+
+            expect(analytics.track).not.toHaveBeenCalled();
+        });
+
+        it('marks the model as modified after model metadata changes', () => {
+            mockStore.dispatch = jest.fn();
+
+            wrapper.vm.onModifyModel();
+
+            expect(mockStore.dispatch).toHaveBeenCalledWith('THREATMODEL_MODIFIED');
+        });
+
+        it.each([
+            ['CIA', 'threatmodel.diagram.stride.defaultTitle', 'CIA', 'threatmodel.diagram.cia.defaultTitle'],
+            ['DIE', 'threatmodel.diagram.cia.defaultTitle', 'DIE', 'threatmodel.diagram.die.defaultTitle'],
+            ['CIADIE', 'threatmodel.diagram.die.defaultTitle', 'CIADIE', 'threatmodel.diagram.die.defaultTitle'],
+            ['LINDDUN', 'threatmodel.diagram.die.defaultTitle', 'LINDDUN', 'threatmodel.diagram.linddun.defaultTitle'],
+            ['PLOT4ai', 'threatmodel.diagram.linddun.defaultTitle', 'PLOT4ai', 'threatmodel.diagram.plot4ai.defaultTitle'],
+            ['STRIDE', 'threatmodel.diagram.plot4ai.defaultTitle', 'STRIDE', 'threatmodel.diagram.stride.defaultTitle'],
+            ['EOP', 'threatmodel.diagram.stride.defaultTitle', 'EOP', 'threatmodel.diagram.eop.defaultTitle'],
+            ['unknown', 'threatmodel.diagram.eop.defaultTitle', 'threatmodel.diagram.generic.select', 'threatmodel.diagram.generic.defaultTitle']
+        ])('updates a default diagram title when changing to %s', (type, currentTitle, expectedType, expectedTitle) => {
+            const diagram = wrapper.vm.model.detail.diagrams[0];
+            diagram.title = currentTitle;
+
+            wrapper.vm.onDiagramTypeClick(0, type);
+
+            expect(diagram).toMatchObject({ diagramType: expectedType, title: expectedTitle });
+        });
+
+        it('preserves a custom diagram title when changing diagram type', () => {
+            const diagram = wrapper.vm.model.detail.diagrams[0];
+            diagram.title = 'Custom title';
+
+            wrapper.vm.onDiagramTypeClick(0, 'CIA');
+
+            expect(diagram.title).toBe('Custom title');
         });
     });
 


### PR DESCRIPTION
**Summary**:  

Some of the analytics were recording "(none)" for properties we'd expect to have.
Threat edit session duration had a race condition that led to inaccurate data.
Diagram type was also being counted inaccurately.

I took a big swing at improving _existing_ test coverage where it was lacking, but did not bring it all the way to the desired 95%. Additional coverage would have required refactoring, and this PR is already big enough!

**Description for the changelog**:  

chore: analytics updates

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [ ] *either* no AI-generated content has been used in this pull request
- [x] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `Codex`
  - LLMs and versions: `gpt-5.6-terra`
  - Prompts: `I summarized some of the data points that seemed inaccurate or had an unexpected "(none)" value, and asked it to trace where those came from and uncovered a few other issues along the way`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
