### PR TITLE
fix oauth frontend return url env var implementation

### DIFF
--- a/td.server/src/controllers/auth.js
+++ b/td.server/src/controllers/auth.js
@@ -1,7 +1,7 @@
-import env from '../env/Env.js';
 import errors from './errors.js';
 import jwtHelper from '../helpers/jwt.helper.js';
 import loggerHelper from '../helpers/logger.helper.js';
+import oauthHelper from '../helpers/oauth.helper.js';
 import providers from '../providers/index.js';
 import responseWrapper from './responseWrapper.js';
 import tokenRepo from '../repositories/token.js';
@@ -22,11 +22,7 @@ const login = (req, res) => {
 const oauthReturn = (req, res) => {
     logger.debug(`API oauthReturn request: ${logger.transformToString(req)}`);
 
-    let returnUrl = `/#/oauth-return?code=${req.query.code}`;
-    if (env.get().config.NODE_ENV === 'development') {
-        returnUrl = `http://localhost:8080${returnUrl}`;
-    }
-    return res.redirect(returnUrl);
+    return res.redirect(oauthHelper.getOauthReturnUrl(req.query.code));
 };
 
 const completeLogin = (req, res) => {

--- a/td.server/test/controllers/auth.spec.js
+++ b/td.server/test/controllers/auth.spec.js
@@ -79,10 +79,27 @@ describe('controllers/auth.js', () => {
 
     describe('oauthReturn', () => {
         beforeEach(() => {
-            mockRequest.query.code = '12345';
+            mockRequest.query.code = 'valid-oauth-code';
         });
 
-        describe('development', () => {
+        describe('with OAUTH_FRONTEND_RETURN_URL configured', () => {
+            beforeEach(() => {
+                sinon.stub(env, 'get').returns({
+                    config: {
+                        NODE_ENV: 'production',
+                        OAUTH_FRONTEND_RETURN_URL: 'https://threatdragon.example'
+                    }
+                });
+                auth.oauthReturn(mockRequest, mockResponse);
+            });
+
+            it('redirects to the configured frontend url', () => {
+                const expected = `https://threatdragon.example/#/oauth-return?code=${mockRequest.query.code}`;
+                expect(mockResponse.redirect).to.have.been.calledWith(expected);
+            });
+        });
+
+        describe('development default', () => {
             beforeEach(() => {
                 sinon.stub(env, 'get').returns({ config: { NODE_ENV: 'development' }});
                 auth.oauthReturn(mockRequest, mockResponse);
@@ -94,7 +111,7 @@ describe('controllers/auth.js', () => {
             });
         });
 
-        describe('simulated production', () => {
+        describe('production default', () => {
             beforeEach(() => {
                 sinon.stub(env, 'get').returns({ config: { NODE_ENV: 'simulated_production' }});
                 auth.oauthReturn(mockRequest, mockResponse);


### PR DESCRIPTION
**Summary**:  

Closes #1860 

**Description for the changelog**:  

bugfix: implement oauth frontend return url env var

**Declaration**:  

Thanks for submitting a pull request, please make sure:  

- [x] content meets the [license](../blob/main/license.txt) for this project
- [x] appropriate unit tests have been created and/or modified
- [x] you have considered any changes required for the functional tests
- [x] you have read the [contribution guide](../blob/main/contributing.md) and agree to the [Code of Conduct](../blob/main/code_of_conduct.md)
- [x] *either* no AI-generated content has been used in this pull request
- [ ] *or* any [use of AI](../blob/main/contributing.md#use-of-ai) in this pull request has been disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie, etc]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro, etc]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

**Other info**:  

<!--
Add here any other information that may be of help to the reviewer
Automated tests are run which must pass before the pull request can be merged
-->
